### PR TITLE
DPTB-68: remove deprecated notifications table

### DIFF
--- a/src/main/resources/liquibase/7.6.0/changes.yaml
+++ b/src/main/resources/liquibase/7.6.0/changes.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 7.6.0
+      author: illine
+      comment: Release 7.6.0
+      changes:
+        - tagDatabase:
+            tag: 7.6.0
+
+  # DDL
+  - include:
+      file: ddl/01_notifications.sql
+      relativeToChangelogFile: true

--- a/src/main/resources/liquibase/7.6.0/ddl/01_notifications.sql
+++ b/src/main/resources/liquibase/7.6.0/ddl/01_notifications.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+
+--changeset illine:7.6.0/ddl/drop_notifications
+--rollback create sequence notification_seq;
+--rollback create table notifications (id bigint default nextval('notification_seq') not null constraint notifications_pk primary key, user_id bigint not null, chat_id bigint not null, delay_notification interval, time_of_last_notification timestamp(0), created timestamp(0), updated timestamp(0), deleted boolean default false not null, notification_attempts integer default 0 not null, previous_notification_message_id integer, user_time_zone text default 'Europe/Moscow' not null, quiet_mode_start time, quiet_mode_end time);
+--rollback create unique index notifications_user_id_unique_index on notifications (user_id);
+
+drop table notifications;
+drop sequence notification_seq;

--- a/src/main/resources/liquibase/changelog.yaml
+++ b/src/main/resources/liquibase/changelog.yaml
@@ -19,3 +19,6 @@ databaseChangeLog:
   - include:
       file: 7.4.0/changes.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 7.6.0/changes.yaml
+      relativeToChangelogFile: true


### PR DESCRIPTION
## Summary
- Add Liquibase migration 7.6.0 to drop the `notifications` table and `notification_seq` sequence
- No code or view references to the `notifications` table exist — data was already migrated to `notification_settings` in 7.4.0

## Test plan
- [x] No Java/Kotlin references to the `notifications` table in codebase
- [x] No SQL views referencing the `notifications` table
- [x] Liquibase migration includes rollback to recreate the table and sequence
- [x] Migration is included in `changelog.yaml`