### PR TITLE
DPTB-22: implement water statistics saving

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/builder/WaterStatisticBuilder.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/builder/WaterStatisticBuilder.kt
@@ -1,0 +1,28 @@
+package ru.illine.drinking.ponies.builder
+
+import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
+import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
+import ru.illine.drinking.ponies.model.entity.WaterStatisticEntity
+
+object WaterStatisticBuilder {
+
+    fun toDto(entity: WaterStatisticEntity, user: TelegramUserDto): WaterStatisticDto =
+        WaterStatisticDto(
+            id = entity.id,
+            telegramUser = user,
+            eventTime = entity.eventTime,
+            eventType = entity.eventType,
+            waterAmountMl = entity.waterAmountMl
+        )
+
+    fun toEntity(dto: WaterStatisticDto, user: TelegramUserEntity): WaterStatisticEntity =
+        WaterStatisticEntity(
+            id = dto.id,
+            telegramUser = user,
+            eventTime = dto.eventTime,
+            eventType = dto.eventType,
+            waterAmountMl = dto.waterAmountMl
+        )
+
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/WaterStatisticAccessService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/WaterStatisticAccessService.kt
@@ -1,0 +1,9 @@
+package ru.illine.drinking.ponies.dao.access
+
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
+
+interface WaterStatisticAccessService {
+
+    fun save(dto: WaterStatisticDto): WaterStatisticDto
+
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/WaterStatisticAccessService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/WaterStatisticAccessService.kt
@@ -6,4 +6,6 @@ interface WaterStatisticAccessService {
 
     fun save(dto: WaterStatisticDto): WaterStatisticDto
 
+    fun saveAll(statistics: Collection<WaterStatisticDto>): List<WaterStatisticDto>
+
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/WaterStatisticAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/WaterStatisticAccessServiceImpl.kt
@@ -1,0 +1,34 @@
+package ru.illine.drinking.ponies.dao.access.impl
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import ru.illine.drinking.ponies.builder.TelegramUserBuilder
+import ru.illine.drinking.ponies.builder.WaterStatisticBuilder
+import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
+import ru.illine.drinking.ponies.dao.repository.TelegramUserRepository
+import ru.illine.drinking.ponies.dao.repository.WaterStatisticRepository
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
+
+@Service
+class WaterStatisticAccessServiceImpl(
+    private val waterStatisticRepository: WaterStatisticRepository,
+    private val userRepository: TelegramUserRepository,
+) : WaterStatisticAccessService {
+
+    private val logger = LoggerFactory.getLogger("ACCESS-SERVICE")
+
+    @Transactional
+    override fun save(dto: WaterStatisticDto): WaterStatisticDto {
+        logger.debug("Saving a water statistic record for a telegram user: [${dto.telegramUser.externalUserId}]")
+
+        val userEntity = requireNotNull(
+            userRepository.findByExternalUserId(dto.telegramUser.externalUserId),
+            { "Not found a Telegram User by externalUserId [${dto.telegramUser.externalUserId}]" }
+        )
+
+        return waterStatisticRepository.save(WaterStatisticBuilder.toEntity(dto, userEntity))
+            .let { WaterStatisticBuilder.toDto(it, TelegramUserBuilder.toDto(it.telegramUser)) }
+    }
+
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/WaterStatisticAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/WaterStatisticAccessServiceImpl.kt
@@ -31,4 +31,20 @@ class WaterStatisticAccessServiceImpl(
             .let { WaterStatisticBuilder.toDto(it, TelegramUserBuilder.toDto(it.telegramUser)) }
     }
 
+    @Transactional
+    override fun saveAll(statistics: Collection<WaterStatisticDto>): List<WaterStatisticDto> {
+        logger.debug("Saving [${statistics.size}] water statistic records")
+
+        return statistics
+            .map {
+                val userEntity = requireNotNull(
+                    userRepository.findByExternalUserId(it.telegramUser.externalUserId),
+                    { "Not found a Telegram User by externalUserId [${it.telegramUser.externalUserId}]" }
+                )
+                WaterStatisticBuilder.toEntity(it, userEntity)
+            }
+            .let { waterStatisticRepository.saveAll(it) }
+            .map { WaterStatisticBuilder.toDto(it, TelegramUserBuilder.toDto(it.telegramUser)) }
+    }
+
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/WaterStatisticRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/WaterStatisticRepository.kt
@@ -1,0 +1,6 @@
+package ru.illine.drinking.ponies.dao.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import ru.illine.drinking.ponies.model.entity.WaterStatisticEntity
+
+interface WaterStatisticRepository : JpaRepository<WaterStatisticEntity, Long>

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/WaterStatisticDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/WaterStatisticDto.kt
@@ -1,0 +1,16 @@
+package ru.illine.drinking.ponies.model.dto.internal
+
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import java.time.LocalDateTime
+
+data class WaterStatisticDto(
+    var id: Long? = null,
+
+    val telegramUser: TelegramUserDto,
+
+    val eventTime: LocalDateTime,
+
+    val eventType: AnswerNotificationType,
+
+    val waterAmountMl: Int = 0
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/entity/WaterStatisticEntity.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/entity/WaterStatisticEntity.kt
@@ -1,0 +1,61 @@
+package ru.illine.drinking.ponies.model.entity
+
+import jakarta.persistence.*
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "water_statistics")
+class WaterStatisticEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "waterStatisticsSeqGenerator")
+    @SequenceGenerator(
+        name = "waterStatisticsSeqGenerator",
+        sequenceName = "water_statistics_seq",
+        allocationSize = 1
+    )
+    var id: Long? = null,
+
+    @ManyToOne(
+        fetch = FetchType.LAZY,
+        cascade = [CascadeType.MERGE, CascadeType.REFRESH],
+    )
+    @JoinColumn(name = "user_id", nullable = false)
+    var telegramUser: TelegramUserEntity,
+
+    @Column(name = "event_time", nullable = false)
+    var eventTime: LocalDateTime,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false)
+    var eventType: AnswerNotificationType,
+
+    @Column(name = "water_amount_ml", nullable = false)
+    var waterAmountMl: Int = 0
+
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as WaterStatisticEntity
+
+        if (id != other.id) return false
+        if (eventTime != other.eventTime) return false
+        if (eventType != other.eventType) return false
+        if (waterAmountMl != other.waterAmountMl) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id?.hashCode() ?: 0
+        result = 31 * result + eventTime.hashCode()
+        result = 31 * result + eventType.hashCode()
+        result = 31 * result + waterAmountMl
+        return result
+    }
+
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategy.kt
@@ -4,8 +4,10 @@ import org.springframework.stereotype.Service
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.service.button.strategy.AbstractAnswerNotificationReplyButtonStrategy
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
@@ -17,11 +19,21 @@ class CancelAnswerNotificationReplyButtonStrategy(
     sender: TelegramClient,
     messageEditorService: MessageEditorService,
     private val notificationAccessService: NotificationAccessService,
+    private val waterStatisticAccessService: WaterStatisticAccessService,
     private val clock: Clock
 ) : AbstractAnswerNotificationReplyButtonStrategy<NotificationSettingDto>(sender, messageEditorService) {
 
     override fun updateLastNotificationTime(callbackQuery: CallbackQuery): () -> NotificationSettingDto = {
         notificationAccessService.updateTimeOfLastNotification(callbackQuery.from.id, LocalDateTime.now(clock))
+            .also { setting ->
+                waterStatisticAccessService.save(
+                    WaterStatisticDto(
+                        telegramUser = setting.telegramUser,
+                        eventTime = LocalDateTime.now(clock),
+                        eventType = getAnswerType()
+                    )
+                )
+            }
     }
 
     override fun getMessageText(): String = TelegramMessageConstants.NOTIFICATION_ANSWER_CANCEL_MESSAGE

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategy.kt
@@ -4,8 +4,10 @@ import org.springframework.stereotype.Service
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.service.button.strategy.AbstractAnswerNotificationReplyButtonStrategy
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
@@ -17,11 +19,21 @@ class YesAnswerNotificationReplyButtonStrategy(
     sender: TelegramClient,
     messageEditorService: MessageEditorService,
     private val notificationAccessService: NotificationAccessService,
+    private val waterStatisticAccessService: WaterStatisticAccessService,
     private val clock: Clock
 ) : AbstractAnswerNotificationReplyButtonStrategy<NotificationSettingDto>(sender, messageEditorService) {
 
     override fun updateLastNotificationTime(callbackQuery: CallbackQuery): () -> NotificationSettingDto = {
         notificationAccessService.updateTimeOfLastNotification(callbackQuery.from.id, LocalDateTime.now(clock))
+            .also { setting ->
+                waterStatisticAccessService.save(
+                    WaterStatisticDto(
+                        telegramUser = setting.telegramUser,
+                        eventTime = LocalDateTime.now(clock),
+                        eventType = getAnswerType()
+                    )
+                )
+            }
     }
 
     override fun getMessageText(): String = TelegramMessageConstants.NOTIFICATION_ANSWER_YES_MESSAGE

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategy.kt
@@ -6,17 +6,22 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.TimeHelper
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
 import java.time.Clock
+import java.time.LocalDateTime
 
 @Service
 class SnoozeApplyReplyButtonStrategy(
     private val sender: TelegramClient,
     private val notificationAccessService: NotificationAccessService,
+    private val waterStatisticAccessService: WaterStatisticAccessService,
     private val messageEditorService: MessageEditorService,
     private val clock: Clock
 ) : ReplyButtonStrategy {
@@ -50,6 +55,14 @@ class SnoozeApplyReplyButtonStrategy(
                 snoozeType.minutes
             )
         notificationAccessService.updateTimeOfLastNotification(userId, nextNotificationTime)
+
+        waterStatisticAccessService.save(
+            WaterStatisticDto(
+                telegramUser = notificationSetting.telegramUser,
+                eventTime = LocalDateTime.now(clock),
+                eventType = AnswerNotificationType.SNOOZE
+            )
+        )
 
         SendMessage(
             chatId.toString(),

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
@@ -8,10 +8,13 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.config.property.TelegramBotProperties
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.SettingsType
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.service.button.ButtonDataService
 import ru.illine.drinking.ponies.service.notification.NotificationService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
@@ -29,6 +32,7 @@ class NotificationServiceImpl(
     private val notificationAccessService: NotificationAccessService,
     private val settingsButtonDataService: ButtonDataService<SettingsType>,
     private val telegramBotProperties: TelegramBotProperties,
+    private val waterStatisticAccessService: WaterStatisticAccessService,
     private val clock: Clock,
 ) : NotificationService {
 
@@ -174,6 +178,15 @@ class NotificationServiceImpl(
         }
 
         notificationAccessService.updateNotificationSettings(sent)
+        waterStatisticAccessService.saveAll(
+            sent.map {
+                WaterStatisticDto(
+                    telegramUser = it.telegramUser,
+                    eventTime = LocalDateTime.now(clock),
+                    eventType = AnswerNotificationType.CANCEL
+                )
+            }
+        )
     }
 
     private fun sendOrDisableOnBlock(notification: NotificationSettingDto, send: () -> Unit): Boolean {

--- a/src/main/resources/liquibase/7.9.0/changes.yaml
+++ b/src/main/resources/liquibase/7.9.0/changes.yaml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: 7.9.0
+      author: illine
+      comment: Release 7.9.0
+      changes:
+        - tagDatabase:
+            tag: 7.9.0
+
+  # DDL
+  - include:
+      file: ddl/01_water_statistics.sql
+      relativeToChangelogFile: true
+  - include:
+      file: ddl/02_grants.sql
+      relativeToChangelogFile: true

--- a/src/main/resources/liquibase/7.9.0/ddl/01_water_statistics.sql
+++ b/src/main/resources/liquibase/7.9.0/ddl/01_water_statistics.sql
@@ -1,0 +1,28 @@
+--liquibase formatted sql
+
+--changeset illine:7.9.0/ddl/water_statistics
+
+/* liquibase rollback
+ drop table water_statistics;
+ drop sequence water_statistics_seq;
+*/
+
+create sequence water_statistics_seq;
+
+create table water_statistics
+(
+    id              bigint  default nextval('water_statistics_seq') not null
+        primary key,
+    user_id         bigint                                          not null
+        references telegram_users (id),
+    event_time      timestamp(0)                                    not null,
+    event_type      text                                            not null,
+    water_amount_ml integer default 0                               not null
+);
+
+comment on table water_statistics is 'Table storing water consumption statistics for users';
+comment on column water_statistics.id is 'Primary key of the table';
+comment on column water_statistics.user_id is 'Foreign key referencing the telegram users table';
+comment on column water_statistics.event_time is 'Time when the event occurred, stored in UTC';
+comment on column water_statistics.event_type is 'Type of the event: YES, SNOOZE, CANCEL';
+comment on column water_statistics.water_amount_ml is 'Amount of water consumed in millilitres, 0 if not applicable';

--- a/src/main/resources/liquibase/7.9.0/ddl/02_grants.sql
+++ b/src/main/resources/liquibase/7.9.0/ddl/02_grants.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+
+--changeset illine:7.9.0/ddl/grants
+--rollback revoke all on table water_statistics from dptb;
+
+grant all on table water_statistics to dptb;
+
+grant usage, select, update on sequence water_statistics_seq to dptb;

--- a/src/main/resources/liquibase/changelog.yaml
+++ b/src/main/resources/liquibase/changelog.yaml
@@ -22,3 +22,6 @@ databaseChangeLog:
   - include:
       file: 7.6.0/changes.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 7.9.0/changes.yaml
+      relativeToChangelogFile: true

--- a/src/test/kotlin/ru/illine/drinking/ponies/dao/access/WaterStatisticAccessServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/dao/access/WaterStatisticAccessServiceTest.kt
@@ -1,0 +1,86 @@
+package ru.illine.drinking.ponies.dao.access
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.function.ThrowingSupplier
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.context.jdbc.SqlConfig
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.test.generator.DtoGenerator
+import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
+
+@SpringIntegrationTest
+@DisplayName("WaterStatisticAccessService Spring Integration Test")
+@Sql(
+    scripts = ["classpath:sql/access/WaterStatisticAccessService.sql"],
+    config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+)
+@Sql(
+    scripts = ["classpath:sql/clear.sql"],
+    config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD
+)
+class WaterStatisticAccessServiceTest @Autowired constructor(
+    private val accessService: WaterStatisticAccessService,
+) {
+
+    private val DEFAULT_EXTERNAL_USER_ID = 1L
+    private val SECOND_EXTERNAL_USER_ID = 2L
+    private val NOT_EXISTED_USER_ID = 0L
+
+    @Test
+    @DisplayName("save(): returns a saved record with id")
+    fun `successful save`() {
+        val dto = DtoGenerator.generateWaterStatisticDto(externalUserId = DEFAULT_EXTERNAL_USER_ID)
+
+        val actual = assertDoesNotThrow(ThrowingSupplier { accessService.save(dto) })
+
+        assertNotNull(actual.id)
+        assertEquals(DEFAULT_EXTERNAL_USER_ID, actual.telegramUser.externalUserId)
+        assertEquals(AnswerNotificationType.YES, actual.eventType)
+        assertEquals(250, actual.waterAmountMl)
+    }
+
+    @Test
+    @DisplayName("save(): throws IllegalArgumentException when user not found")
+    fun `failure save user not found`() {
+        val dto = DtoGenerator.generateWaterStatisticDto(externalUserId = NOT_EXISTED_USER_ID)
+
+        assertThrows<IllegalArgumentException> { accessService.save(dto) }
+    }
+
+    @Test
+    @DisplayName("saveAll(): returns a list of saved records")
+    fun `successful saveAll`() {
+        val statistics = listOf(
+            DtoGenerator.generateWaterStatisticDto(externalUserId = DEFAULT_EXTERNAL_USER_ID, eventType = AnswerNotificationType.YES, waterAmountMl = 250),
+            DtoGenerator.generateWaterStatisticDto(externalUserId = SECOND_EXTERNAL_USER_ID, eventType = AnswerNotificationType.CANCEL, waterAmountMl = 0)
+        )
+
+        val actual = assertDoesNotThrow(ThrowingSupplier<List<*>> { accessService.saveAll(statistics) })
+
+        assertEquals(2, actual.size)
+        assertTrue(actual.all { it != null })
+    }
+
+    @Test
+    @DisplayName("saveAll(): returns empty list for empty input")
+    fun `successful saveAll empty`() {
+        val actual = assertDoesNotThrow(ThrowingSupplier<List<*>> { accessService.saveAll(emptyList()) })
+
+        assertTrue(actual.isEmpty())
+    }
+
+    @Test
+    @DisplayName("saveAll(): throws IllegalArgumentException when user not found")
+    fun `failure saveAll user not found`() {
+        val statistics = listOf(DtoGenerator.generateWaterStatisticDto(externalUserId = NOT_EXISTED_USER_ID))
+
+        assertThrows<IllegalArgumentException> { accessService.saveAll(statistics) }
+    }
+
+}

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactoryTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactoryTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mockito.mock
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
 import ru.illine.drinking.ponies.service.button.impl.ReplyButtonFactoryImpl
 import ru.illine.drinking.ponies.service.button.strategy.snooze.SnoozeApplyReplyButtonStrategy
@@ -28,6 +29,7 @@ class ReplyButtonFactoryTest {
         val strategy = SnoozeApplyReplyButtonStrategy(
             mock(TelegramClient::class.java),
             mock(NotificationAccessService::class.java),
+            mock(WaterStatisticAccessService::class.java),
             mock(MessageEditorService::class.java),
             Clock.systemUTC()
         )

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategyTest.kt
@@ -8,13 +8,17 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.*
+import org.mockito.kotlin.any
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
+
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
@@ -36,6 +40,7 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     private lateinit var sender: TelegramClient
     private lateinit var messageEditorService: MessageEditorService
     private lateinit var notificationAccessService: NotificationAccessService
+    private lateinit var waterStatisticAccessService: WaterStatisticAccessService
     private lateinit var strategy: CancelAnswerNotificationReplyButtonStrategy
 
     @BeforeEach
@@ -43,7 +48,14 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
         sender = mock(TelegramClient::class.java)
         messageEditorService = mock(MessageEditorService::class.java)
         notificationAccessService = mock(NotificationAccessService::class.java)
-        strategy = CancelAnswerNotificationReplyButtonStrategy(sender, messageEditorService, notificationAccessService, fixedClock)
+        waterStatisticAccessService = mock(WaterStatisticAccessService::class.java)
+        strategy = CancelAnswerNotificationReplyButtonStrategy(
+            sender,
+            messageEditorService,
+            notificationAccessService,
+            waterStatisticAccessService,
+            fixedClock
+        )
     }
 
     @Test
@@ -68,6 +80,17 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
         strategy.reply(buildCallbackQuery())
 
         verify(notificationAccessService).updateTimeOfLastNotification(userId, fixedNow)
+    }
+
+    @Test
+    @DisplayName("reply(): saves new water statistic")
+    fun `reply saves statistic`() {
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
+        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+
+        strategy.reply(buildCallbackQuery())
+
+        verify(waterStatisticAccessService).save(any<WaterStatisticDto>())
     }
 
     @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategyTest.kt
@@ -16,8 +16,11 @@ import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
+import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
 import java.time.Clock
@@ -37,6 +40,7 @@ class YesAnswerNotificationReplyButtonStrategyTest {
     private lateinit var sender: TelegramClient
     private lateinit var messageEditorService: MessageEditorService
     private lateinit var notificationAccessService: NotificationAccessService
+    private lateinit var waterStatisticAccessService: WaterStatisticAccessService
     private lateinit var strategy: YesAnswerNotificationReplyButtonStrategy
 
     @BeforeEach
@@ -44,14 +48,22 @@ class YesAnswerNotificationReplyButtonStrategyTest {
         sender = mock(TelegramClient::class.java)
         messageEditorService = mock(MessageEditorService::class.java)
         notificationAccessService = mock(NotificationAccessService::class.java)
+        waterStatisticAccessService = mock(WaterStatisticAccessService::class.java)
         strategy = YesAnswerNotificationReplyButtonStrategy(
-            sender, messageEditorService, notificationAccessService, fixedClock
+            sender,
+            messageEditorService,
+            notificationAccessService,
+            waterStatisticAccessService,
+            fixedClock
         )
     }
 
     @Test
     @DisplayName("reply(): edits original message with YES display name")
     fun `reply edits original message`() {
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
+        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+
         strategy.reply(buildCallbackQuery())
 
         val expectedText = TelegramMessageConstants.NOTIFICATION_QUESTION_EDITED_MESSAGE_PATTERN
@@ -62,6 +74,9 @@ class YesAnswerNotificationReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): updates last notification time to now()")
     fun `reply updates notification time`() {
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
+        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+
         strategy.reply(buildCallbackQuery())
 
         verify(notificationAccessService).updateTimeOfLastNotification(eq(userId), any<LocalDateTime>())
@@ -70,6 +85,9 @@ class YesAnswerNotificationReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): sends YES confirmation message")
     fun `reply sends confirmation message`() {
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
+        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
         strategy.reply(buildCallbackQuery())
 
@@ -77,6 +95,17 @@ class YesAnswerNotificationReplyButtonStrategyTest {
         val sent = captor.value
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(TelegramMessageConstants.NOTIFICATION_ANSWER_YES_MESSAGE, sent.text)
+    }
+
+    @Test
+    @DisplayName("reply(): saves new water statistic")
+    fun `reply saves statistic`() {
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
+        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+
+        strategy.reply(buildCallbackQuery())
+
+        verify(waterStatisticAccessService).save(any<WaterStatisticDto>())
     }
 
     @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategyTest.kt
@@ -8,13 +8,16 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.*
+import org.mockito.kotlin.any
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
@@ -36,6 +39,7 @@ class SnoozeApplyReplyButtonStrategyTest {
     private lateinit var sender: TelegramClient
     private lateinit var notificationAccessService: NotificationAccessService
     private lateinit var messageEditorService: MessageEditorService
+    private lateinit var waterStatisticAccessService: WaterStatisticAccessService
     private lateinit var strategy: SnoozeApplyReplyButtonStrategy
 
     @BeforeEach
@@ -43,7 +47,14 @@ class SnoozeApplyReplyButtonStrategyTest {
         sender = mock(TelegramClient::class.java)
         notificationAccessService = mock(NotificationAccessService::class.java)
         messageEditorService = mock(MessageEditorService::class.java)
-        strategy = SnoozeApplyReplyButtonStrategy(sender, notificationAccessService, messageEditorService, fixedClock)
+        waterStatisticAccessService = mock(WaterStatisticAccessService::class.java)
+        strategy = SnoozeApplyReplyButtonStrategy(
+            sender,
+            notificationAccessService,
+            waterStatisticAccessService,
+            messageEditorService,
+            fixedClock
+        )
     }
 
     @ParameterizedTest
@@ -95,14 +106,6 @@ class SnoozeApplyReplyButtonStrategyTest {
         )
     }
 
-    @ParameterizedTest
-    @EnumSource(SnoozeNotificationType::class)
-    @DisplayName("isQueryData(): returns true for each SnoozeNotificationType queryData")
-    fun `isQueryData returns true for snooze types`(snoozeType: SnoozeNotificationType) {
-        val result = strategy.isQueryData(snoozeType.queryData.toString())
-        assertTrue(result)
-    }
-
     @Test
     @DisplayName("reply(): falls back to TEN_MINS when queryData doesn't match any SnoozeNotificationType")
     fun `reply falls back to TEN_MINS for unknown queryData`() {
@@ -115,6 +118,28 @@ class SnoozeApplyReplyButtonStrategyTest {
         val interval = notificationDto.notificationInterval.minutes
         val expectedTime = fixedNow.minusMinutes(interval).plusMinutes(SnoozeNotificationType.TEN_MINS.minutes)
         verify(notificationAccessService).updateTimeOfLastNotification(userId, expectedTime)
+    }
+
+    @ParameterizedTest
+    @EnumSource(SnoozeNotificationType::class)
+    @DisplayName("reply(): saves new water statistic with any snooze type")
+    fun `reply saves statistic any type`(snoozeType: SnoozeNotificationType) {
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
+        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
+
+        val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
+
+        strategy.reply(callbackQuery)
+
+        verify(waterStatisticAccessService).save(any<WaterStatisticDto>())
+    }
+
+    @ParameterizedTest
+    @EnumSource(SnoozeNotificationType::class)
+    @DisplayName("isQueryData(): returns true for each SnoozeNotificationType queryData")
+    fun `isQueryData returns true for snooze types`(snoozeType: SnoozeNotificationType) {
+        val result = strategy.isQueryData(snoozeType.queryData.toString())
+        assertTrue(result)
     }
 
     @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
@@ -17,8 +17,10 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.config.property.TelegramBotProperties
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.base.SettingsType
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.service.button.ButtonDataService
 import ru.illine.drinking.ponies.service.notification.impl.NotificationServiceImpl
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
@@ -52,6 +54,7 @@ class NotificationServiceTest {
     private lateinit var messageEditorService: MessageEditorService
     private lateinit var notificationAccessService: NotificationAccessService
     private lateinit var settingsButtonDataService: ButtonDataService<SettingsType>
+    private lateinit var waterStatisticAccessService: WaterStatisticAccessService
     private lateinit var clock: Clock
     private lateinit var service: NotificationServiceImpl
 
@@ -62,6 +65,7 @@ class NotificationServiceTest {
         notificationAccessService = mock(NotificationAccessService::class.java)
         @Suppress("UNCHECKED_CAST")
         settingsButtonDataService = mock(ButtonDataService::class.java) as ButtonDataService<SettingsType>
+        waterStatisticAccessService = mock(WaterStatisticAccessService::class.java)
         clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)
         service = NotificationServiceImpl(
             sender,
@@ -69,6 +73,7 @@ class NotificationServiceTest {
             notificationAccessService,
             settingsButtonDataService,
             botProperties,
+            waterStatisticAccessService,
             clock
         )
     }
@@ -263,6 +268,16 @@ class NotificationServiceTest {
         verify(notificationAccessService).updateNotificationSettings(anyCollection())
         assertEquals(0, dto.notificationAttempts)
         assertNull(dto.telegramChat.previousNotificationMessageId)
+    }
+
+    @Test
+    @DisplayName("suspendNotifications(): saves water statistic for each sent notification")
+    fun `suspendNotifications saves water statistics`() {
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+
+        service.suspendNotifications(listOf(dto))
+
+        verify(waterStatisticAccessService).saveAll(any<Collection<WaterStatisticDto>>())
     }
 
     @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
@@ -1,9 +1,11 @@
 package ru.illine.drinking.ponies.test.generator
 
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import java.time.LocalDateTime
 import java.time.LocalTime
 import kotlin.random.Random
@@ -40,6 +42,25 @@ class DtoGenerator {
                 notificationAttempts = notificationAttempts,
                 quietModeStart = quietModeStart,
                 quietModeEnd = quietModeEnd,
+            )
+        }
+
+        fun generateWaterStatisticDto(
+            externalUserId: Long = Random.nextLong(),
+            eventTime: LocalDateTime = LocalDateTime.now(),
+            eventType: AnswerNotificationType = AnswerNotificationType.YES,
+            waterAmountMl: Int = 250,
+            userTimeZone: String = "Europe/Moscow",
+        ): WaterStatisticDto {
+            val user = TelegramUserDto(
+                externalUserId = externalUserId,
+                userTimeZone = userTimeZone,
+            )
+            return WaterStatisticDto(
+                telegramUser = user,
+                eventTime = eventTime,
+                eventType = eventType,
+                waterAmountMl = waterAmountMl,
             )
         }
     }

--- a/src/test/resources/sql/access/WaterStatisticAccessService.sql
+++ b/src/test/resources/sql/access/WaterStatisticAccessService.sql
@@ -1,0 +1,5 @@
+insert into telegram_users (external_user_id, user_time_zone, created, deleted)
+values (1, 'Europe/Moscow', now(), false);
+
+insert into telegram_users (external_user_id, user_time_zone, created, deleted)
+values (2, 'Europe/Moscow', now(), false);

--- a/src/test/resources/sql/clear.sql
+++ b/src/test/resources/sql/clear.sql
@@ -1,7 +1,9 @@
+delete from water_statistics where id is not null;
 delete from notification_settings where id is not null;
 delete from telegram_chats where id is not null;
 delete from telegram_users where id is not null;
 
+alter sequence water_statistics_seq restart with 1;
 alter sequence notification_setting_seq restart with 1;
 alter sequence telegram_chat_seq restart with 1;
 alter sequence telegram_user_seq restart with 1;


### PR DESCRIPTION
## Summary
- Add `water_statistics` table (DDL + Liquibase migration 7.9.0)
- Add `WaterStatisticEntity`, `WaterStatisticRepository`, `WaterStatisticDto`, `WaterStatisticBuilder`
- Add `WaterStatisticAccessService` with `save()` and `saveAll()` methods
- Save statistics on YES, SNOOZE, CANCEL answers in notification reply strategies
- Save statistics for all suspended notifications in quiet mode (`NotificationServiceImpl`)

## Test plan
- [x] Unit tests: `YesAnswerNotificationReplyButtonStrategyTest`, `CancelAnswerNotificationReplyButtonStrategyTest`, `SnoozeApplyReplyButtonStrategyTest`
- [x] Unit test: `NotificationServiceTest` — verifies `saveAll` is called on `suspendNotifications`
- [x] Integration tests: `WaterStatisticAccessServiceTest` — save, saveAll, failure cases