### PR TITLE
DPTB-81: integrate GitLab CI with YouTrack (build, version, pipeline comments)

### DIFF
--- a/.ansible.gitlab-ci.yml
+++ b/.ansible.gitlab-ci.yml
@@ -1,0 +1,100 @@
+variables:
+  IMAGE_ANSIBLE_NAME: "ansible"
+  IMAGE_ANSIBLE_TAG: "1.1.0"
+  ANSIBLE_LIMIT: "test"
+
+build-ansible-image:
+  extends: .default-tags
+  stage: pre
+  allow_failure: true
+  image: docker:27
+  rules:
+    - if: '$PIPELINE_TYPE == "version-tag"'
+      when: never
+    - when: manual
+  before_script:
+    - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
+  script:
+    - docker build -f .ansible/Dockerfile -t "${CI_REGISTRY_IMAGE}/${IMAGE_ANSIBLE_NAME}:${IMAGE_ANSIBLE_TAG}" .
+    - docker push "${CI_REGISTRY_IMAGE}/${IMAGE_ANSIBLE_NAME}:${IMAGE_ANSIBLE_TAG}"
+  after_script:
+    - docker rmi "${CI_REGISTRY_IMAGE}/${IMAGE_ANSIBLE_NAME}:${IMAGE_ANSIBLE_TAG}" || true
+
+.run-ansible:
+  extends: .default-tags
+  stage: deploy
+  image: ${CI_REGISTRY_IMAGE}/${IMAGE_ANSIBLE_NAME}:${IMAGE_ANSIBLE_TAG}
+  when: manual
+  variables:
+    ANSIBLE_PLAYBOOK: .ansible/playbooks/deploy.yml
+    ANSIBLE_INVENTORIES: .ansible/inventories/all.yml
+  before_script:
+    - chmod 600 ${ANSIBLE_SSH_PRIVATE_KEY} || true
+  script:
+    - |
+      ansible-playbook \
+        -i ${ANSIBLE_INVENTORIES} \
+        ${ANSIBLE_PLAYBOOK} \
+        ${ANSIBLE_LIMIT:+--limit=$ANSIBLE_LIMIT} \
+        -v
+
+update-database:
+  extends:
+    - .run-ansible
+  stage: migration
+  variables:
+    ANSIBLE_PLAYBOOK: .ansible/playbooks/migration.yml
+    LIQUIBASE_COMMAND: update
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "develop"'
+      when: on_success
+    - if: '$CI_COMMIT_BRANCH == "master"'
+      when: on_success
+      variables:
+        ANSIBLE_LIMIT: "prod"
+    - if: '$CI_COMMIT_BRANCH'
+      when: manual
+      allow_failure: true
+  before_script:
+    - !reference [.run-ansible, before_script]
+
+rollback-database:
+  extends:
+    - .run-ansible
+  stage: migration
+  variables:
+    ANSIBLE_PLAYBOOK: ".ansible/playbooks/migration.yml"
+    LIQUIBASE_COMMAND: "rollback"
+    LIQUIBASE_ROLLBACK_TAG: "" # must be overridden when the job will be run
+  rules:
+    - if: '$PIPELINE_TYPE == "version-tag"'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "master"'
+      when: manual
+      variables:
+        ANSIBLE_LIMIT: "prod"
+    - when: manual
+  before_script:
+    - !reference [.run-ansible, before_script]
+
+deploy-service:
+  extends:
+    - .run-ansible
+  needs:
+    - job: generate-version
+      artifacts: true
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "develop"'
+      when: on_success
+    - if: '$CI_COMMIT_BRANCH == "master"'
+      when: on_success
+      variables:
+        ANSIBLE_LIMIT: "prod"
+    - if: '$CI_COMMIT_BRANCH'
+      when: manual
+      allow_failure: true
+  variables:
+    ANSIBLE_PLAYBOOK: .ansible/playbooks/deploy.yml
+    DPTB_VERSION: ${GitVersion_SemVer}
+  before_script:
+    - !reference [.run-ansible, before_script]

