### PR TITLE
DPTB-66: fix wrong chat identifier used for sending notifications

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/service/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/impl/NotificationServiceImpl.kt
@@ -133,7 +133,7 @@ class NotificationServiceImpl(
                 ++it.notificationAttempts
                 it.telegramChat.previousNotificationMessageId =
                     SendMessage(
-                        it.telegramChat.previousNotificationMessageId.toString(),
+                        it.telegramChat.externalChatId.toString(),
                         TelegramConstants.NOTIFICATION_QUESTION_MESSAGE
                     ).apply {
                         replyMarkup = TelegramBotKeyboardHelper.notifyButtons()
@@ -154,7 +154,7 @@ class NotificationServiceImpl(
         notifications
             .forEach {
                 SendMessage(
-                    it.telegramChat.previousNotificationMessageId.toString(),
+                    it.telegramChat.externalChatId.toString(),
                     TelegramConstants.NOTIFICATION_SUSPEND_MESSAGE.format(it.delayNotification.displayName)
                 ).apply {
                     disableNotification = true


### PR DESCRIPTION
## Summary
- Fix incorrect field usage in `NotificationServiceImpl`: replaced `previousNotificationMessageId` with `externalChatId` when sending notification messages
- The bot was using the previous message ID instead of the actual chat ID, which caused notifications to fail

## Test plan
- [x] Verify notification question messages are sent to the correct chat
- [x] Verify notification suspend messages are sent to the correct chat