### PR TITLE
DPTB-72: fix snooze delay for overdue notifications

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplayButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplayButtonStrategy.kt
@@ -10,12 +10,15 @@ import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
 import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
+import java.time.Clock
+import java.time.LocalDateTime
 
 @Service
 class SnoozeApplyReplayButtonStrategy(
     private val sender: TelegramClient,
     private val notificationAccessService: NotificationAccessService,
-    private val messageEditorService: MessageEditorService
+    private val messageEditorService: MessageEditorService,
+    private val clock: Clock
 ) : ReplyButtonStrategy {
 
     private val log = LoggerFactory.getLogger("REPLAY-STRATEGY")
@@ -40,9 +43,14 @@ class SnoozeApplyReplayButtonStrategy(
         )
 
         val notificationSetting = notificationAccessService.findNotificationSettingByTelegramUserId(userId)
+        val now = LocalDateTime.now(clock)
+        // The scheduler fires when: timeOfLastNotification + interval <= now
+        // To make the next notification fire exactly snoozeMinutes from now:
+        //   timeOfLastNotification + interval = now + snoozeMinutes
+        //   timeOfLastNotification = now - interval + snoozeMinutes
         notificationAccessService.updateTimeOfLastNotification(
             userId,
-            notificationSetting.timeOfLastNotification.plusMinutes(snoozeType.minutes)
+            now.minusMinutes(notificationSetting.notificationInterval.minutes).plusMinutes(snoozeType.minutes)
         )
 
         SendMessage(

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplayButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplayButtonStrategyTest.kt
@@ -19,7 +19,9 @@ import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
+import java.time.Clock
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @UnitTest
 @DisplayName("SnoozeApplyReplayButtonStrategy Unit Test")
@@ -28,7 +30,8 @@ class SnoozeApplyReplayButtonStrategyTest {
     private val userId = 1L
     private val chatId = 100500L
     private val messageId = 42
-    private val lastNotificationTime = LocalDateTime.of(2025, 1, 1, 12, 0, 0)
+    private val fixedNow = LocalDateTime.of(2025, 1, 1, 14, 0, 0)
+    private val fixedClock = Clock.fixed(fixedNow.toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
 
     private lateinit var sender: TelegramClient
     private lateinit var notificationAccessService: NotificationAccessService
@@ -40,17 +43,14 @@ class SnoozeApplyReplayButtonStrategyTest {
         sender = mock(TelegramClient::class.java)
         notificationAccessService = mock(NotificationAccessService::class.java)
         messageEditorService = mock(MessageEditorService::class.java)
-        strategy = SnoozeApplyReplayButtonStrategy(sender, notificationAccessService, messageEditorService)
+        strategy = SnoozeApplyReplayButtonStrategy(sender, notificationAccessService, messageEditorService, fixedClock)
     }
 
     @ParameterizedTest
     @EnumSource(SnoozeNotificationType::class)
     @DisplayName("reply(): deletes reply markup on original message")
     fun `reply deletes reply markup`(snoozeType: SnoozeNotificationType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
-            timeOfLastNotification = lastNotificationTime
-        )
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
         `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
@@ -61,18 +61,16 @@ class SnoozeApplyReplayButtonStrategyTest {
 
     @ParameterizedTest
     @EnumSource(SnoozeNotificationType::class)
-    @DisplayName("reply(): updates timeOfLastNotification by snooze minutes")
+    @DisplayName("reply(): next notification fires exactly snoozeMinutes from now")
     fun `reply updates notification time`(snoozeType: SnoozeNotificationType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
-            timeOfLastNotification = lastNotificationTime
-        )
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
         `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         strategy.reply(callbackQuery)
 
-        val expectedTime = lastNotificationTime.plusMinutes(snoozeType.minutes)
+        val interval = notificationDto.notificationInterval.minutes
+        val expectedTime = fixedNow.minusMinutes(interval).plusMinutes(snoozeType.minutes)
         verify(notificationAccessService).updateTimeOfLastNotification(userId, expectedTime)
     }
 
@@ -80,10 +78,7 @@ class SnoozeApplyReplayButtonStrategyTest {
     @EnumSource(SnoozeNotificationType::class)
     @DisplayName("reply(): sends confirmation message with snooze display name")
     fun `reply sends confirmation message`(snoozeType: SnoozeNotificationType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
-            timeOfLastNotification = lastNotificationTime
-        )
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
         `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())


### PR DESCRIPTION
## Summary
- Fixed snooze delay calculation: `timeOfLastNotification` is now set relative to the current moment, not to the previous notification time
- Ensures that after pressing snooze, the next notification arrives exactly X minutes from now, regardless of how overdue the current notification was

## Test plan
- [x] Press snooze on a fresh (non-overdue) notification — next notification arrives in X minutes
- [x] Press snooze on an overdue notification (2nd or 3rd retry) — next notification still arrives in X minutes from now, not immediately