### PR TITLE
DPTB-70: handle 403 in notification scheduler by disabling blocked users

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/scheduler/NotificationScheduler.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/scheduler/NotificationScheduler.kt
@@ -24,6 +24,7 @@ class NotificationScheduler(
     fun sendDrinkingReminders() { log.info("Starting drinking notification scheduler")
 
         val (exhaustedNotifications, activeNotifications) = notificationAccessService.findAllNotificationSettings()
+            .filter { it.enabled }
             .filter(notificationTimeService::isOutsideQuietTime)
             .filter { notificationTimeService.isNotificationDue(it) }
             .partition { it.notificationAttempts == MAX_REMINDED_NOTIFICATION_ATTEMPTS }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
@@ -4,6 +4,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.telegram.telegrambots.abilitybots.api.objects.MessageContext
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
+import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.model.base.SettingsType
@@ -127,8 +128,8 @@ class NotificationServiceImpl(
 
         deletePreviousNotificationMessages(notifications)
 
-        notifications
-            .forEach {
+        val sent = notifications.filter {
+            sendOrDisableOnBlock(it) {
                 ++it.notificationAttempts
                 it.telegramChat.previousNotificationMessageId =
                     SendMessage(
@@ -138,8 +139,9 @@ class NotificationServiceImpl(
                         replyMarkup = TelegramBotKeyboardHelper.notifyButtons()
                     }.let { sender.execute(it) }.messageId
             }
+        }
 
-        notificationAccessService.updateNotificationSettings(notifications)
+        notificationAccessService.updateNotificationSettings(sent)
     }
 
     override fun suspendNotifications(notifications: Collection<NotificationSettingDto>) {
@@ -150,8 +152,8 @@ class NotificationServiceImpl(
 
         deletePreviousNotificationMessages(notifications)
 
-        notifications
-            .forEach {
+        val sent = notifications.filter {
+            sendOrDisableOnBlock(it) {
                 SendMessage(
                     it.telegramChat.externalChatId.toString(),
                     TelegramMessageConstants.NOTIFICATION_SUSPEND_MESSAGE.format(it.notificationInterval.displayName)
@@ -163,8 +165,24 @@ class NotificationServiceImpl(
                 it.timeOfLastNotification = LocalDateTime.now(clock)
                 it.telegramChat.previousNotificationMessageId = null
             }
+        }
 
-        notificationAccessService.updateNotificationSettings(notifications)
+        notificationAccessService.updateNotificationSettings(sent)
+    }
+
+    private fun sendOrDisableOnBlock(notification: NotificationSettingDto, send: () -> Unit): Boolean {
+        return try {
+            send()
+            true
+        } catch (e: TelegramApiRequestException) {
+            if (e.errorCode == 403) {
+                log.warn("User (externalUserId: [{}]) blocked the bot, disabling notifications", notification.telegramUser.externalUserId)
+                notificationAccessService.disableNotifications(notification.telegramUser.externalUserId)
+                false
+            } else {
+                throw e
+            }
+        }
     }
 
     private fun deletePreviousNotificationMessages(settings: Collection<NotificationSettingDto>) {


### PR DESCRIPTION
## Summary
- Catch `TelegramApiRequestException` (403) per user in `sendNotifications` and `suspendNotifications` instead of crashing the entire scheduler run
- On 403, automatically disable notifications for the blocked user via `disableNotifications()`
- Extract error handling into `sendOrDisableOnBlock()` to avoid duplication
- Add `.filter { it.enabled }` in `NotificationScheduler` so disabled users are skipped on subsequent runs

## Test plan
- [x] Scheduler run completes successfully even when one user has blocked the bot
- [x] Blocked user's notifications are disabled in DB after 403
- [x] Other users in the same run still receive their notifications
- [x] Disabled user is not picked up on the next scheduler run