### PR TITLE
DPTB-79: extract NotificationSenderService from NotificationServiceImpl

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/scheduler/NotificationScheduler.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/scheduler/NotificationScheduler.kt
@@ -5,13 +5,13 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
-import ru.illine.drinking.ponies.service.notification.NotificationService
+import ru.illine.drinking.ponies.service.notification.NotificationSenderService
 import ru.illine.drinking.ponies.service.notification.NotificationTimeService
 
 @Component
 class NotificationScheduler(
     private val notificationAccessService: NotificationAccessService,
-    private val notificationService: NotificationService,
+    private val notificationSenderService: NotificationSenderService,
     private val notificationTimeService: NotificationTimeService
 ) {
 
@@ -45,7 +45,7 @@ class NotificationScheduler(
         }
 
         logger.info("Sending notifications to [{}] users", notifications.size)
-        notificationService.sendNotifications(notifications)
+        notificationSenderService.sendNotifications(notifications)
     }
 
     private fun cancelAll(notifications: List<NotificationSettingDto>) {
@@ -54,6 +54,6 @@ class NotificationScheduler(
         }
 
         logger.info("Suspending notifications for [{}] users (max attempts reached)", notifications.size)
-        notificationService.suspendNotifications(notifications)
+        notificationSenderService.suspendNotifications(notifications)
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderService.kt
@@ -1,0 +1,11 @@
+package ru.illine.drinking.ponies.service.notification
+
+import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
+
+interface NotificationSenderService {
+
+    fun sendNotifications(notifications: Collection<NotificationSettingDto>)
+
+    fun suspendNotifications(notifications: Collection<NotificationSettingDto>)
+
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationService.kt
@@ -1,7 +1,6 @@
 package ru.illine.drinking.ponies.service.notification
 
 import org.telegram.telegrambots.abilitybots.api.objects.MessageContext
-import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 
 interface NotificationService {
 
@@ -15,7 +14,4 @@ interface NotificationService {
 
     fun settings(messageContext: MessageContext)
 
-    fun sendNotifications(notifications: Collection<NotificationSettingDto>)
-
-    fun suspendNotifications(notifications: Collection<NotificationSettingDto>)
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSenderServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSenderServiceImpl.kt
@@ -1,0 +1,121 @@
+package ru.illine.drinking.ponies.service.notification.impl
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage
+import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException
+import org.telegram.telegrambots.meta.generics.TelegramClient
+import ru.illine.drinking.ponies.config.property.TelegramBotProperties
+import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
+import ru.illine.drinking.ponies.service.notification.NotificationSenderService
+import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
+import ru.illine.drinking.ponies.service.telegram.MessageEditorService
+import ru.illine.drinking.ponies.util.TimeHelper
+import ru.illine.drinking.ponies.util.telegram.TelegramBotKeyboardHelper
+import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
+import java.time.Clock
+import java.time.LocalDateTime
+
+@Service
+class NotificationSenderServiceImpl(
+    private val sender: TelegramClient,
+    private val messageEditorService: MessageEditorService,
+    private val notificationAccessService: NotificationAccessService,
+    private val telegramBotProperties: TelegramBotProperties,
+    private val waterStatisticService: WaterStatisticService,
+    private val clock: Clock,
+) : NotificationSenderService {
+
+    private val logger = LoggerFactory.getLogger("SERVICE")
+
+    override fun sendNotifications(notifications: Collection<NotificationSettingDto>) {
+        if (notifications.isEmpty()) {
+            logger.debug("There are no notifications to send")
+            return
+        }
+
+        deletePreviousNotificationMessages(notifications)
+
+        val sent = notifications.filter {
+            sendOrDisableOnBlock(it) {
+                ++it.notificationAttempts
+                it.timeOfLastNotification = TimeHelper.nextNotificationTimeByNow(
+                    clock, it.notificationInterval.minutes, telegramBotProperties.notification.retryIntervalMinutes
+                )
+                it.telegramChat.previousNotificationMessageId =
+                    SendMessage(
+                        it.telegramChat.externalChatId.toString(),
+                        TelegramMessageConstants.NOTIFICATION_QUESTION_MESSAGE
+                    ).apply {
+                        replyMarkup = TelegramBotKeyboardHelper.notifyButtons()
+                    }.let { sender.execute(it) }.messageId
+            }
+        }
+
+        notificationAccessService.updateNotificationSettings(sent)
+    }
+
+    override fun suspendNotifications(notifications: Collection<NotificationSettingDto>) {
+        if (notifications.isEmpty()) {
+            logger.debug("There are no notifications to send")
+            return
+        }
+
+        deletePreviousNotificationMessages(notifications)
+
+        val sent = notifications.filter {
+            sendOrDisableOnBlock(it) {
+                SendMessage(
+                    it.telegramChat.externalChatId.toString(),
+                    TelegramMessageConstants.NOTIFICATION_SUSPEND_MESSAGE.format(it.notificationInterval.displayName)
+                ).apply {
+                    disableNotification = true
+                }.apply { sender.execute(this) }
+
+                it.notificationAttempts = 0
+                it.timeOfLastNotification = LocalDateTime.now(clock)
+                it.telegramChat.previousNotificationMessageId = null
+            }
+        }
+
+        notificationAccessService.updateNotificationSettings(sent)
+        waterStatisticService.recordEvents(
+            sent.map { it.telegramUser },
+            AnswerNotificationType.CANCEL
+        )
+    }
+
+    private fun sendOrDisableOnBlock(notification: NotificationSettingDto, send: () -> Unit): Boolean {
+        return try {
+            send()
+            true
+        } catch (e: TelegramApiRequestException) {
+            if (e.errorCode == 403) {
+                logger.warn(
+                    "User (externalUserId: [{}]) blocked the bot, disabling notifications",
+                    notification.telegramUser.externalUserId
+                )
+                notificationAccessService.disableNotifications(notification.telegramUser.externalUserId)
+                false
+            } else {
+                throw e
+            }
+        }
+    }
+
+    private fun deletePreviousNotificationMessages(settings: Collection<NotificationSettingDto>) {
+        logger.info("Deleting all old notifications messages...")
+
+        val messageInfo = settings
+            .filter { it.telegramChat.previousNotificationMessageId != null }
+            .map { Pair(it.telegramChat.externalChatId, it.telegramChat.previousNotificationMessageId!!) }
+            .toList()
+
+        logger.info("Found [${messageInfo.size}] the old notification messages")
+        logger.debug("The old messages: \n{}", messageInfo)
+
+        messageEditorService.deleteMessages(messageInfo)
+    }
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
@@ -4,35 +4,25 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.telegram.telegrambots.abilitybots.api.objects.MessageContext
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
-import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.config.property.TelegramBotProperties
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
-import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.SettingsType
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
 import ru.illine.drinking.ponies.service.button.ButtonDataService
 import ru.illine.drinking.ponies.service.notification.NotificationService
-import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.FunctionHelper.check
-import ru.illine.drinking.ponies.util.TimeHelper
 import ru.illine.drinking.ponies.util.telegram.TelegramBotKeyboardHelper
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
-import java.time.Clock
-import java.time.LocalDateTime
 
 @Service
 class NotificationServiceImpl(
     private val sender: TelegramClient,
     private val messageEditorService: MessageEditorService,
     private val notificationAccessService: NotificationAccessService,
-    private val settingsButtonDataService: ButtonDataService<SettingsType>,
-    private val telegramBotProperties: TelegramBotProperties,
-    private val waterStatisticService: WaterStatisticService,
-    private val clock: Clock,
+    private val settingsButtonDataService: ButtonDataService<SettingsType>
 ) : NotificationService {
 
     private val logger = LoggerFactory.getLogger("SERVICE")
@@ -124,92 +114,6 @@ class NotificationServiceImpl(
         sendIfNotificationEnabled(
             messageContext.user().id, messageContext.chatId(), sendMessageFunction
         )
-    }
-
-    override fun sendNotifications(notifications: Collection<NotificationSettingDto>) {
-        if (notifications.isEmpty()) {
-            logger.debug("There are no notifications to send")
-            return
-        }
-
-        deletePreviousNotificationMessages(notifications)
-
-        val sent = notifications.filter {
-            sendOrDisableOnBlock(it) {
-                ++it.notificationAttempts
-                it.timeOfLastNotification = TimeHelper.nextNotificationTimeByNow(
-                    clock, it.notificationInterval.minutes, telegramBotProperties.notification.retryIntervalMinutes
-                )
-                it.telegramChat.previousNotificationMessageId =
-                    SendMessage(
-                        it.telegramChat.externalChatId.toString(),
-                        TelegramMessageConstants.NOTIFICATION_QUESTION_MESSAGE
-                    ).apply {
-                        replyMarkup = TelegramBotKeyboardHelper.notifyButtons()
-                    }.let { sender.execute(it) }.messageId
-            }
-        }
-
-        notificationAccessService.updateNotificationSettings(sent)
-    }
-
-    override fun suspendNotifications(notifications: Collection<NotificationSettingDto>) {
-        if (notifications.isEmpty()) {
-            logger.debug("There are no notifications to send")
-            return
-        }
-
-        deletePreviousNotificationMessages(notifications)
-
-        val sent = notifications.filter {
-            sendOrDisableOnBlock(it) {
-                SendMessage(
-                    it.telegramChat.externalChatId.toString(),
-                    TelegramMessageConstants.NOTIFICATION_SUSPEND_MESSAGE.format(it.notificationInterval.displayName)
-                ).apply {
-                    disableNotification = true
-                }.apply { sender.execute(this) }
-
-                it.notificationAttempts = 0
-                it.timeOfLastNotification = LocalDateTime.now(clock)
-                it.telegramChat.previousNotificationMessageId = null
-            }
-        }
-
-        notificationAccessService.updateNotificationSettings(sent)
-        waterStatisticService.recordEvents(
-            sent.map { it.telegramUser },
-            AnswerNotificationType.CANCEL
-        )
-    }
-
-    private fun sendOrDisableOnBlock(notification: NotificationSettingDto, send: () -> Unit): Boolean {
-        return try {
-            send()
-            true
-        } catch (e: TelegramApiRequestException) {
-            if (e.errorCode == 403) {
-                logger.warn("User (externalUserId: [{}]) blocked the bot, disabling notifications", notification.telegramUser.externalUserId)
-                notificationAccessService.disableNotifications(notification.telegramUser.externalUserId)
-                false
-            } else {
-                throw e
-            }
-        }
-    }
-
-    private fun deletePreviousNotificationMessages(settings: Collection<NotificationSettingDto>) {
-        logger.info("Deleting all old notifications messages...")
-
-        val messageInfo = settings
-            .filter { it.telegramChat.previousNotificationMessageId != null }
-            .map { Pair(it.telegramChat.externalChatId, it.telegramChat.previousNotificationMessageId!!) }
-            .toList()
-
-        logger.info("Found [${messageInfo.size}] the old notification messages")
-        logger.debug("The old messages: \n{}", messageInfo)
-
-        messageEditorService.deleteMessages(messageInfo)
     }
 
     private fun sendIfNotificationEnabled(userId: Long, chatId: Long, sendMessage: () -> Unit) {

--- a/src/test/kotlin/ru/illine/drinking/ponies/scheduler/NotificationSchedulerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/scheduler/NotificationSchedulerTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
-import ru.illine.drinking.ponies.service.notification.NotificationService
+import ru.illine.drinking.ponies.service.notification.NotificationSenderService
 import ru.illine.drinking.ponies.service.notification.NotificationTimeService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
@@ -15,16 +15,16 @@ import ru.illine.drinking.ponies.test.tag.UnitTest
 class NotificationSchedulerTest {
 
     private lateinit var notificationAccessService: NotificationAccessService
-    private lateinit var notificationService: NotificationService
+    private lateinit var notificationSenderService: NotificationSenderService
     private lateinit var notificationTimeService: NotificationTimeService
     private lateinit var scheduler: NotificationScheduler
 
     @BeforeEach
     fun setUp() {
         notificationAccessService = mock(NotificationAccessService::class.java)
-        notificationService = mock(NotificationService::class.java)
+        notificationSenderService = mock(NotificationSenderService::class.java)
         notificationTimeService = mock(NotificationTimeService::class.java)
-        scheduler = NotificationScheduler(notificationAccessService, notificationService, notificationTimeService)
+        scheduler = NotificationScheduler(notificationAccessService, notificationSenderService, notificationTimeService)
     }
 
     @Test
@@ -34,8 +34,8 @@ class NotificationSchedulerTest {
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationService, never()).sendNotifications(anyCollection())
-        verify(notificationService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(anyCollection())
+        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
     }
 
     @Test
@@ -46,8 +46,8 @@ class NotificationSchedulerTest {
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationService, never()).sendNotifications(anyCollection())
-        verify(notificationService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(anyCollection())
+        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
     }
 
     @Test
@@ -59,8 +59,8 @@ class NotificationSchedulerTest {
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationService, never()).sendNotifications(anyCollection())
-        verify(notificationService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(anyCollection())
+        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
     }
 
     @Test
@@ -73,8 +73,8 @@ class NotificationSchedulerTest {
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationService, never()).sendNotifications(anyCollection())
-        verify(notificationService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(anyCollection())
+        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
     }
 
     @Test
@@ -87,8 +87,8 @@ class NotificationSchedulerTest {
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationService).sendNotifications(listOf(dto))
-        verify(notificationService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService).sendNotifications(listOf(dto))
+        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
     }
 
     @Test
@@ -101,8 +101,8 @@ class NotificationSchedulerTest {
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationService).suspendNotifications(listOf(dto))
-        verify(notificationService, never()).sendNotifications(anyCollection())
+        verify(notificationSenderService).suspendNotifications(listOf(dto))
+        verify(notificationSenderService, never()).sendNotifications(anyCollection())
     }
 
     @Test
@@ -118,8 +118,8 @@ class NotificationSchedulerTest {
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationService).sendNotifications(listOf(active))
-        verify(notificationService).suspendNotifications(listOf(exhausted))
+        verify(notificationSenderService).sendNotifications(listOf(active))
+        verify(notificationSenderService).suspendNotifications(listOf(exhausted))
     }
 
     @Test
@@ -129,7 +129,7 @@ class NotificationSchedulerTest {
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationService, never()).sendNotifications(anyCollection())
-        verify(notificationService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(anyCollection())
+        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactoryTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactoryTest.kt
@@ -10,12 +10,12 @@ import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mockito.mock
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
-import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
 import ru.illine.drinking.ponies.model.base.WaterAmountType
 import ru.illine.drinking.ponies.service.button.impl.ReplyButtonFactoryImpl
 import ru.illine.drinking.ponies.service.button.strategy.snooze.SnoozeApplyReplyButtonStrategy
 import ru.illine.drinking.ponies.service.button.strategy.wateramount.WaterAmountApplyReplyButtonStrategy
+import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import java.time.Clock
@@ -24,7 +24,7 @@ import java.time.Clock
 @DisplayName("ReplyButtonFactory Unit Test")
 class ReplyButtonFactoryTest {
 
-    private lateinit var factory: ReplyButtonFactoryImpl
+    private lateinit var factory: ReplyButtonFactory
 
     @BeforeEach
     fun setUp() {

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/SettingsButtonDataServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/SettingsButtonDataServiceTest.kt
@@ -17,7 +17,7 @@ class SettingsButtonDataServiceTest {
     private val quietModeTimeUrl = "http://example.com/quiet"
     private val timezoneUrl = "http://example.com/timezone"
 
-    private lateinit var service: SettingsButtonDataServiceImpl
+    private lateinit var service: ButtonDataService<SettingsType>
 
     @BeforeEach
     fun setUp() {

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
@@ -1,0 +1,216 @@
+package ru.illine.drinking.ponies.service.notification
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage
+import org.telegram.telegrambots.meta.api.objects.message.Message
+import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException
+import org.telegram.telegrambots.meta.generics.TelegramClient
+import ru.illine.drinking.ponies.config.property.TelegramBotProperties
+import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.base.IntervalNotificationType
+import ru.illine.drinking.ponies.model.base.SettingsType
+import ru.illine.drinking.ponies.service.button.ButtonDataService
+import ru.illine.drinking.ponies.service.notification.impl.NotificationSenderServiceImpl
+import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
+import ru.illine.drinking.ponies.service.telegram.MessageEditorService
+import ru.illine.drinking.ponies.test.generator.DtoGenerator
+import ru.illine.drinking.ponies.test.tag.UnitTest
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@UnitTest
+@DisplayName("NotificationSenderService Unit Test")
+class NotificationSenderServiceTest {
+
+    private val userId = 1L
+    private val chatId = 2L
+
+    private val retryIntervalMinutes = 1L
+    private val botProperties = TelegramBotProperties(
+        version = "1.0.0",
+        token = "token",
+        username = "username",
+        creatorId = 1L,
+        autoUpdateCommands = true,
+        http = TelegramBotProperties.Http(connectionTimeToLiveInSec = 30, maxConnectionTotal = 10),
+        notification = TelegramBotProperties.Notification(retryIntervalMinutes = retryIntervalMinutes)
+    )
+
+    private lateinit var sender: TelegramClient
+    private lateinit var messageEditorService: MessageEditorService
+    private lateinit var notificationAccessService: NotificationAccessService
+    private lateinit var waterStatisticService: WaterStatisticService
+    private lateinit var clock: Clock
+    private lateinit var service: NotificationSenderService
+
+    @BeforeEach
+    fun setUp() {
+        sender = mock(TelegramClient::class.java)
+        messageEditorService = mock(MessageEditorService::class.java)
+        notificationAccessService = mock(NotificationAccessService::class.java)
+        @Suppress("UNCHECKED_CAST")
+        waterStatisticService = mock(WaterStatisticService::class.java)
+        clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)
+        service = NotificationSenderServiceImpl(
+            sender,
+            messageEditorService,
+            notificationAccessService,
+            botProperties,
+            waterStatisticService,
+            clock
+        )
+    }
+
+    @Test
+    @DisplayName("sendNotifications(): empty collection - no interactions with sender or access service")
+    fun `sendNotifications with empty list does nothing`() {
+        service.sendNotifications(emptyList())
+
+        verifyNoInteractions(sender)
+        verifyNoInteractions(notificationAccessService)
+        verifyNoInteractions(messageEditorService)
+    }
+
+    @Test
+    @DisplayName("sendNotifications(): sends notification messages, increments attempts, updates settings")
+    fun `sendNotifications sends and updates`() {
+        val dto = DtoGenerator.generateNotificationDto(
+            externalUserId = userId,
+            externalChatId = chatId,
+            notificationAttempts = 0,
+            previousNotificationMessageId = 10
+        )
+        val returnedMessage = mock(Message::class.java)
+        `when`(returnedMessage.messageId).thenReturn(2)
+        doReturn(returnedMessage).`when`(sender).execute(any<SendMessage>())
+
+        service.sendNotifications(listOf(dto))
+
+        val expectedTimeOfLastNotification = LocalDateTime.now(clock)
+            .minusMinutes(IntervalNotificationType.HOUR.minutes)
+            .plusMinutes(retryIntervalMinutes)
+
+        verify(messageEditorService).deleteMessages(anyCollection())
+        verify(sender).execute(any<SendMessage>())
+        verify(notificationAccessService).updateNotificationSettings(anyCollection())
+        assertEquals(1, dto.notificationAttempts)
+        assertEquals(2, dto.telegramChat.previousNotificationMessageId)
+        assertEquals(expectedTimeOfLastNotification, dto.timeOfLastNotification)
+    }
+
+    @Test
+    @DisplayName("sendNotifications(): 403 error - disables user and excludes from settings update")
+    fun `sendNotifications on 403 disables notifications`() {
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val exception = mock(TelegramApiRequestException::class.java)
+        `when`(exception.errorCode).thenReturn(403)
+        doThrow(exception).`when`(sender).execute(any<SendMessage>())
+
+        service.sendNotifications(listOf(dto))
+
+        verify(notificationAccessService).disableNotifications(userId)
+        verify(notificationAccessService).updateNotificationSettings(anyCollection())
+    }
+
+    @Test
+    @DisplayName("suspendNotifications(): empty collection - no interactions with sender or access service")
+    fun `suspendNotifications with empty list does nothing`() {
+        service.suspendNotifications(emptyList())
+
+        verifyNoInteractions(sender)
+        verifyNoInteractions(notificationAccessService)
+        verifyNoInteractions(messageEditorService)
+    }
+
+    @Test
+    @DisplayName("suspendNotifications(): sends suspend message, resets attempts and time, updates settings")
+    fun `suspendNotifications sends and updates`() {
+        val dto = DtoGenerator.generateNotificationDto(
+            externalUserId = userId,
+            externalChatId = chatId,
+            notificationAttempts = 3,
+            previousNotificationMessageId = 10
+        )
+
+        service.suspendNotifications(listOf(dto))
+
+        verify(messageEditorService).deleteMessages(anyCollection())
+        verify(sender).execute(any<SendMessage>())
+        verify(notificationAccessService).updateNotificationSettings(anyCollection())
+        assertEquals(0, dto.notificationAttempts)
+        assertNull(dto.telegramChat.previousNotificationMessageId)
+    }
+
+    @Test
+    @DisplayName("suspendNotifications(): records water statistic events for each sent notification")
+    fun `suspendNotifications records water statistics`() {
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+
+        service.suspendNotifications(listOf(dto))
+
+        verify(waterStatisticService).recordEvents(listOf(dto.telegramUser), AnswerNotificationType.CANCEL)
+    }
+
+    @Test
+    @DisplayName("suspendNotifications(): 403 error - disables user and excludes from settings update")
+    fun `suspendNotifications on 403 disables notifications`() {
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val exception = mock(TelegramApiRequestException::class.java)
+        `when`(exception.errorCode).thenReturn(403)
+        doThrow(exception).`when`(sender).execute(any<SendMessage>())
+
+        service.suspendNotifications(listOf(dto))
+
+        verify(notificationAccessService).disableNotifications(userId)
+        verify(notificationAccessService).updateNotificationSettings(anyCollection())
+    }
+
+    @Test
+    @DisplayName("sendNotifications(): non-403 error - rethrows exception")
+    fun `sendNotifications rethrows non-403 exception`() {
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val exception = mock(TelegramApiRequestException::class.java)
+        `when`(exception.errorCode).thenReturn(500)
+        doThrow(exception).`when`(sender).execute(any<SendMessage>())
+
+        assertThrows(TelegramApiRequestException::class.java) {
+            service.sendNotifications(listOf(dto))
+        }
+    }
+
+    @Test
+    @DisplayName("sendNotifications(): null errorCode - rethrows exception")
+    fun `sendNotifications rethrows null errorCode exception`() {
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val exception = mock(TelegramApiRequestException::class.java)
+        doReturn(null).`when`(exception).errorCode
+        doThrow(exception).`when`(sender).execute(any<SendMessage>())
+
+        assertThrows(TelegramApiRequestException::class.java) {
+            service.sendNotifications(listOf(dto))
+        }
+    }
+
+    @Test
+    @DisplayName("suspendNotifications(): non-403 error - rethrows exception")
+    fun `suspendNotifications rethrows non-403 exception`() {
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val exception = mock(TelegramApiRequestException::class.java)
+        `when`(exception.errorCode).thenReturn(500)
+        doThrow(exception).`when`(sender).execute(any<SendMessage>())
+
+        assertThrows(TelegramApiRequestException::class.java) {
+            service.suspendNotifications(listOf(dto))
+        }
+        verify(notificationAccessService, never()).disableNotifications(any())
+    }
+}

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
@@ -13,23 +13,18 @@ import org.telegram.telegrambots.abilitybots.api.objects.MessageContext
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
-import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.config.property.TelegramBotProperties
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
-import ru.illine.drinking.ponies.model.base.AnswerNotificationType
-import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.base.SettingsType
-import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.button.ButtonDataService
 import ru.illine.drinking.ponies.service.notification.impl.NotificationServiceImpl
+import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
 import java.time.Clock
 import java.time.Instant
-import java.time.LocalDateTime
 import java.time.ZoneOffset
 
 @UnitTest
@@ -39,24 +34,11 @@ class NotificationServiceTest {
     private val userId = 1L
     private val chatId = 2L
 
-    private val retryIntervalMinutes = 1L
-    private val botProperties = TelegramBotProperties(
-        version = "1.0.0",
-        token = "token",
-        username = "username",
-        creatorId = 1L,
-        autoUpdateCommands = true,
-        http = TelegramBotProperties.Http(connectionTimeToLiveInSec = 30, maxConnectionTotal = 10),
-        notification = TelegramBotProperties.Notification(retryIntervalMinutes = retryIntervalMinutes)
-    )
-
     private lateinit var sender: TelegramClient
     private lateinit var messageEditorService: MessageEditorService
     private lateinit var notificationAccessService: NotificationAccessService
     private lateinit var settingsButtonDataService: ButtonDataService<SettingsType>
-    private lateinit var waterStatisticService: WaterStatisticService
-    private lateinit var clock: Clock
-    private lateinit var service: NotificationServiceImpl
+    private lateinit var service: NotificationService
 
     @BeforeEach
     fun setUp() {
@@ -65,16 +47,11 @@ class NotificationServiceTest {
         notificationAccessService = mock(NotificationAccessService::class.java)
         @Suppress("UNCHECKED_CAST")
         settingsButtonDataService = mock(ButtonDataService::class.java) as ButtonDataService<SettingsType>
-        waterStatisticService = mock(WaterStatisticService::class.java)
-        clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)
         service = NotificationServiceImpl(
             sender,
             messageEditorService,
             notificationAccessService,
-            settingsButtonDataService,
-            botProperties,
-            waterStatisticService,
-            clock
+            settingsButtonDataService
         )
     }
 
@@ -188,150 +165,6 @@ class NotificationServiceTest {
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
         verify(sender).execute(captor.capture())
         assertTrue(captor.value.text.contains(TelegramMessageConstants.NOTIFICATION_NOT_ACTIVE_MESSAGE))
-    }
-
-    @Test
-    @DisplayName("sendNotifications(): empty collection - no interactions with sender or access service")
-    fun `sendNotifications with empty list does nothing`() {
-        service.sendNotifications(emptyList())
-
-        verifyNoInteractions(sender)
-        verifyNoInteractions(notificationAccessService)
-        verifyNoInteractions(messageEditorService)
-    }
-
-    @Test
-    @DisplayName("sendNotifications(): sends notification messages, increments attempts, updates settings")
-    fun `sendNotifications sends and updates`() {
-        val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
-            externalChatId = chatId,
-            notificationAttempts = 0,
-            previousNotificationMessageId = 10
-        )
-        val returnedMessage = mock(Message::class.java)
-        `when`(returnedMessage.messageId).thenReturn(2)
-        doReturn(returnedMessage).`when`(sender).execute(any<SendMessage>())
-
-        service.sendNotifications(listOf(dto))
-
-        val expectedTimeOfLastNotification = LocalDateTime.now(clock)
-            .minusMinutes(IntervalNotificationType.HOUR.minutes)
-            .plusMinutes(retryIntervalMinutes)
-
-        verify(messageEditorService).deleteMessages(anyCollection())
-        verify(sender).execute(any<SendMessage>())
-        verify(notificationAccessService).updateNotificationSettings(anyCollection())
-        assertEquals(1, dto.notificationAttempts)
-        assertEquals(2, dto.telegramChat.previousNotificationMessageId)
-        assertEquals(expectedTimeOfLastNotification, dto.timeOfLastNotification)
-    }
-
-    @Test
-    @DisplayName("sendNotifications(): 403 error - disables user and excludes from settings update")
-    fun `sendNotifications on 403 disables notifications`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
-        val exception = mock(TelegramApiRequestException::class.java)
-        `when`(exception.errorCode).thenReturn(403)
-        doThrow(exception).`when`(sender).execute(any<SendMessage>())
-
-        service.sendNotifications(listOf(dto))
-
-        verify(notificationAccessService).disableNotifications(userId)
-        verify(notificationAccessService).updateNotificationSettings(anyCollection())
-    }
-
-    @Test
-    @DisplayName("suspendNotifications(): empty collection - no interactions with sender or access service")
-    fun `suspendNotifications with empty list does nothing`() {
-        service.suspendNotifications(emptyList())
-
-        verifyNoInteractions(sender)
-        verifyNoInteractions(notificationAccessService)
-        verifyNoInteractions(messageEditorService)
-    }
-
-    @Test
-    @DisplayName("suspendNotifications(): sends suspend message, resets attempts and time, updates settings")
-    fun `suspendNotifications sends and updates`() {
-        val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
-            externalChatId = chatId,
-            notificationAttempts = 3,
-            previousNotificationMessageId = 10
-        )
-
-        service.suspendNotifications(listOf(dto))
-
-        verify(messageEditorService).deleteMessages(anyCollection())
-        verify(sender).execute(any<SendMessage>())
-        verify(notificationAccessService).updateNotificationSettings(anyCollection())
-        assertEquals(0, dto.notificationAttempts)
-        assertNull(dto.telegramChat.previousNotificationMessageId)
-    }
-
-    @Test
-    @DisplayName("suspendNotifications(): records water statistic events for each sent notification")
-    fun `suspendNotifications records water statistics`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
-
-        service.suspendNotifications(listOf(dto))
-
-        verify(waterStatisticService).recordEvents(listOf(dto.telegramUser), AnswerNotificationType.CANCEL)
-    }
-
-    @Test
-    @DisplayName("suspendNotifications(): 403 error - disables user and excludes from settings update")
-    fun `suspendNotifications on 403 disables notifications`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
-        val exception = mock(TelegramApiRequestException::class.java)
-        `when`(exception.errorCode).thenReturn(403)
-        doThrow(exception).`when`(sender).execute(any<SendMessage>())
-
-        service.suspendNotifications(listOf(dto))
-
-        verify(notificationAccessService).disableNotifications(userId)
-        verify(notificationAccessService).updateNotificationSettings(anyCollection())
-    }
-
-    @Test
-    @DisplayName("sendNotifications(): non-403 error - rethrows exception")
-    fun `sendNotifications rethrows non-403 exception`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
-        val exception = mock(TelegramApiRequestException::class.java)
-        `when`(exception.errorCode).thenReturn(500)
-        doThrow(exception).`when`(sender).execute(any<SendMessage>())
-
-        assertThrows(TelegramApiRequestException::class.java) {
-            service.sendNotifications(listOf(dto))
-        }
-    }
-
-    @Test
-    @DisplayName("sendNotifications(): null errorCode - rethrows exception")
-    fun `sendNotifications rethrows null errorCode exception`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
-        val exception = mock(TelegramApiRequestException::class.java)
-        doReturn(null).`when`(exception).errorCode
-        doThrow(exception).`when`(sender).execute(any<SendMessage>())
-
-        assertThrows(TelegramApiRequestException::class.java) {
-            service.sendNotifications(listOf(dto))
-        }
-    }
-
-    @Test
-    @DisplayName("suspendNotifications(): non-403 error - rethrows exception")
-    fun `suspendNotifications rethrows non-403 exception`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
-        val exception = mock(TelegramApiRequestException::class.java)
-        `when`(exception.errorCode).thenReturn(500)
-        doThrow(exception).`when`(sender).execute(any<SendMessage>())
-
-        assertThrows(TelegramApiRequestException::class.java) {
-            service.suspendNotifications(listOf(dto))
-        }
-        verify(notificationAccessService, never()).disableNotifications(any())
     }
 
     private fun buildMessageContext(): MessageContext {

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsServiceTest.kt
@@ -27,7 +27,7 @@ class NotificationSettingsServiceTest {
     private lateinit var notificationAccessService: NotificationAccessService
     private lateinit var messageEditorService: MessageEditorService
     private lateinit var sender: TelegramClient
-    private lateinit var service: NotificationSettingsServiceImpl
+    private lateinit var service: NotificationSettingsService
 
     @BeforeEach
     fun setUp() {

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
@@ -1,11 +1,12 @@
 package ru.illine.drinking.ponies.service.statistic
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 import org.mockito.kotlin.argumentCaptor
-import org.junit.jupiter.api.Assertions.assertEquals
 import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
@@ -24,7 +25,7 @@ class WaterStatisticServiceTest {
     private val fixedClock = Clock.fixed(fixedNow.toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
 
     private lateinit var waterStatisticAccessService: WaterStatisticAccessService
-    private lateinit var service: WaterStatisticServiceImpl
+    private lateinit var service: WaterStatisticService
 
     @BeforeEach
     fun setUp() {

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/telegram/MessageEditorServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/telegram/MessageEditorServiceTest.kt
@@ -21,7 +21,7 @@ class MessageEditorServiceTest {
     private val messageId = 2
 
     private lateinit var sender: TelegramClient
-    private lateinit var service: MessageEditorServiceImpl
+    private lateinit var service: MessageEditorService
 
     @BeforeEach
     fun setUp() {

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/telegram/TelegramValidatorServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/telegram/TelegramValidatorServiceTest.kt
@@ -21,7 +21,7 @@ class TelegramValidatorServiceTest {
     private val userJson = """{"id":1,"first_name":"First Name"}"""
     private val queryId = "query"
 
-    private lateinit var service: TelegramValidatorServiceImpl
+    private lateinit var service: TelegramValidatorService
 
     @BeforeEach
     fun setUp() {

--- a/src/test/kotlin/ru/illine/drinking/ponies/test/tag/SpringIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/test/tag/SpringIntegrationTest.kt
@@ -21,6 +21,8 @@ import ru.illine.drinking.ponies.test.config.TestTimeConfig
         TestTimeConfig::class,
     ]
 )
+// These library beans must be mocked via @MockitoBean (not @Bean @Primary) 
+// to prevent real instantiation and network connections
 @MockitoBean(types = [TelegramBotsLongPollingApplication::class, BaseAbilityBot::class])
 @ActiveProfiles("integration-test")
 annotation class SpringIntegrationTest


### PR DESCRIPTION
## Summary
- Extract `sendNotifications()` and `suspendNotifications()` (+ private helpers) from `NotificationServiceImpl` into new `NotificationSenderServiceImpl`
- `NotificationServiceImpl` reduced from 7 to 4 dependencies (user commands only)
- `NotificationScheduler` now depends on `NotificationSenderService` instead of `NotificationService`
- Use interface types for service fields across all unit tests
- Add comment explaining `@MockitoBean` usage in `SpringIntegrationTest`

## Test plan
- [x] All existing unit tests pass
- [x] All existing integration tests pass
- [x] `NotificationSenderServiceTest` covers send/suspend/block scenarios
- [x] `NotificationServiceTest` covers user command scenarios
- [x] `NotificationSchedulerTest` updated for new dependency