--- a/.common.gitlab-ci.yml
+++ b/.common.gitlab-ci.yml
@@ -1,0 +1,10 @@
+.default-tags:
+  tags:
+    - self-hosted
+    - docker
+
+.branch-only:
+  rules:
+    - if: '$PIPELINE_TYPE == "version-tag"'
+      when: never
+    - when: on_success

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 .liquibase
 .jpb
 .env
+plans/
 
 ### macOS ###
 **/.DS_Store

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,8 @@
+include:
+  - local: .common.gitlab-ci.yml
+  - local: .ansible.gitlab-ci.yml
+  - local: .post.gitlab-ci.yml
+
 stages:
   - pre
   - test
@@ -8,6 +13,10 @@ stages:
 
 workflow:
   rules:
+    - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
+      when: always
+      variables:
+        PIPELINE_TYPE: "version-tag"
     - if: '$CI_COMMIT_MESSAGE =~ /\[skip gitlab-ci\]/'
       when: never
     - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH'
@@ -18,34 +27,15 @@ variables:
   GRADLE_JVM_OPTS: "-Xmx4096m"
   GRADLE_OPTS: "-Dorg.gradle.workers.max=4"
   SERVICE_NAME: "dptb"
-  IMAGE_ANSIBLE_NAME: ansible
-  IMAGE_ANSIBLE_TAG: 1.1.0
-  ANSIBLE_LIMIT: "test"
+  YOUTRACK_PROJECT: "DPTB"
 
 default:
   interruptible: true
 
-.default-tags: &default-tags
-  tags:
-    - self-hosted
-    - docker
-
-build-ansible-image:
-  <<: *default-tags
-  stage: pre
-  allow_failure: true
-  image: docker:27
-  when: manual
-  before_script:
-    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" "$CI_REGISTRY"
-  script:
-    - docker build -f .ansible/Dockerfile -t "$CI_REGISTRY_IMAGE/$IMAGE_ANSIBLE_NAME:$IMAGE_ANSIBLE_TAG" .
-    - docker push "$CI_REGISTRY_IMAGE/$IMAGE_ANSIBLE_NAME:$IMAGE_ANSIBLE_TAG"
-  after_script:
-    - docker rmi "$CI_REGISTRY_IMAGE/$IMAGE_ANSIBLE_NAME:$IMAGE_ANSIBLE_TAG" || true
-
 generate-version:
-  <<: *default-tags
+  extends:
+    - .default-tags
+    - .branch-only
   stage: pre
   image:
     name: gittools/gitversion:6.5.0
@@ -66,17 +56,19 @@ generate-version:
       - gitversion.properties
 
 test:
-  <<: *default-tags
+  extends:
+    - .default-tags
+    - .branch-only
   stage: test
   image: gradle:8.4-jdk17
   variables:
     GRADLE_USER_HOME: ".gradle"
-    TELEGRAM_BOT_TOKEN: $TELEGRAM_BOT_TEST_TOKEN
+    TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TEST_TOKEN}
   cache:
     - key: gradle-cache-${CI_PROJECT_ID}
       paths:
         - .gradle
-    - key: gradle-build-${CI_PROJECT_ID-$CI_COMMIT_REF_NAME}
+    - key: gradle-build-${CI_PROJECT_ID}-${CI_COMMIT_REF_NAME}
       paths:
         - build/
   before_script:
@@ -91,7 +83,7 @@ test:
     - |
       ./codecov create-commit
       ./codecov create-report
-      ./codecov do-upload -Z -n "codecov-$CI_PROJECT_ID-$CI_COMMIT_REF_NAME"
+      ./codecov do-upload -Z -n "codecov-${CI_PROJECT_ID}-${CI_COMMIT_REF_NAME}"
   artifacts:
     expire_in: 1 day
     when: always
@@ -105,7 +97,9 @@ test:
         path: "build/jacoco/coverage.xml"
 
 build-jar:
-  <<: *default-tags
+  extends:
+    - .default-tags
+    - .branch-only
   stage: build
   image: gradle:8.4-jdk17
   needs:
