### PR TITLE
DPTB-67: rename column delay_notification to notification_interval

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/model/entity/NotificationSettingEntity.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/entity/NotificationSettingEntity.kt
@@ -38,7 +38,7 @@ class NotificationSettingEntity(
     var telegramChat: TelegramChatEntity,
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "delay_notification", nullable = false)
+    @Column(name = "notification_interval", nullable = false)
     var notificationInterval: IntervalNotificationType,
 
     @Column(name = "time_of_last_notification", nullable = false)

--- a/src/main/resources/liquibase/7.6.0/changes.yaml
+++ b/src/main/resources/liquibase/7.6.0/changes.yaml
@@ -11,3 +11,6 @@ databaseChangeLog:
   - include:
       file: ddl/01_notifications.sql
       relativeToChangelogFile: true
+  - include:
+      file: ddl/02_notification_settings.sql
+      relativeToChangelogFile: true

--- a/src/main/resources/liquibase/7.6.0/ddl/02_notification_settings.sql
+++ b/src/main/resources/liquibase/7.6.0/ddl/02_notification_settings.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset illine:7.6.0/ddl/rename_delay_notification
+--rollback alter table notification_settings rename column notification_interval to delay_notification;
+
+alter table notification_settings rename column delay_notification to notification_interval;

--- a/src/test/resources/sql/access/NotificationAccessService.sql
+++ b/src/test/resources/sql/access/NotificationAccessService.sql
@@ -10,8 +10,8 @@ values (1, 1);
 insert into telegram_chats (telegram_user_id, external_chat_id)
 values (2, 2);
 
-insert into notification_settings (telegram_user_id, telegram_chat_id, delay_notification, time_of_last_notification, notification_attempts, enabled)
+insert into notification_settings (telegram_user_id, telegram_chat_id, notification_interval, time_of_last_notification, notification_attempts, enabled)
 values (1, 1, 'TWO_HOURS', now(), 1, true);
 
-insert into notification_settings (telegram_user_id, telegram_chat_id, delay_notification, time_of_last_notification, notification_attempts, enabled)
+insert into notification_settings (telegram_user_id, telegram_chat_id, notification_interval, time_of_last_notification, notification_attempts, enabled)
 values (2, 2, 'TWO_HOURS', now(), 1, false);


### PR DESCRIPTION
## Summary
- Add Liquibase migration to rename column `delay_notification` → `notification_interval` in `notification_settings` table
- Update `@Column(name = ...)` in `NotificationSettingEntity.kt` to match the new column name
- Include rollback changeset

## Test plan
- [x] Apply migration on local DB and verify column is renamed
- [x] Run application and verify `NotificationSettingEntity` reads/writes correctly
- [x] Verify Liquibase rollback works: column reverts to `delay_notification`