### PR TITLE
DPTB-23: implement water amount selection on yes answer

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/model/base/WaterAmountType.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/base/WaterAmountType.kt
@@ -1,0 +1,27 @@
+package ru.illine.drinking.ponies.model.base
+
+import ru.illine.drinking.ponies.util.telegram.TelegramWaterAmountConstants
+import java.util.*
+
+@Suppress("unused")
+enum class WaterAmountType(
+    val displayName: String,
+    val amountMl: Int,
+    val queryData: UUID
+) {
+    ML_50(TelegramWaterAmountConstants.ML_50, 50, UUID.fromString("a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d")),
+    ML_100(TelegramWaterAmountConstants.ML_100, 100, UUID.fromString("b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e")),
+    ML_150(TelegramWaterAmountConstants.ML_150, 150, UUID.fromString("c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f")),
+    ML_250(TelegramWaterAmountConstants.ML_250, 250, UUID.fromString("d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a")),
+    ML_450(TelegramWaterAmountConstants.ML_450, 450, UUID.fromString("e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8a9b"));
+
+    companion object {
+
+        fun typeOf(queryData: String): WaterAmountType? {
+            return WaterAmountType.entries
+                .find { Objects.equals(queryData, it.queryData.toString()) }
+        }
+
+    }
+
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategy.kt
@@ -4,11 +4,10 @@ import org.springframework.stereotype.Service
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
-import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
-import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.service.button.strategy.AbstractAnswerNotificationReplyButtonStrategy
+import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
 import java.time.Clock
@@ -19,20 +18,14 @@ class CancelAnswerNotificationReplyButtonStrategy(
     sender: TelegramClient,
     messageEditorService: MessageEditorService,
     private val notificationAccessService: NotificationAccessService,
-    private val waterStatisticAccessService: WaterStatisticAccessService,
+    private val waterStatisticService: WaterStatisticService,
     private val clock: Clock
 ) : AbstractAnswerNotificationReplyButtonStrategy<NotificationSettingDto>(sender, messageEditorService) {
 
     override fun updateLastNotificationTime(callbackQuery: CallbackQuery): () -> NotificationSettingDto = {
         notificationAccessService.updateTimeOfLastNotification(callbackQuery.from.id, LocalDateTime.now(clock))
             .also { setting ->
-                waterStatisticAccessService.save(
-                    WaterStatisticDto(
-                        telegramUser = setting.telegramUser,
-                        eventTime = LocalDateTime.now(clock),
-                        eventType = getAnswerType()
-                    )
-                )
+                waterStatisticService.recordEvent(setting.telegramUser, getAnswerType())
             }
     }
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategy.kt
@@ -1,42 +1,42 @@
 package ru.illine.drinking.ponies.service.button.strategy.notification
 
 import org.springframework.stereotype.Service
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
-import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
-import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
-import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
-import ru.illine.drinking.ponies.service.button.strategy.AbstractAnswerNotificationReplyButtonStrategy
+import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
+import ru.illine.drinking.ponies.util.telegram.TelegramBotKeyboardHelper
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
-import java.time.Clock
-import java.time.LocalDateTime
+import java.util.*
 
 @Service
 class YesAnswerNotificationReplyButtonStrategy(
-    sender: TelegramClient,
-    messageEditorService: MessageEditorService,
-    private val notificationAccessService: NotificationAccessService,
-    private val waterStatisticAccessService: WaterStatisticAccessService,
-    private val clock: Clock
-) : AbstractAnswerNotificationReplyButtonStrategy<NotificationSettingDto>(sender, messageEditorService) {
+    private val sender: TelegramClient,
+    private val messageEditorService: MessageEditorService
+) : ReplyButtonStrategy {
 
-    override fun updateLastNotificationTime(callbackQuery: CallbackQuery): () -> NotificationSettingDto = {
-        notificationAccessService.updateTimeOfLastNotification(callbackQuery.from.id, LocalDateTime.now(clock))
-            .also { setting ->
-                waterStatisticAccessService.save(
-                    WaterStatisticDto(
-                        telegramUser = setting.telegramUser,
-                        eventTime = LocalDateTime.now(clock),
-                        eventType = getAnswerType()
-                    )
-                )
-            }
+    override fun reply(callbackQuery: CallbackQuery) {
+        val chatId = callbackQuery.message.chatId
+        val messageId = callbackQuery.message.messageId
+        val messageText =
+            TelegramMessageConstants.NOTIFICATION_QUESTION_EDITED_MESSAGE_PATTERN.format(
+                AnswerNotificationType.YES.displayName
+            )
+
+        messageEditorService.editReplyMarkup(messageText, chatId, messageId, true)
+
+        SendMessage(
+            chatId.toString(),
+            TelegramMessageConstants.NOTIFICATION_WATER_AMOUNT_MENU_MESSAGE
+        ).apply {
+            replyMarkup = TelegramBotKeyboardHelper.waterAmountButtons()
+        }.apply { sender.execute(this) }
     }
 
-    override fun getMessageText(): String = TelegramMessageConstants.NOTIFICATION_ANSWER_YES_MESSAGE
+    override fun isQueryData(queryData: String): Boolean {
+        return Objects.equals(AnswerNotificationType.YES.queryData.toString(), queryData)
+    }
 
-    override fun getAnswerType(): AnswerNotificationType = AnswerNotificationType.YES
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategy.kt
@@ -6,22 +6,20 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
-import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
-import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
+import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.TimeHelper
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
 import java.time.Clock
-import java.time.LocalDateTime
 
 @Service
 class SnoozeApplyReplyButtonStrategy(
     private val sender: TelegramClient,
     private val notificationAccessService: NotificationAccessService,
-    private val waterStatisticAccessService: WaterStatisticAccessService,
+    private val waterStatisticService: WaterStatisticService,
     private val messageEditorService: MessageEditorService,
     private val clock: Clock
 ) : ReplyButtonStrategy {
@@ -56,13 +54,7 @@ class SnoozeApplyReplyButtonStrategy(
             )
         notificationAccessService.updateTimeOfLastNotification(userId, nextNotificationTime)
 
-        waterStatisticAccessService.save(
-            WaterStatisticDto(
-                telegramUser = notificationSetting.telegramUser,
-                eventTime = LocalDateTime.now(clock),
-                eventType = AnswerNotificationType.SNOOZE
-            )
-        )
+        waterStatisticService.recordEvent(notificationSetting.telegramUser, AnswerNotificationType.SNOOZE)
 
         SendMessage(
             chatId.toString(),

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategy.kt
@@ -6,11 +6,10 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
-import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.WaterAmountType
-import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
+import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
 import java.time.Clock
@@ -20,7 +19,7 @@ import java.time.LocalDateTime
 class WaterAmountApplyReplyButtonStrategy(
     private val sender: TelegramClient,
     private val notificationAccessService: NotificationAccessService,
-    private val waterStatisticAccessService: WaterStatisticAccessService,
+    private val waterStatisticService: WaterStatisticService,
     private val messageEditorService: MessageEditorService,
     private val clock: Clock
 ) : ReplyButtonStrategy {
@@ -48,13 +47,10 @@ class WaterAmountApplyReplyButtonStrategy(
 
         val notificationSetting = notificationAccessService.updateTimeOfLastNotification(userId, LocalDateTime.now(clock))
 
-        waterStatisticAccessService.save(
-            WaterStatisticDto(
-                telegramUser = notificationSetting.telegramUser,
-                eventTime = LocalDateTime.now(clock),
-                eventType = AnswerNotificationType.YES,
-                waterAmountMl = waterAmountType.amountMl
-            )
+        waterStatisticService.recordEvent(
+            notificationSetting.telegramUser,
+            AnswerNotificationType.YES,
+            waterAmountType.amountMl
         )
 
         SendMessage(

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategy.kt
@@ -1,0 +1,68 @@
+package ru.illine.drinking.ponies.service.button.strategy.wateramount
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery
+import org.telegram.telegrambots.meta.generics.TelegramClient
+import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.base.WaterAmountType
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
+import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
+import ru.illine.drinking.ponies.service.telegram.MessageEditorService
+import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
+import java.time.Clock
+import java.time.LocalDateTime
+
+@Service
+class WaterAmountApplyReplyButtonStrategy(
+    private val sender: TelegramClient,
+    private val notificationAccessService: NotificationAccessService,
+    private val waterStatisticAccessService: WaterStatisticAccessService,
+    private val messageEditorService: MessageEditorService,
+    private val clock: Clock
+) : ReplyButtonStrategy {
+
+    private val logger = LoggerFactory.getLogger("REPLY-STRATEGY")
+
+    override fun reply(callbackQuery: CallbackQuery) {
+        messageEditorService.deleteReplyMarkup(
+            callbackQuery.message.chatId,
+            callbackQuery.message.messageId
+        )
+
+        val userId = callbackQuery.from.id
+        val chatId = callbackQuery.message.chatId
+        val queryData = callbackQuery.data
+
+        val waterAmountType = WaterAmountType.typeOf(queryData) ?: WaterAmountType.ML_250
+
+        logger.info(
+            "A telegram user [{}] for telegram chat [{}] drank [{}] ml of water",
+            userId,
+            chatId,
+            waterAmountType.amountMl
+        )
+
+        val notificationSetting = notificationAccessService.updateTimeOfLastNotification(userId, LocalDateTime.now(clock))
+
+        waterStatisticAccessService.save(
+            WaterStatisticDto(
+                telegramUser = notificationSetting.telegramUser,
+                eventTime = LocalDateTime.now(clock),
+                eventType = AnswerNotificationType.YES,
+                waterAmountMl = waterAmountType.amountMl
+            )
+        )
+
+        SendMessage(
+            chatId.toString(),
+            TelegramMessageConstants.NOTIFICATION_ANSWER_YES_MESSAGE
+        ).apply { sender.execute(this) }
+    }
+
+    override fun isQueryData(queryData: String): Boolean = WaterAmountType.typeOf(queryData) != null
+
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
@@ -8,15 +8,14 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.config.property.TelegramBotProperties
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
-import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.SettingsType
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
-import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.service.button.ButtonDataService
 import ru.illine.drinking.ponies.service.notification.NotificationService
+import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.FunctionHelper.check
 import ru.illine.drinking.ponies.util.TimeHelper
@@ -32,7 +31,7 @@ class NotificationServiceImpl(
     private val notificationAccessService: NotificationAccessService,
     private val settingsButtonDataService: ButtonDataService<SettingsType>,
     private val telegramBotProperties: TelegramBotProperties,
-    private val waterStatisticAccessService: WaterStatisticAccessService,
+    private val waterStatisticService: WaterStatisticService,
     private val clock: Clock,
 ) : NotificationService {
 
@@ -178,14 +177,9 @@ class NotificationServiceImpl(
         }
 
         notificationAccessService.updateNotificationSettings(sent)
-        waterStatisticAccessService.saveAll(
-            sent.map {
-                WaterStatisticDto(
-                    telegramUser = it.telegramUser,
-                    eventTime = LocalDateTime.now(clock),
-                    eventType = AnswerNotificationType.CANCEL
-                )
-            }
+        waterStatisticService.recordEvents(
+            sent.map { it.telegramUser },
+            AnswerNotificationType.CANCEL
         )
     }
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticService.kt
@@ -1,0 +1,12 @@
+package ru.illine.drinking.ponies.service.statistic
+
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
+
+interface WaterStatisticService {
+
+    fun recordEvent(telegramUser: TelegramUserDto, eventType: AnswerNotificationType, waterAmountMl: Int = 0)
+
+    fun recordEvents(telegramUsers: Collection<TelegramUserDto>, eventType: AnswerNotificationType)
+
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/impl/WaterStatisticServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/impl/WaterStatisticServiceImpl.kt
@@ -1,0 +1,53 @@
+package ru.illine.drinking.ponies.service.statistic.impl
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
+import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
+import java.time.Clock
+import java.time.LocalDateTime
+
+@Service
+class WaterStatisticServiceImpl(
+    private val waterStatisticAccessService: WaterStatisticAccessService,
+    private val clock: Clock
+) : WaterStatisticService {
+
+    private val logger = LoggerFactory.getLogger("SERVICE")
+
+    override fun recordEvent(telegramUser: TelegramUserDto, eventType: AnswerNotificationType, waterAmountMl: Int) {
+        logger.info(
+            "Recording water statistic event [{}] for user [{}], amount [{}] ml",
+            eventType,
+            telegramUser.externalUserId,
+            waterAmountMl
+        )
+
+        waterStatisticAccessService.save(
+            WaterStatisticDto(
+                telegramUser = telegramUser,
+                eventTime = LocalDateTime.now(clock),
+                eventType = eventType,
+                waterAmountMl = waterAmountMl
+            )
+        )
+    }
+
+    override fun recordEvents(telegramUsers: Collection<TelegramUserDto>, eventType: AnswerNotificationType) {
+        logger.info("Recording [{}] water statistic events with type [{}]", telegramUsers.size, eventType)
+
+        waterStatisticAccessService.saveAll(
+            telegramUsers.map {
+                WaterStatisticDto(
+                    telegramUser = it,
+                    eventTime = LocalDateTime.now(clock),
+                    eventType = eventType
+                )
+            }
+        )
+    }
+
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramBotKeyboardHelper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramBotKeyboardHelper.kt
@@ -7,6 +7,7 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKe
 import org.telegram.telegrambots.meta.api.objects.webapp.WebAppInfo
 import ru.illine.drinking.ponies.model.base.*
 import ru.illine.drinking.ponies.service.button.ButtonDataService
+import java.util.*
 
 object TelegramBotKeyboardHelper {
 
@@ -37,68 +38,67 @@ object TelegramBotKeyboardHelper {
     }
 
     fun intervalTimeButtons(intervalTime: IntervalNotificationType? = null): ReplyKeyboard {
-        val rows = IntervalNotificationType.entries
-            .filter { it != intervalTime }
-            .map {
-                InlineKeyboardRow(
-                    InlineKeyboardButton.builder()
-                        .text(it.displayName)
-                        .callbackData(it.queryData.toString())
-                        .build()
-                )
-            }
-
-        return InlineKeyboardMarkup.builder()
-            .keyboard(rows)
-            .build()
+        return buildInlineKeyboard(
+            IntervalNotificationType.entries.filter { it != intervalTime },
+            IntervalNotificationType::displayName,
+            IntervalNotificationType::queryData
+        )
     }
 
     fun pauseTimeButtons(currentIntervalTime: IntervalNotificationType): ReplyKeyboard {
-        val rows = PauseNotificationType.entries
-            .filter { it == PauseNotificationType.RESET || it.minutes > currentIntervalTime.minutes }
-            .map {
-                InlineKeyboardRow(
-                    InlineKeyboardButton.builder()
-                        .text(it.displayName)
-                        .callbackData(it.queryData.toString())
-                        .build()
-                )
-            }
-
-        return InlineKeyboardMarkup.builder()
-            .keyboard(rows)
-            .build()
+        return buildInlineKeyboard(
+            PauseNotificationType.entries.filter { it == PauseNotificationType.RESET || it.minutes > currentIntervalTime.minutes },
+            PauseNotificationType::displayName,
+            PauseNotificationType::queryData
+        )
     }
 
     fun snoozeTimeButtons(): ReplyKeyboard {
-        val rows = SnoozeNotificationType.entries
-            .map {
-                InlineKeyboardRow(
-                    InlineKeyboardButton.builder()
-                        .text(it.displayName)
-                        .callbackData(it.queryData.toString())
-                        .build()
-                )
-            }
+        return buildInlineKeyboard(
+            SnoozeNotificationType.entries,
+            SnoozeNotificationType::displayName,
+            SnoozeNotificationType::queryData
+        )
+    }
 
-        return InlineKeyboardMarkup.builder()
-            .keyboard(rows)
-            .build()
+    fun waterAmountButtons(): ReplyKeyboard {
+        return buildInlineKeyboard(
+            WaterAmountType.entries,
+            WaterAmountType::displayName,
+            WaterAmountType::queryData
+        )
     }
 
     fun notifyButtons(): ReplyKeyboard {
-        val buttons = AnswerNotificationType.entries
-            .map {
-                InlineKeyboardButton.builder()
-                    .text(it.displayName)
-                    .callbackData(it.queryData.toString())
-                    .build()
-            }
+        return buildInlineKeyboard(
+            AnswerNotificationType.entries,
+            AnswerNotificationType::displayName,
+            AnswerNotificationType::queryData,
+            singleRow = true
+        )
+    }
 
-        val row = InlineKeyboardRow(buttons)
+    private fun <T> buildInlineKeyboard(
+        entries: List<T>,
+        displayName: (T) -> String,
+        queryData: (T) -> UUID,
+        singleRow: Boolean = false
+    ): ReplyKeyboard {
+        val buttons = entries.map {
+            InlineKeyboardButton.builder()
+                .text(displayName(it))
+                .callbackData(queryData(it).toString())
+                .build()
+        }
+
+        val keyboard = if (singleRow) {
+            listOf(InlineKeyboardRow(buttons))
+        } else {
+            buttons.map { InlineKeyboardRow(it) }
+        }
 
         return InlineKeyboardMarkup.builder()
-            .keyboard(listOf(row))
+            .keyboard(keyboard)
             .build()
     }
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramMessageConstants.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramMessageConstants.kt
@@ -79,4 +79,6 @@ object TelegramMessageConstants {
 
     val NOTIFICATION_SNOOZE_MENU_MESSAGE = "Выбери, на сколько хочешь отложить уведомление"
 
+    val NOTIFICATION_WATER_AMOUNT_MENU_MESSAGE = "Сколько водицы ты выпил(а)?"
+
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramWaterAmountConstants.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramWaterAmountConstants.kt
@@ -1,0 +1,11 @@
+package ru.illine.drinking.ponies.util.telegram
+
+object TelegramWaterAmountConstants {
+
+    val ML_50 = "50 мл"
+    val ML_100 = "100 мл"
+    val ML_150 = "150 мл"
+    val ML_250 = "250 мл"
+    val ML_450 = "450 мл"
+
+}

--- a/src/test/kotlin/ru/illine/drinking/ponies/model/base/WaterAmountTypeTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/model/base/WaterAmountTypeTest.kt
@@ -1,0 +1,10 @@
+package ru.illine.drinking.ponies.model.base
+
+import org.junit.jupiter.api.DisplayName
+
+@DisplayName("WaterAmountType Unit Test")
+class WaterAmountTypeTest : EnumTypeOfTest<WaterAmountType>(
+    WaterAmountType.entries,
+    WaterAmountType::typeOf,
+    WaterAmountType::queryData
+)

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactoryTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactoryTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mockito.mock
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
-import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
+import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
 import ru.illine.drinking.ponies.service.button.impl.ReplyButtonFactoryImpl
 import ru.illine.drinking.ponies.service.button.strategy.snooze.SnoozeApplyReplyButtonStrategy
@@ -29,7 +29,7 @@ class ReplyButtonFactoryTest {
         val strategy = SnoozeApplyReplyButtonStrategy(
             mock(TelegramClient::class.java),
             mock(NotificationAccessService::class.java),
-            mock(WaterStatisticAccessService::class.java),
+            mock(WaterStatisticService::class.java),
             mock(MessageEditorService::class.java),
             Clock.systemUTC()
         )

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactoryTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactoryTest.kt
@@ -12,8 +12,10 @@ import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
+import ru.illine.drinking.ponies.model.base.WaterAmountType
 import ru.illine.drinking.ponies.service.button.impl.ReplyButtonFactoryImpl
 import ru.illine.drinking.ponies.service.button.strategy.snooze.SnoozeApplyReplyButtonStrategy
+import ru.illine.drinking.ponies.service.button.strategy.wateramount.WaterAmountApplyReplyButtonStrategy
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import java.time.Clock
@@ -26,14 +28,21 @@ class ReplyButtonFactoryTest {
 
     @BeforeEach
     fun setUp() {
-        val strategy = SnoozeApplyReplyButtonStrategy(
+        val snoozeStrategy = SnoozeApplyReplyButtonStrategy(
             mock(TelegramClient::class.java),
             mock(NotificationAccessService::class.java),
             mock(WaterStatisticService::class.java),
             mock(MessageEditorService::class.java),
             Clock.systemUTC()
         )
-        factory = ReplyButtonFactoryImpl(listOf(strategy))
+        val waterAmountStrategy = WaterAmountApplyReplyButtonStrategy(
+            mock(TelegramClient::class.java),
+            mock(NotificationAccessService::class.java),
+            mock(WaterStatisticService::class.java),
+            mock(MessageEditorService::class.java),
+            Clock.systemUTC()
+        )
+        factory = ReplyButtonFactoryImpl(listOf(snoozeStrategy, waterAmountStrategy))
     }
 
     @ParameterizedTest
@@ -41,6 +50,15 @@ class ReplyButtonFactoryTest {
     @DisplayName("getStrategy(): returns strategy for each SnoozeNotificationType queryData")
     fun `getStrategy returns strategy for snooze queryData`(snoozeType: SnoozeNotificationType) {
         val result = factory.getStrategy(snoozeType.queryData.toString())
+
+        assertNotNull(result)
+    }
+
+    @ParameterizedTest
+    @EnumSource(WaterAmountType::class)
+    @DisplayName("getStrategy(): returns strategy for each WaterAmountType queryData")
+    fun `getStrategy returns strategy for water amount queryData`(waterAmountType: WaterAmountType) {
+        val result = factory.getStrategy(waterAmountType.queryData.toString())
 
         assertNotNull(result)
     }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategyTest.kt
@@ -8,17 +8,14 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.*
-import org.mockito.kotlin.any
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
-import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
-import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
-
+import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
@@ -40,7 +37,7 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     private lateinit var sender: TelegramClient
     private lateinit var messageEditorService: MessageEditorService
     private lateinit var notificationAccessService: NotificationAccessService
-    private lateinit var waterStatisticAccessService: WaterStatisticAccessService
+    private lateinit var waterStatisticService: WaterStatisticService
     private lateinit var strategy: CancelAnswerNotificationReplyButtonStrategy
 
     @BeforeEach
@@ -48,12 +45,12 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
         sender = mock(TelegramClient::class.java)
         messageEditorService = mock(MessageEditorService::class.java)
         notificationAccessService = mock(NotificationAccessService::class.java)
-        waterStatisticAccessService = mock(WaterStatisticAccessService::class.java)
+        waterStatisticService = mock(WaterStatisticService::class.java)
         strategy = CancelAnswerNotificationReplyButtonStrategy(
             sender,
             messageEditorService,
             notificationAccessService,
-            waterStatisticAccessService,
+            waterStatisticService,
             fixedClock
         )
     }
@@ -83,14 +80,14 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     }
 
     @Test
-    @DisplayName("reply(): saves new water statistic")
-    fun `reply saves statistic`() {
+    @DisplayName("reply(): records water statistic with CANCEL event type")
+    fun `reply records statistic`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
         `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
-        verify(waterStatisticAccessService).save(any<WaterStatisticDto>())
+        verify(waterStatisticService).recordEvent(notificationDto.telegramUser, AnswerNotificationType.CANCEL)
     }
 
     @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategyTest.kt
@@ -8,6 +8,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.message.Message
@@ -60,6 +62,17 @@ class YesAnswerNotificationReplyButtonStrategyTest {
         assertEquals(TelegramMessageConstants.NOTIFICATION_WATER_AMOUNT_MENU_MESSAGE, sent.text)
         val buttons = (sent.replyMarkup as InlineKeyboardMarkup).keyboard
         assertEquals(WaterAmountType.entries.size, buttons.size)
+    }
+
+    @Test
+    @DisplayName("reply(): only interacts with sender and messageEditorService")
+    fun `reply has no side effects beyond menu display`() {
+        strategy.reply(buildCallbackQuery())
+
+        verify(messageEditorService).editReplyMarkup(any<String>(), any<Long>(), any<Int>(), any<Boolean>(), anyOrNull())
+        verify(sender).execute(any<SendMessage>())
+        verifyNoMoreInteractions(messageEditorService)
+        verifyNoMoreInteractions(sender)
     }
 
     @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategyTest.kt
@@ -8,62 +8,38 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.*
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
-import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
-import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
-import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
+import ru.illine.drinking.ponies.model.base.WaterAmountType
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
-import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
-import java.time.Clock
-import java.time.LocalDateTime
-import java.time.ZoneOffset
 
 @UnitTest
 @DisplayName("YesAnswerNotificationReplyButtonStrategy Unit Test")
 class YesAnswerNotificationReplyButtonStrategyTest {
 
-    private val userId = 1L
-    private val chatId = 2L
-    private val messageId = 3
-    private val fixedNow = LocalDateTime.of(2025, 1, 1, 14, 0, 0)
-    private val fixedClock = Clock.fixed(fixedNow.toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
+    private val chatId = 1L
+    private val messageId = 2
 
     private lateinit var sender: TelegramClient
     private lateinit var messageEditorService: MessageEditorService
-    private lateinit var notificationAccessService: NotificationAccessService
-    private lateinit var waterStatisticAccessService: WaterStatisticAccessService
     private lateinit var strategy: YesAnswerNotificationReplyButtonStrategy
 
     @BeforeEach
     fun setUp() {
         sender = mock(TelegramClient::class.java)
         messageEditorService = mock(MessageEditorService::class.java)
-        notificationAccessService = mock(NotificationAccessService::class.java)
-        waterStatisticAccessService = mock(WaterStatisticAccessService::class.java)
-        strategy = YesAnswerNotificationReplyButtonStrategy(
-            sender,
-            messageEditorService,
-            notificationAccessService,
-            waterStatisticAccessService,
-            fixedClock
-        )
+        strategy = YesAnswerNotificationReplyButtonStrategy(sender, messageEditorService)
     }
 
     @Test
     @DisplayName("reply(): edits original message with YES display name")
     fun `reply edits original message`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
-
         strategy.reply(buildCallbackQuery())
 
         val expectedText = TelegramMessageConstants.NOTIFICATION_QUESTION_EDITED_MESSAGE_PATTERN
@@ -72,40 +48,18 @@ class YesAnswerNotificationReplyButtonStrategyTest {
     }
 
     @Test
-    @DisplayName("reply(): updates last notification time to now()")
-    fun `reply updates notification time`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
-
-        strategy.reply(buildCallbackQuery())
-
-        verify(notificationAccessService).updateTimeOfLastNotification(eq(userId), any<LocalDateTime>())
-    }
-
-    @Test
-    @DisplayName("reply(): sends YES confirmation message")
-    fun `reply sends confirmation message`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
-
+    @DisplayName("reply(): sends water amount menu message with buttons")
+    fun `reply sends water amount menu message`() {
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+
         strategy.reply(buildCallbackQuery())
 
         verify(sender).execute(captor.capture())
         val sent = captor.value
         assertEquals(chatId.toString(), sent.chatId)
-        assertEquals(TelegramMessageConstants.NOTIFICATION_ANSWER_YES_MESSAGE, sent.text)
-    }
-
-    @Test
-    @DisplayName("reply(): saves new water statistic")
-    fun `reply saves statistic`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
-
-        strategy.reply(buildCallbackQuery())
-
-        verify(waterStatisticAccessService).save(any<WaterStatisticDto>())
+        assertEquals(TelegramMessageConstants.NOTIFICATION_WATER_AMOUNT_MENU_MESSAGE, sent.text)
+        val buttons = (sent.replyMarkup as InlineKeyboardMarkup).keyboard
+        assertEquals(WaterAmountType.entries.size, buttons.size)
     }
 
     @Test
@@ -131,15 +85,11 @@ class YesAnswerNotificationReplyButtonStrategyTest {
     }
 
     private fun buildCallbackQuery(): CallbackQuery {
-        val user = mock(User::class.java)
-        `when`(user.id).thenReturn(userId)
-
         val message = mock(Message::class.java)
         `when`(message.chatId).thenReturn(chatId)
         `when`(message.messageId).thenReturn(messageId)
 
         val callbackQuery = mock(CallbackQuery::class.java)
-        `when`(callbackQuery.from).thenReturn(user)
         `when`(callbackQuery.message).thenReturn(message)
         return callbackQuery
     }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategyTest.kt
@@ -8,16 +8,15 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.*
-import org.mockito.kotlin.any
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
-import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
-import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
+import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
@@ -39,7 +38,7 @@ class SnoozeApplyReplyButtonStrategyTest {
     private lateinit var sender: TelegramClient
     private lateinit var notificationAccessService: NotificationAccessService
     private lateinit var messageEditorService: MessageEditorService
-    private lateinit var waterStatisticAccessService: WaterStatisticAccessService
+    private lateinit var waterStatisticService: WaterStatisticService
     private lateinit var strategy: SnoozeApplyReplyButtonStrategy
 
     @BeforeEach
@@ -47,11 +46,11 @@ class SnoozeApplyReplyButtonStrategyTest {
         sender = mock(TelegramClient::class.java)
         notificationAccessService = mock(NotificationAccessService::class.java)
         messageEditorService = mock(MessageEditorService::class.java)
-        waterStatisticAccessService = mock(WaterStatisticAccessService::class.java)
+        waterStatisticService = mock(WaterStatisticService::class.java)
         strategy = SnoozeApplyReplyButtonStrategy(
             sender,
             notificationAccessService,
-            waterStatisticAccessService,
+            waterStatisticService,
             messageEditorService,
             fixedClock
         )
@@ -122,8 +121,8 @@ class SnoozeApplyReplyButtonStrategyTest {
 
     @ParameterizedTest
     @EnumSource(SnoozeNotificationType::class)
-    @DisplayName("reply(): saves new water statistic with any snooze type")
-    fun `reply saves statistic any type`(snoozeType: SnoozeNotificationType) {
+    @DisplayName("reply(): records water statistic with SNOOZE event type")
+    fun `reply records statistic any type`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
         `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
 
@@ -131,7 +130,7 @@ class SnoozeApplyReplyButtonStrategyTest {
 
         strategy.reply(callbackQuery)
 
-        verify(waterStatisticAccessService).save(any<WaterStatisticDto>())
+        verify(waterStatisticService).recordEvent(notificationDto.telegramUser, AnswerNotificationType.SNOOZE)
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.*
+import org.mockito.kotlin.any
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
@@ -125,6 +126,25 @@ class WaterAmountApplyReplyButtonStrategyTest {
             AnswerNotificationType.YES,
             WaterAmountType.ML_250.amountMl
         )
+    }
+
+    @Test
+    @DisplayName("reply(): executes operations in correct order")
+    fun `reply executes in correct order`() {
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
+        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+
+        strategy.reply(buildCallbackQuery(WaterAmountType.ML_250.queryData.toString()))
+
+        val inOrder = inOrder(messageEditorService, notificationAccessService, waterStatisticService, sender)
+        inOrder.verify(messageEditorService).deleteReplyMarkup(chatId, messageId)
+        inOrder.verify(notificationAccessService).updateTimeOfLastNotification(userId, fixedNow)
+        inOrder.verify(waterStatisticService).recordEvent(
+            notificationDto.telegramUser,
+            AnswerNotificationType.YES,
+            WaterAmountType.ML_250.amountMl
+        )
+        inOrder.verify(sender).execute(any<SendMessage>())
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
@@ -1,0 +1,167 @@
+package ru.illine.drinking.ponies.service.button.strategy.wateramount
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.*
+import org.mockito.kotlin.argumentCaptor
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery
+import org.telegram.telegrambots.meta.api.objects.User
+import org.telegram.telegrambots.meta.api.objects.message.Message
+import org.telegram.telegrambots.meta.generics.TelegramClient
+import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.base.WaterAmountType
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
+import ru.illine.drinking.ponies.service.telegram.MessageEditorService
+import ru.illine.drinking.ponies.test.generator.DtoGenerator
+import ru.illine.drinking.ponies.test.tag.UnitTest
+import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@UnitTest
+@DisplayName("WaterAmountApplyReplyButtonStrategy Unit Test")
+class WaterAmountApplyReplyButtonStrategyTest {
+
+    private val userId = 1L
+    private val chatId = 2L
+    private val messageId = 3
+    private val fixedNow = LocalDateTime.of(2025, 1, 1, 14, 0, 0)
+    private val fixedClock = Clock.fixed(fixedNow.toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
+
+    private lateinit var sender: TelegramClient
+    private lateinit var notificationAccessService: NotificationAccessService
+    private lateinit var waterStatisticAccessService: WaterStatisticAccessService
+    private lateinit var messageEditorService: MessageEditorService
+    private lateinit var strategy: WaterAmountApplyReplyButtonStrategy
+
+    @BeforeEach
+    fun setUp() {
+        sender = mock(TelegramClient::class.java)
+        notificationAccessService = mock(NotificationAccessService::class.java)
+        waterStatisticAccessService = mock(WaterStatisticAccessService::class.java)
+        messageEditorService = mock(MessageEditorService::class.java)
+        strategy = WaterAmountApplyReplyButtonStrategy(
+            sender,
+            notificationAccessService,
+            waterStatisticAccessService,
+            messageEditorService,
+            fixedClock
+        )
+    }
+
+    @ParameterizedTest
+    @EnumSource(WaterAmountType::class)
+    @DisplayName("reply(): deletes reply markup on original message")
+    fun `reply deletes reply markup`(waterAmountType: WaterAmountType) {
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
+        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+
+        strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
+
+        verify(messageEditorService).deleteReplyMarkup(chatId, messageId)
+    }
+
+    @ParameterizedTest
+    @EnumSource(WaterAmountType::class)
+    @DisplayName("reply(): updates last notification time to now()")
+    fun `reply updates notification time`(waterAmountType: WaterAmountType) {
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
+        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+
+        strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
+
+        verify(notificationAccessService).updateTimeOfLastNotification(userId, fixedNow)
+    }
+
+    @ParameterizedTest
+    @EnumSource(WaterAmountType::class)
+    @DisplayName("reply(): sends YES confirmation message")
+    fun `reply sends confirmation message`(waterAmountType: WaterAmountType) {
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
+        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+
+        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
+
+        verify(sender).execute(captor.capture())
+        val sent = captor.value
+        assertEquals(chatId.toString(), sent.chatId)
+        assertEquals(TelegramMessageConstants.NOTIFICATION_ANSWER_YES_MESSAGE, sent.text)
+    }
+
+    @ParameterizedTest
+    @EnumSource(WaterAmountType::class)
+    @DisplayName("reply(): saves water statistic with correct water amount")
+    fun `reply saves statistic with correct water amount`(waterAmountType: WaterAmountType) {
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
+        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+
+        val captor = argumentCaptor<WaterStatisticDto>()
+        strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
+
+        verify(waterStatisticAccessService).save(captor.capture())
+        val saved = captor.firstValue
+        assertEquals(waterAmountType.amountMl, saved.waterAmountMl)
+        assertEquals(AnswerNotificationType.YES, saved.eventType)
+    }
+
+    @Test
+    @DisplayName("reply(): falls back to ML_250 when queryData doesn't match any WaterAmountType")
+    fun `reply falls back to ML_250 for unknown queryData`() {
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
+        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+
+        val captor = argumentCaptor<WaterStatisticDto>()
+        strategy.reply(buildCallbackQuery("00000000-0000-0000-0000-000000000000"))
+
+        verify(waterStatisticAccessService).save(captor.capture())
+        assertEquals(WaterAmountType.ML_250.amountMl, captor.firstValue.waterAmountMl)
+    }
+
+    @ParameterizedTest
+    @EnumSource(WaterAmountType::class)
+    @DisplayName("isQueryData(): returns true for each WaterAmountType queryData")
+    fun `isQueryData returns true for water amount types`(waterAmountType: WaterAmountType) {
+        val result = strategy.isQueryData(waterAmountType.queryData.toString())
+        assertTrue(result)
+    }
+
+    @Test
+    @DisplayName("isQueryData(): returns false for random string")
+    fun `isQueryData returns false for random string`() {
+        val result = strategy.isQueryData("not-a-uuid")
+        assertFalse(result)
+    }
+
+    @Test
+    @DisplayName("isQueryData(): returns false for unknown UUID")
+    fun `isQueryData returns false for unknown uuid`() {
+        val result = strategy.isQueryData("00000000-0000-0000-0000-000000000000")
+        assertFalse(result)
+    }
+
+    private fun buildCallbackQuery(queryData: String): CallbackQuery {
+        val user = mock(User::class.java)
+        `when`(user.id).thenReturn(userId)
+
+        val message = mock(Message::class.java)
+        `when`(message.chatId).thenReturn(chatId)
+        `when`(message.messageId).thenReturn(messageId)
+
+        val callbackQuery = mock(CallbackQuery::class.java)
+        `when`(callbackQuery.from).thenReturn(user)
+        `when`(callbackQuery.message).thenReturn(message)
+        `when`(callbackQuery.data).thenReturn(queryData)
+        return callbackQuery
+    }
+
+}

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
@@ -8,17 +8,15 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.*
-import org.mockito.kotlin.argumentCaptor
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
-import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.WaterAmountType
-import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
+import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
@@ -39,7 +37,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
 
     private lateinit var sender: TelegramClient
     private lateinit var notificationAccessService: NotificationAccessService
-    private lateinit var waterStatisticAccessService: WaterStatisticAccessService
+    private lateinit var waterStatisticService: WaterStatisticService
     private lateinit var messageEditorService: MessageEditorService
     private lateinit var strategy: WaterAmountApplyReplyButtonStrategy
 
@@ -47,12 +45,12 @@ class WaterAmountApplyReplyButtonStrategyTest {
     fun setUp() {
         sender = mock(TelegramClient::class.java)
         notificationAccessService = mock(NotificationAccessService::class.java)
-        waterStatisticAccessService = mock(WaterStatisticAccessService::class.java)
+        waterStatisticService = mock(WaterStatisticService::class.java)
         messageEditorService = mock(MessageEditorService::class.java)
         strategy = WaterAmountApplyReplyButtonStrategy(
             sender,
             notificationAccessService,
-            waterStatisticAccessService,
+            waterStatisticService,
             messageEditorService,
             fixedClock
         )
@@ -100,18 +98,18 @@ class WaterAmountApplyReplyButtonStrategyTest {
 
     @ParameterizedTest
     @EnumSource(WaterAmountType::class)
-    @DisplayName("reply(): saves water statistic with correct water amount")
-    fun `reply saves statistic with correct water amount`(waterAmountType: WaterAmountType) {
+    @DisplayName("reply(): records water statistic with correct water amount")
+    fun `reply records statistic with correct water amount`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
         `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
 
-        val captor = argumentCaptor<WaterStatisticDto>()
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
-        verify(waterStatisticAccessService).save(captor.capture())
-        val saved = captor.firstValue
-        assertEquals(waterAmountType.amountMl, saved.waterAmountMl)
-        assertEquals(AnswerNotificationType.YES, saved.eventType)
+        verify(waterStatisticService).recordEvent(
+            notificationDto.telegramUser,
+            AnswerNotificationType.YES,
+            waterAmountType.amountMl
+        )
     }
 
     @Test
@@ -120,11 +118,13 @@ class WaterAmountApplyReplyButtonStrategyTest {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
         `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
 
-        val captor = argumentCaptor<WaterStatisticDto>()
         strategy.reply(buildCallbackQuery("00000000-0000-0000-0000-000000000000"))
 
-        verify(waterStatisticAccessService).save(captor.capture())
-        assertEquals(WaterAmountType.ML_250.amountMl, captor.firstValue.waterAmountMl)
+        verify(waterStatisticService).recordEvent(
+            notificationDto.telegramUser,
+            AnswerNotificationType.YES,
+            WaterAmountType.ML_250.amountMl
+        )
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
@@ -277,7 +277,7 @@ class NotificationServiceTest {
 
         service.suspendNotifications(listOf(dto))
 
-        verify(waterStatisticService).recordEvents(anyCollection(), any<AnswerNotificationType>())
+        verify(waterStatisticService).recordEvents(listOf(dto.telegramUser), AnswerNotificationType.CANCEL)
     }
 
     @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
@@ -17,10 +17,10 @@ import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.config.property.TelegramBotProperties
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
-import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.base.SettingsType
-import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
+import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.button.ButtonDataService
 import ru.illine.drinking.ponies.service.notification.impl.NotificationServiceImpl
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
@@ -54,7 +54,7 @@ class NotificationServiceTest {
     private lateinit var messageEditorService: MessageEditorService
     private lateinit var notificationAccessService: NotificationAccessService
     private lateinit var settingsButtonDataService: ButtonDataService<SettingsType>
-    private lateinit var waterStatisticAccessService: WaterStatisticAccessService
+    private lateinit var waterStatisticService: WaterStatisticService
     private lateinit var clock: Clock
     private lateinit var service: NotificationServiceImpl
 
@@ -65,7 +65,7 @@ class NotificationServiceTest {
         notificationAccessService = mock(NotificationAccessService::class.java)
         @Suppress("UNCHECKED_CAST")
         settingsButtonDataService = mock(ButtonDataService::class.java) as ButtonDataService<SettingsType>
-        waterStatisticAccessService = mock(WaterStatisticAccessService::class.java)
+        waterStatisticService = mock(WaterStatisticService::class.java)
         clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)
         service = NotificationServiceImpl(
             sender,
@@ -73,7 +73,7 @@ class NotificationServiceTest {
             notificationAccessService,
             settingsButtonDataService,
             botProperties,
-            waterStatisticAccessService,
+            waterStatisticService,
             clock
         )
     }
@@ -271,13 +271,13 @@ class NotificationServiceTest {
     }
 
     @Test
-    @DisplayName("suspendNotifications(): saves water statistic for each sent notification")
-    fun `suspendNotifications saves water statistics`() {
+    @DisplayName("suspendNotifications(): records water statistic events for each sent notification")
+    fun `suspendNotifications records water statistics`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
 
         service.suspendNotifications(listOf(dto))
 
-        verify(waterStatisticAccessService).saveAll(any<Collection<WaterStatisticDto>>())
+        verify(waterStatisticService).recordEvents(anyCollection(), any<AnswerNotificationType>())
     }
 
     @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
@@ -1,0 +1,84 @@
+package ru.illine.drinking.ponies.service.statistic
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.mockito.kotlin.argumentCaptor
+import org.junit.jupiter.api.Assertions.assertEquals
+import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
+import ru.illine.drinking.ponies.service.statistic.impl.WaterStatisticServiceImpl
+import ru.illine.drinking.ponies.test.generator.DtoGenerator
+import ru.illine.drinking.ponies.test.tag.UnitTest
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@UnitTest
+@DisplayName("WaterStatisticService Unit Test")
+class WaterStatisticServiceTest {
+
+    private val fixedNow = LocalDateTime.of(2025, 1, 1, 14, 0, 0)
+    private val fixedClock = Clock.fixed(fixedNow.toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
+
+    private lateinit var waterStatisticAccessService: WaterStatisticAccessService
+    private lateinit var service: WaterStatisticServiceImpl
+
+    @BeforeEach
+    fun setUp() {
+        waterStatisticAccessService = mock(WaterStatisticAccessService::class.java)
+        service = WaterStatisticServiceImpl(waterStatisticAccessService, fixedClock)
+    }
+
+    @Test
+    @DisplayName("recordEvent(): saves statistic with correct eventType and waterAmountMl")
+    fun `recordEvent saves statistic with correct fields`() {
+        val telegramUser = DtoGenerator.generateNotificationDto().telegramUser
+        val captor = argumentCaptor<WaterStatisticDto>()
+
+        service.recordEvent(telegramUser, AnswerNotificationType.YES, 250)
+
+        verify(waterStatisticAccessService).save(captor.capture())
+        val saved = captor.firstValue
+        assertEquals(telegramUser, saved.telegramUser)
+        assertEquals(AnswerNotificationType.YES, saved.eventType)
+        assertEquals(250, saved.waterAmountMl)
+        assertEquals(fixedNow, saved.eventTime)
+    }
+
+    @Test
+    @DisplayName("recordEvent(): defaults waterAmountMl to 0")
+    fun `recordEvent defaults waterAmountMl to zero`() {
+        val telegramUser = DtoGenerator.generateNotificationDto().telegramUser
+        val captor = argumentCaptor<WaterStatisticDto>()
+
+        service.recordEvent(telegramUser, AnswerNotificationType.SNOOZE)
+
+        verify(waterStatisticAccessService).save(captor.capture())
+        assertEquals(0, captor.firstValue.waterAmountMl)
+    }
+
+    @Test
+    @DisplayName("recordEvents(): saves all statistics with correct eventType")
+    fun `recordEvents saves all statistics`() {
+        val users = listOf(
+            DtoGenerator.generateNotificationDto(externalUserId = 1L).telegramUser,
+            DtoGenerator.generateNotificationDto(externalUserId = 2L).telegramUser
+        )
+        val captor = argumentCaptor<Collection<WaterStatisticDto>>()
+
+        service.recordEvents(users, AnswerNotificationType.CANCEL)
+
+        verify(waterStatisticAccessService).saveAll(captor.capture())
+        val saved = captor.firstValue.toList()
+        assertEquals(2, saved.size)
+        saved.forEach {
+            assertEquals(AnswerNotificationType.CANCEL, it.eventType)
+            assertEquals(0, it.waterAmountMl)
+            assertEquals(fixedNow, it.eventTime)
+        }
+    }
+
+}

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
@@ -74,6 +74,8 @@ class WaterStatisticServiceTest {
         verify(waterStatisticAccessService).saveAll(captor.capture())
         val saved = captor.firstValue.toList()
         assertEquals(2, saved.size)
+        assertEquals(users[0], saved[0].telegramUser)
+        assertEquals(users[1], saved[1].telegramUser)
         saved.forEach {
             assertEquals(AnswerNotificationType.CANCEL, it.eventType)
             assertEquals(0, it.waterAmountMl)

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
@@ -61,6 +61,19 @@ class WaterStatisticServiceTest {
     }
 
     @Test
+    @DisplayName("recordEvent(): explicit waterAmountMl=0 produces same result as default")
+    fun `recordEvent explicit zero waterAmountMl`() {
+        val telegramUser = DtoGenerator.generateNotificationDto().telegramUser
+        val captor = argumentCaptor<WaterStatisticDto>()
+
+        service.recordEvent(telegramUser, AnswerNotificationType.CANCEL, 0)
+
+        verify(waterStatisticAccessService).save(captor.capture())
+        assertEquals(0, captor.firstValue.waterAmountMl)
+        assertEquals(AnswerNotificationType.CANCEL, captor.firstValue.eventType)
+    }
+
+    @Test
     @DisplayName("recordEvents(): saves all statistics with correct eventType")
     fun `recordEvents saves all statistics`() {
         val users = listOf(

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/TelegramBotKeyboardHelperTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/TelegramBotKeyboardHelperTest.kt
@@ -13,6 +13,7 @@ import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.base.SettingsType
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
+import ru.illine.drinking.ponies.model.base.WaterAmountType
 import ru.illine.drinking.ponies.service.button.ButtonDataService
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import ru.illine.drinking.ponies.util.telegram.TelegramBotKeyboardHelper
@@ -121,6 +122,21 @@ class TelegramBotKeyboardHelperTest {
 
         val actual =
             TelegramBotKeyboardHelper.snoozeTimeButtons() as InlineKeyboardMarkup
+
+        assertNotNull(actual)
+        assertDoesNotThrow { actual.validate() }
+        assertEquals(expectedRowsSize, actual.keyboard.size)
+        assertEquals(expectedButtonsSize, actual.keyboard[0].size)
+    }
+
+    @Test
+    @DisplayName("waterAmountButtons(): returns valid keyboard")
+    fun `successful waterAmountButtons`() {
+        val expectedButtonsSize = 1
+        val expectedRowsSize = WaterAmountType.entries.size
+
+        val actual =
+            TelegramBotKeyboardHelper.waterAmountButtons() as InlineKeyboardMarkup
 
         assertNotNull(actual)
         assertDoesNotThrow { actual.validate() }


### PR DESCRIPTION
## Summary
- Add water amount sub-menu (50/100/150/250/450 ml) when user presses "Yes" on drinking notification
- Create `WaterAmountType` enum with constants in `TelegramWaterAmountConstants`
- Refactor `TelegramBotKeyboardHelper` - extract generic `buildInlineKeyboard` method, reducing duplication across 5 keyboard builders
- Refactor `YesAnswerNotificationReplyButtonStrategy` from direct save to showing water amount sub-menu
- Add `WaterAmountApplyReplyButtonStrategy` to handle amount selection and save with actual `waterAmountMl`
- Introduce `WaterStatisticService` abstraction layer with `recordEvent`/`recordEvents` methods
- Replace direct `WaterStatisticAccessService` calls in 4 places with `WaterStatisticService`

## Test plan
- [x] WaterAmountType enum - typeOf for known/unknown queryData
- [x] TelegramBotKeyboardHelper - waterAmountButtons returns correct keyboard
- [x] YesAnswerNotificationReplyButtonStrategy - shows sub-menu, no side effects on statistic/notification services
- [x] WaterAmountApplyReplyButtonStrategy - saves correct waterAmountMl per type, fallback to ML_250, operation order (InOrder)
- [x] WaterStatisticService - recordEvent with explicit amount, default 0, recordEvents with user mapping
- [x] ReplyButtonFactory - resolves WaterAmountType queryData to correct strategy
- [x] Snooze/Cancel strategies - updated to use WaterStatisticService, no regression
- [x] NotificationService - suspendNotifications verifies exact CANCEL type and user list
- [x] Full test suite: 323 tests passing