@@ -124,7 +118,9 @@ build-jar:
       - build/libs/drinking-ponies.jar
 
 build-image:
-  <<: *default-tags
+  extends:
+    - .default-tags
+    - .branch-only
   stage: build
   image: docker:27
   needs:
@@ -133,132 +129,17 @@ build-image:
     - job: build-jar
       artifacts: true
   before_script:
-    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" "$CI_REGISTRY"
+    - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
   script:
-    - echo "image tag=$GitVersion_SemVer"
+    - echo "image tag=${GitVersion_SemVer}"
     - |
-      docker build -t "$CI_REGISTRY_IMAGE:$GitVersion_SemVer" .
-      docker push "$CI_REGISTRY_IMAGE:$GitVersion_SemVer"
-      if [ "$CI_COMMIT_BRANCH" = "master" ]; then
-        docker tag "$CI_REGISTRY_IMAGE:$GitVersion_SemVer" "$CI_REGISTRY_IMAGE:latest"
-        docker push "$CI_REGISTRY_IMAGE:latest"
+      docker build -t "${CI_REGISTRY_IMAGE}:${GitVersion_SemVer}" .
+      docker push "${CI_REGISTRY_IMAGE}:${GitVersion_SemVer}"
+      if [ "${CI_COMMIT_BRANCH}" = "master" ]; then
+        docker tag "${CI_REGISTRY_IMAGE}:${GitVersion_SemVer}" "${CI_REGISTRY_IMAGE}:latest"
+        docker push "${CI_REGISTRY_IMAGE}:latest"
       fi
   after_script:
     - |
-      docker rmi "$CI_REGISTRY_IMAGE:$GitVersion_SemVer" || true
-      docker rmi "$CI_REGISTRY_IMAGE:latest" || true
-
-.run-ansible:
-  <<: *default-tags
-  stage: deploy
-  image: $CI_REGISTRY_IMAGE/$IMAGE_ANSIBLE_NAME:$IMAGE_ANSIBLE_TAG
-  when: manual
-  variables:
-    ANSIBLE_PLAYBOOK: .ansible/playbooks/deploy.yml
-    ANSIBLE_INVENTORIES: .ansible/inventories/all.yml
-  before_script:
-    - chmod 600 $ANSIBLE_SSH_PRIVATE_KEY || true
-  script:
-    - |
-      ansible-playbook \
-        -i $ANSIBLE_INVENTORIES \
-        $ANSIBLE_PLAYBOOK \
-        ${ANSIBLE_LIMIT:+--limit=$ANSIBLE_LIMIT} \
-        -v
-
-update-database:
-  extends:
-    - .run-ansible
-  stage: migration
-  variables:
-    ANSIBLE_PLAYBOOK: .ansible/playbooks/migration.yml
-    LIQUIBASE_COMMAND: update
-  rules:
-    - if: '$CI_COMMIT_BRANCH == "develop"'
-      when: on_success
-    - if: '$CI_COMMIT_BRANCH == "master"'
-      when: on_success
-      variables:
-        ANSIBLE_LIMIT: "prod"
-    - if: '$CI_COMMIT_BRANCH'
-      when: manual
-      allow_failure: true
-  before_script:
-    - !reference [.run-ansible, before_script]
-
-rollback-database:
-  extends:
-    - .run-ansible
-  stage: migration
-  variables:
-    ANSIBLE_PLAYBOOK: .ansible/playbooks/migration.yml
-    LIQUIBASE_COMMAND: rollback
-    LIQUIBASE_ROLLBACK_TAG: "" # must be overridden when the job will be run
-  rules:
-    - if: '$CI_COMMIT_BRANCH == "master"'
-      when: manual
-      variables:
-        ANSIBLE_LIMIT: "prod"
-    - when: manual
-  before_script:
-    - !reference [.run-ansible, before_script]
-
-deploy-service:
-  extends:
-    - .run-ansible
-  dependencies:
-    - generate-version
-  rules:
-    - if: '$CI_COMMIT_BRANCH == "develop"'
-      when: on_success
-    - if: '$CI_COMMIT_BRANCH == "master"'
-      when: on_success
-      variables:
-        ANSIBLE_LIMIT: "prod"
-    - if: '$CI_COMMIT_BRANCH'
-      when: manual
-      allow_failure: true
-  variables:
-    ANSIBLE_PLAYBOOK: .ansible/playbooks/deploy.yml
-    DPTB_VERSION: ${GitVersion_SemVer}
-  before_script:
-    - !reference [.run-ansible, before_script]
-
-tag-build:
-  <<: *default-tags
-  stage: post
-  image:
-    name: alpine/git:2.49.1
-    entrypoint: [""]
-  dependencies:
-    - generate-version
-  rules:
-    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "develop"'
-      when: on_success
-    - when: never
-  before_script:
-    - |
-      git config user.name "Deploy Bot"
-      git config user.email "deploy-bot@local"
-
-      if git remote get-url github >/dev/null 2>&1; then
-        git remote set-url github "https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
-      else
-        git remote add github "https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
-      fi
-  script:
-    - |
-      PREFIX=build
-      if [ "$CI_COMMIT_BRANCH" = "master" ]; then
-        PREFIX=release
-      fi
-      
-      GIT_TAG="$PREFIX-$GitVersion_SemVer"
-      
-      if git rev-parse "$GIT_TAG" >/dev/null 2>&1; then
-        echo "Tag $GIT_TAG already exists locally"
-      else
-        git tag "$GIT_TAG"
-      fi
-
-      git push github "refs/tags/$GIT_TAG"
+      docker rmi "${CI_REGISTRY_IMAGE}:${GitVersion_SemVer}" || true
+      docker rmi "${CI_REGISTRY_IMAGE}:latest" || true

--- a/.post.gitlab-ci.yml
+++ b/.post.gitlab-ci.yml
@@ -1,0 +1,239 @@
+variables:
+  YOUTRACK_BUILD_BUNDLE_ID: "146-1"
+  YOUTRACK_BUILD_FIELD_ID: "143-24"
+  YOUTRACK_VERSION_BUNDLE_ID: "128-3"
+  YOUTRACK_VERSION_FIELD_ID: "143-30"
+
+tag-build:
+  extends: .default-tags
+  stage: post
+  image:
+    name: alpine/git:2.49.1
+    entrypoint: [""]
+  needs:
+    - job: generate-version
+      artifacts: true
+  variables:
+    GIT_DEPTH: 0
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "develop"'
+      when: on_success
+    - when: never
+  before_script:
+    - |
+      git config user.name "Deploy Bot"
+      git config user.email "deploy-bot@local"
+
+      if git remote get-url github >/dev/null 2>&1; then
+        git remote set-url github "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+      else
+        git remote add github "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+      fi
+  script:
+    - |
+      PREFIX=build
+      if [ "${CI_COMMIT_BRANCH}" = "master" ]; then
+        PREFIX=release
+      fi
+
+      GIT_TAG="${PREFIX}-${GitVersion_SemVer}"
+
+      if git rev-parse "${GIT_TAG}" >/dev/null 2>&1; then
+        echo "Tag ${GIT_TAG} already exists locally"
+      else
+        git tag "${GIT_TAG}"
+      fi
+
+      git push github "refs/tags/${GIT_TAG}"
+
+update-youtrack-build:
+  extends: .default-tags
+  stage: post
+  image: alpine:3.21
+  needs:
+    - job: generate-version
+      artifacts: true
+    - job: tag-build
+  variables:
+    GIT_DEPTH: 0
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "develop"'
+      when: on_success
+    - when: never
+  before_script:
+    - apk add --no-cache curl git jq
+    - git fetch --tags
+  script:
+    - |
+      TAG_NAME="build-${GitVersion_SemVer}"
+      echo "Tag: ${TAG_NAME}"
+
+      # Find previous build tag (exclude current)
+      PREV_TAG=""
+      for TAG in $(git tag --sort=-v:creatordate --list "build-*"); do
+        if [ "${TAG}" != "build-${GitVersion_SemVer}" ]; then
+          PREV_TAG="${TAG}"
+          break
+        fi
+      done
+
+      if [ -z "${PREV_TAG}" ]; then
+        echo "Error: no previous build tag found. Is this the first run? Set build field manually."
+        exit 1
+      fi
+
+      echo "Previous tag: ${PREV_TAG}"
+      COMMITS=$(git log "${PREV_TAG}..HEAD" --oneline)
+
+      # Extract unique issue IDs
+      ISSUES=$(echo "${COMMITS}" | grep -oE "${YOUTRACK_PROJECT}-[0-9]+" | sort -u) || true
+
+      if [ -z "${ISSUES}" ]; then
+        echo "No ${YOUTRACK_PROJECT} issues found in commits"
+        exit 0
+      fi
+
+      echo "Found issues: ${ISSUES}"
+
+      # Create build value
+      echo "Creating build value '${TAG_NAME}'"
+      HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
+        -H "Content-Type: application/json" \
+        "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/build/${YOUTRACK_BUILD_BUNDLE_ID}/values" \
+        -d "{\"name\": \"${TAG_NAME}\"}")
+
+      if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
+        echo "Build value created"
+      elif [ "${HTTP_CODE}" = "409" ]; then
+        echo "Build value already exists"
+      else
+        echo "Warning: response ${HTTP_CODE}"
+      fi
+
+      # Find latest unreleased version to assign
+      VERSION_NAME=$(curl -sf \
+        -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
+        "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/version/${YOUTRACK_VERSION_BUNDLE_ID}/values?fields=name,released" \
+        | jq -r '[.[] | select(.released == false)] | last | .name // empty') || VERSION_NAME=""
+
+      if [ -n "${VERSION_NAME}" ]; then
+        echo "Assigning unreleased version: ${VERSION_NAME}"
+      else
+        echo "No unreleased version found, skipping version assignment"
+      fi
+
+      # Update each issue
+      for ISSUE_ID in ${ISSUES}; do
+        echo "Updating ${ISSUE_ID}"
+
+        # Build custom fields payload
+        FIELDS_JSON="[{\"id\": \"${YOUTRACK_BUILD_FIELD_ID}\", \"\$type\": \"SingleBuildIssueCustomField\", \"value\": {\"name\": \"${TAG_NAME}\"}}]"
+        if [ -n "${VERSION_NAME}" ]; then
+          FIELDS_JSON="[{\"id\": \"${YOUTRACK_BUILD_FIELD_ID}\", \"\$type\": \"SingleBuildIssueCustomField\", \"value\": {\"name\": \"${TAG_NAME}\"}}, {\"id\": \"${YOUTRACK_VERSION_FIELD_ID}\", \"\$type\": \"SingleVersionIssueCustomField\", \"value\": {\"name\": \"${VERSION_NAME}\"}}]"
+        fi
+
+        # Set fields
+        curl -sf -o /dev/null -X POST \
+          -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
+          -H "Content-Type: application/json" \
+          "${YOUTRACK_URL}/api/issues/${ISSUE_ID}" \
+          -d "{\"customFields\": ${FIELDS_JSON}}" || echo "Warning: failed to update fields for ${ISSUE_ID}"
+
+        # Unpin existing pipeline comments
+        PINNED_IDS=$(curl -sf \
+          -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
+          "${YOUTRACK_URL}/api/issues/${ISSUE_ID}/comments?fields=id,text,pinned" \
+          | jq -r '.[] | select(.pinned == true and (.text | test("GitLab Pipeline:"))) | .id') || PINNED_IDS=""
+
+        for COMMENT_ID in ${PINNED_IDS}; do
+          curl -sf -o /dev/null -X POST \
+            -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
+            -H "Content-Type: application/json" \
+            "${YOUTRACK_URL}/api/issues/${ISSUE_ID}/comments/${COMMENT_ID}" \
+            -d '{"pinned": false}' || echo "Warning: failed to unpin comment ${COMMENT_ID}"
+        done
+
+        # Add new pinned comment
+        curl -sf -o /dev/null -X POST \
+          -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
+          -H "Content-Type: application/json" \
+          "${YOUTRACK_URL}/api/issues/${ISSUE_ID}/comments" \
+          -d "{
+            \"text\": \"GitLab Pipeline: [#${CI_PIPELINE_ID}](${CI_PIPELINE_URL}) | Success ✅\",
+            \"pinned\": true
+          }" || echo "Warning: failed to add comment for ${ISSUE_ID}"
+
+        echo "${ISSUE_ID} done"
+      done
+
+close-youtrack-version:
+  extends: .default-tags
+  stage: post
+  image: alpine:3.21
+  needs:
+    - job: tag-build
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master"'
+      when: on_success
+    - when: never
+  before_script:
+    - apk add --no-cache curl jq
+  script:
+    - |
+      # Find latest unreleased version
+      VERSION_DATA=$(curl -sf \
+        -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
+        "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/version/${YOUTRACK_VERSION_BUNDLE_ID}/values?fields=id,name,released" \
+        | jq -r '[.[] | select(.released == false)] | last') || { echo "Failed to fetch versions"; exit 1; }
+      VERSION_NAME=$(echo "${VERSION_DATA}" | jq -r '.name // empty')
+      VERSION_ID=$(echo "${VERSION_DATA}" | jq -r '.id // empty')
+
+      if [ -z "${VERSION_ID}" ] || [ "${VERSION_ID}" = "null" ]; then
+        echo "No unreleased version found"
+        exit 0
+      fi
+
+      RELEASE_DATE=$(($(date +%s) * 1000))
+      echo "Closing version '${VERSION_NAME}' (${VERSION_ID}): released=true"
+
+      HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
+        -H "Content-Type: application/json" \
+        "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/version/${YOUTRACK_VERSION_BUNDLE_ID}/values/${VERSION_ID}" \
+        -d "{\"released\": true, \"releaseDate\": ${RELEASE_DATE}}")
+
+      if [ "${HTTP_CODE}" = "200" ]; then
+        echo "Version closed"
+      else
+        echo "Warning: response ${HTTP_CODE}"
+      fi
+
+create-youtrack-version:
+  extends: .default-tags
+  stage: post
+  image: alpine:3.21
+  rules:
+    - if: '$PIPELINE_TYPE == "version-tag"'
+      when: on_success
+    - when: never
+  before_script:
+    - apk add --no-cache curl
+  script:
+    - |
+      VERSION_NAME="${CI_COMMIT_TAG#v}"
+      echo "Creating YouTrack version: ${VERSION_NAME} (unreleased)"
+
+      HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
+        -H "Content-Type: application/json" \
+        "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/version/${YOUTRACK_VERSION_BUNDLE_ID}/values" \
+        -d "{\"name\": \"${VERSION_NAME}\", \"released\": false}")
+
+      if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
+        echo "Version created"
+      elif [ "${HTTP_CODE}" = "409" ]; then
+        echo "Version already exists"
+      else
+        echo "Warning: response ${HTTP_CODE}"
+      fi


### PR DESCRIPTION
## Summary
- Split `.gitlab-ci.yml` into modular includes: `.common.gitlab-ci.yml`, `.ansible.gitlab-ci.yml`, `.post.gitlab-ci.yml`
- Add `create-youtrack-version` job: creates unreleased version in YouTrack on `vX.Y.Z` tag push
- Add `update-youtrack-build` job: sets Build + Version fields on issues, pins pipeline comment (develop)
- Add `close-youtrack-version` job: marks version as released on master merge
- Add workflow rule for version tags with `PIPELINE_TYPE` variable to isolate tag pipelines
- Replace YAML anchors with `extends` for cross-file compatibility
- Fix cache key typo, migrate `dependencies` to `needs`, add curl error handling

## Test plan
- [x] Case 0: feature branch push - standard jobs run, YouTrack jobs do not appear
- [x] Case 1: tag `vX.Y.Z` - only `create-youtrack-version` runs, creates unreleased version
- [x] Case 2: develop merge - `update-youtrack-build` sets Build + Version fields, pins comment
- [x] Case 3: master merge - `close-youtrack-version` marks version as released