### PR TITLE
DPTB-82: extract NotificationAccessService from strategies into service layer

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/scheduler/NotificationScheduler.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/scheduler/NotificationScheduler.kt
@@ -3,14 +3,14 @@ package ru.illine.drinking.ponies.scheduler
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.service.notification.NotificationSenderService
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.notification.NotificationTimeService
 
 @Component
 class NotificationScheduler(
-    private val notificationAccessService: NotificationAccessService,
+    private val notificationSettingsService: NotificationSettingsService,
     private val notificationSenderService: NotificationSenderService,
     private val notificationTimeService: NotificationTimeService
 ) {
@@ -24,7 +24,7 @@ class NotificationScheduler(
         logger.info("Starting drinking notification scheduler")
 
         try {
-            val (exhaustedNotifications, activeNotifications) = notificationAccessService.findAllNotificationSettings()
+            val (exhaustedNotifications, activeNotifications) = notificationSettingsService.getAllNotificationSettings()
                 .filter { it.enabled }
                 .filter(notificationTimeService::isOutsideQuietTime)
                 .filter { notificationTimeService.isNotificationDue(it) }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/interval/IntervalApplyReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/interval/IntervalApplyReplyButtonStrategy.kt
@@ -5,16 +5,16 @@ import org.springframework.stereotype.Service
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
 
 @Service
 class IntervalApplyReplyButtonStrategy(
     private val sender: TelegramClient,
-    private val notificationAccessService: NotificationAccessService,
+    private val notificationSettingsService: NotificationSettingsService,
     private val messageEditorService: MessageEditorService
 ) : ReplyButtonStrategy {
 
@@ -38,7 +38,7 @@ class IntervalApplyReplyButtonStrategy(
 
         logger.info("A notification settings for user [{}] with interval setting [{}] will be saved", userId, notificationInterval)
         val updatedNotificationSettings =
-            notificationAccessService.updateNotificationSettings(userId, chatId, notificationInterval)
+            notificationSettingsService.changeInterval(userId, chatId, notificationInterval)
         logger.info("The notification settings (id: [{}]) has updated", updatedNotificationSettings.id)
 
         SendMessage(

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/interval/IntervalMenuReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/interval/IntervalMenuReplyButtonStrategy.kt
@@ -4,10 +4,10 @@ import org.springframework.stereotype.Service
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.model.base.SettingsType
 import ru.illine.drinking.ponies.service.button.ButtonDataService
 import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.telegram.TelegramBotKeyboardHelper
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
@@ -16,7 +16,7 @@ import java.util.*
 @Service
 class IntervalMenuReplyButtonStrategy(
     private val sender: TelegramClient,
-    private val notificationAccessService: NotificationAccessService,
+    private val notificationSettingsService: NotificationSettingsService,
     private val messageEditorService: MessageEditorService,
     private val settingsButtonDataService: ButtonDataService<SettingsType>
 ) : ReplyButtonStrategy {
@@ -28,7 +28,7 @@ class IntervalMenuReplyButtonStrategy(
         messageEditorService.deleteReplyMarkup(chatId, messageId)
 
         val currentNotificationSetting =
-            notificationAccessService.findNotificationSettingByTelegramUserId(callbackQuery.from.id).notificationInterval
+            notificationSettingsService.getNotificationSettings(callbackQuery.from.id).notificationInterval
 
         SendMessage(
             chatId.toString(),

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategy.kt
@@ -4,10 +4,10 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.service.button.strategy.AbstractAnswerNotificationReplyButtonStrategy
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
@@ -18,7 +18,7 @@ import java.time.LocalDateTime
 class CancelAnswerNotificationReplyButtonStrategy(
     sender: TelegramClient,
     messageEditorService: MessageEditorService,
-    private val notificationAccessService: NotificationAccessService,
+    private val notificationSettingsService: NotificationSettingsService,
     private val waterStatisticService: WaterStatisticService,
     private val clock: Clock
 ) : AbstractAnswerNotificationReplyButtonStrategy<NotificationSettingDto>(sender, messageEditorService) {
@@ -26,7 +26,7 @@ class CancelAnswerNotificationReplyButtonStrategy(
     private val logger = LoggerFactory.getLogger("STRATEGY")
 
     override fun updateLastNotificationTime(callbackQuery: CallbackQuery): () -> NotificationSettingDto = {
-        notificationAccessService.updateTimeOfLastNotification(callbackQuery.from.id, LocalDateTime.now(clock))
+        notificationSettingsService.resetNotificationTimer(callbackQuery.from.id, LocalDateTime.now(clock))
             .also { setting ->
                 runCatching {
                     waterStatisticService.recordEvent(setting.telegramUser, getAnswerType())

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/pause/PauseNotificationReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/pause/PauseNotificationReplyButtonStrategy.kt
@@ -5,10 +5,10 @@ import org.springframework.stereotype.Service
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.model.base.PauseNotificationType
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.TimeHelper
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
@@ -19,7 +19,7 @@ import java.time.ZonedDateTime
 @Service
 class PauseNotificationReplyButtonStrategy(
     private val sender: TelegramClient,
-    private val notificationAccessService: NotificationAccessService,
+    private val notificationSettingsService: NotificationSettingsService,
     private val messageEditorService: MessageEditorService
 ) : ReplyButtonStrategy {
 
@@ -48,7 +48,7 @@ class PauseNotificationReplyButtonStrategy(
         chatId: Long
     ) {
         val savedNotificationSetting =
-            notificationAccessService.findNotificationSettingByTelegramUserId(userId)
+            notificationSettingsService.getNotificationSettings(userId)
         val nextNotificationTime = calculateNextNotificationTime(savedNotificationSetting, pauseNotification)
         logger.info(
             "A notification will be postponed to [{}] for a user [{}]",
@@ -57,7 +57,7 @@ class PauseNotificationReplyButtonStrategy(
         )
         logger.info("The new notification will be at [{}]", nextNotificationTime)
 
-        notificationAccessService.updateTimeOfLastNotification(userId, nextNotificationTime)
+        notificationSettingsService.resetNotificationTimer(userId, nextNotificationTime)
 
         SendMessage(
             chatId.toString(),
@@ -71,14 +71,14 @@ class PauseNotificationReplyButtonStrategy(
     ) {
         logger.info("A notification will be reset to user's notification interval for a user [{}]", userId)
         val savedNotificationSetting =
-            notificationAccessService.findNotificationSettingByTelegramUserId(userId)
+            notificationSettingsService.getNotificationSettings(userId)
         val notificationInterval = savedNotificationSetting.notificationInterval
         logger.info("User's notification interval: [{}]", notificationInterval)
         val nextNotificationTime =
             calculateNextNotificationTime(savedNotificationSetting, notificationInterval.minutes)
         logger.info("The new notification will be at [{}]", nextNotificationTime)
 
-        notificationAccessService.updateTimeOfLastNotification(userId, nextNotificationTime)
+        notificationSettingsService.resetNotificationTimer(userId, nextNotificationTime)
 
         val timeNextNotification = TimeHelper.timeToString(nextNotificationTime)
         val message =

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategy.kt
@@ -5,10 +5,10 @@ import org.springframework.stereotype.Service
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
 import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.TimeHelper
@@ -18,7 +18,7 @@ import java.time.Clock
 @Service
 class SnoozeApplyReplyButtonStrategy(
     private val sender: TelegramClient,
-    private val notificationAccessService: NotificationAccessService,
+    private val notificationSettingsService: NotificationSettingsService,
     private val waterStatisticService: WaterStatisticService,
     private val messageEditorService: MessageEditorService,
     private val clock: Clock
@@ -45,7 +45,7 @@ class SnoozeApplyReplyButtonStrategy(
             snoozeType.minutes
         )
 
-        val notificationSetting = notificationAccessService.findNotificationSettingByTelegramUserId(userId)
+        val notificationSetting = notificationSettingsService.getNotificationSettings(userId)
         val nextNotificationTime =
             TimeHelper.nextNotificationTimeByNow(
                 clock,
@@ -53,7 +53,7 @@ class SnoozeApplyReplyButtonStrategy(
                 snoozeType.minutes
             )
 
-        notificationAccessService.updateTimeOfLastNotification(userId, nextNotificationTime)
+        notificationSettingsService.resetNotificationTimer(userId, nextNotificationTime)
             .also { setting ->
                 runCatching {
                     waterStatisticService.recordEvent(setting.telegramUser, AnswerNotificationType.SNOOZE)

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategy.kt
@@ -5,10 +5,10 @@ import org.springframework.stereotype.Service
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.WaterAmountType
 import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
@@ -18,7 +18,7 @@ import java.time.LocalDateTime
 @Service
 class WaterAmountApplyReplyButtonStrategy(
     private val sender: TelegramClient,
-    private val notificationAccessService: NotificationAccessService,
+    private val notificationSettingsService: NotificationSettingsService,
     private val waterStatisticService: WaterStatisticService,
     private val messageEditorService: MessageEditorService,
     private val clock: Clock
@@ -49,7 +49,7 @@ class WaterAmountApplyReplyButtonStrategy(
             waterAmountType.amountMl
         )
 
-        notificationAccessService.updateTimeOfLastNotification(userId, LocalDateTime.now(clock))
+        notificationSettingsService.resetNotificationTimer(userId, LocalDateTime.now(clock))
             .also { setting ->
                 runCatching {
                     waterStatisticService.recordEvent(

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsService.kt
@@ -1,8 +1,19 @@
 package ru.illine.drinking.ponies.service.notification
 
+import ru.illine.drinking.ponies.model.base.IntervalNotificationType
+import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 interface NotificationSettingsService {
+
+    fun getNotificationSettings(telegramUserId: Long): NotificationSettingDto
+
+    fun getAllNotificationSettings(): Collection<NotificationSettingDto>
+
+    fun resetNotificationTimer(telegramUserId: Long, time: LocalDateTime): NotificationSettingDto
+
+    fun changeInterval(telegramUserId: Long, telegramChatId: Long, notificationInterval: IntervalNotificationType): NotificationSettingDto
 
     fun changeQuietMode(userId: Long, messageId: Int, start: LocalTime, end: LocalTime)
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSettingsServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSettingsServiceImpl.kt
@@ -5,9 +5,12 @@ import org.springframework.stereotype.Service
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.model.base.IntervalNotificationType
+import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 @Service
@@ -18,6 +21,30 @@ class NotificationSettingsServiceImpl(
 ) : NotificationSettingsService {
 
     private val logger = LoggerFactory.getLogger("SERVICE")
+
+    override fun getNotificationSettings(telegramUserId: Long): NotificationSettingDto {
+        logger.info("Getting notification settings for telegram user [$telegramUserId]")
+        return notificationAccessService.findNotificationSettingByTelegramUserId(telegramUserId)
+    }
+
+    override fun getAllNotificationSettings(): Collection<NotificationSettingDto> {
+        logger.info("Getting all notification settings")
+        return notificationAccessService.findAllNotificationSettings()
+    }
+
+    override fun resetNotificationTimer(telegramUserId: Long, time: LocalDateTime): NotificationSettingDto {
+        logger.info("Resetting notification timer for telegram user [$telegramUserId] to [$time]")
+        return notificationAccessService.updateTimeOfLastNotification(telegramUserId, time)
+    }
+
+    override fun changeInterval(
+        telegramUserId: Long,
+        telegramChatId: Long,
+        notificationInterval: IntervalNotificationType
+    ): NotificationSettingDto {
+        logger.info("Changing notification interval for telegram user [$telegramUserId] to [$notificationInterval]")
+        return notificationAccessService.updateNotificationSettings(telegramUserId, telegramChatId, notificationInterval)
+    }
 
     override fun changeQuietMode(userId: Long, messageId: Int, start: LocalTime, end: LocalTime) {
         logger.info("Change time of quiet mode for telegram user [$userId], start: [$start], end: [$end]")

--- a/src/test/kotlin/ru/illine/drinking/ponies/scheduler/NotificationSchedulerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/scheduler/NotificationSchedulerTest.kt
@@ -4,8 +4,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.service.notification.NotificationSenderService
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.notification.NotificationTimeService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
@@ -14,23 +14,23 @@ import ru.illine.drinking.ponies.test.tag.UnitTest
 @DisplayName("NotificationScheduler Unit Test")
 class NotificationSchedulerTest {
 
-    private lateinit var notificationAccessService: NotificationAccessService
+    private lateinit var notificationSettingsService: NotificationSettingsService
     private lateinit var notificationSenderService: NotificationSenderService
     private lateinit var notificationTimeService: NotificationTimeService
     private lateinit var scheduler: NotificationScheduler
 
     @BeforeEach
     fun setUp() {
-        notificationAccessService = mock(NotificationAccessService::class.java)
+        notificationSettingsService = mock(NotificationSettingsService::class.java)
         notificationSenderService = mock(NotificationSenderService::class.java)
         notificationTimeService = mock(NotificationTimeService::class.java)
-        scheduler = NotificationScheduler(notificationAccessService, notificationSenderService, notificationTimeService)
+        scheduler = NotificationScheduler(notificationSettingsService, notificationSenderService, notificationTimeService)
     }
 
     @Test
     @DisplayName("sendDrinkingReminders(): no interactions when no notifications exist")
     fun `sendDrinkingReminders does nothing when no notifications`() {
-        `when`(notificationAccessService.findAllNotificationSettings()).thenReturn(emptySet())
+        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(emptySet())
 
         scheduler.sendDrinkingReminders()
 
@@ -42,7 +42,7 @@ class NotificationSchedulerTest {
     @DisplayName("sendDrinkingReminders(): skips disabled notifications")
     fun `sendDrinkingReminders filters out disabled notifications`() {
         val disabled = DtoGenerator.generateNotificationDto().copy(enabled = false)
-        `when`(notificationAccessService.findAllNotificationSettings()).thenReturn(setOf(disabled))
+        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(disabled))
 
         scheduler.sendDrinkingReminders()
 
@@ -54,7 +54,7 @@ class NotificationSchedulerTest {
     @DisplayName("sendDrinkingReminders(): skips notifications inside quiet time")
     fun `sendDrinkingReminders filters out quiet time notifications`() {
         val dto = DtoGenerator.generateNotificationDto()
-        `when`(notificationAccessService.findAllNotificationSettings()).thenReturn(setOf(dto))
+        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
         doReturn(false).`when`(notificationTimeService).isOutsideQuietTime(dto)
 
         scheduler.sendDrinkingReminders()
@@ -67,7 +67,7 @@ class NotificationSchedulerTest {
     @DisplayName("sendDrinkingReminders(): skips notifications not yet due")
     fun `sendDrinkingReminders filters out not due notifications`() {
         val dto = DtoGenerator.generateNotificationDto()
-        `when`(notificationAccessService.findAllNotificationSettings()).thenReturn(setOf(dto))
+        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
         doReturn(true).`when`(notificationTimeService).isOutsideQuietTime(dto)
         doReturn(false).`when`(notificationTimeService).isNotificationDue(dto)
 
@@ -81,7 +81,7 @@ class NotificationSchedulerTest {
     @DisplayName("sendDrinkingReminders(): sends active notification (attempts < 3)")
     fun `sendDrinkingReminders sends active notification`() {
         val dto = DtoGenerator.generateNotificationDto(notificationAttempts = 0)
-        `when`(notificationAccessService.findAllNotificationSettings()).thenReturn(setOf(dto))
+        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
         doReturn(true).`when`(notificationTimeService).isOutsideQuietTime(dto)
         doReturn(true).`when`(notificationTimeService).isNotificationDue(dto)
 
@@ -95,7 +95,7 @@ class NotificationSchedulerTest {
     @DisplayName("sendDrinkingReminders(): suspends exhausted notification (attempts == 3)")
     fun `sendDrinkingReminders suspends exhausted notification`() {
         val dto = DtoGenerator.generateNotificationDto(notificationAttempts = 3)
-        `when`(notificationAccessService.findAllNotificationSettings()).thenReturn(setOf(dto))
+        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
         doReturn(true).`when`(notificationTimeService).isOutsideQuietTime(dto)
         doReturn(true).`when`(notificationTimeService).isNotificationDue(dto)
 
@@ -110,7 +110,7 @@ class NotificationSchedulerTest {
     fun `sendDrinkingReminders partitions exhausted and active`() {
         val active = DtoGenerator.generateNotificationDto(notificationAttempts = 1)
         val exhausted = DtoGenerator.generateNotificationDto(notificationAttempts = 3)
-        `when`(notificationAccessService.findAllNotificationSettings()).thenReturn(setOf(active, exhausted))
+        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(active, exhausted))
         doReturn(true).`when`(notificationTimeService).isOutsideQuietTime(active)
         doReturn(true).`when`(notificationTimeService).isOutsideQuietTime(exhausted)
         doReturn(true).`when`(notificationTimeService).isNotificationDue(active)
@@ -125,7 +125,7 @@ class NotificationSchedulerTest {
     @Test
     @DisplayName("sendDrinkingReminders(): throws an error")
     fun `scheduler failed`() {
-        `when`(notificationAccessService.findAllNotificationSettings()).thenThrow(RuntimeException("Scheduler Failed"))
+        `when`(notificationSettingsService.getAllNotificationSettings()).thenThrow(RuntimeException("Scheduler Failed"))
 
         scheduler.sendDrinkingReminders()
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactoryTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactoryTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mockito.mock
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
 import ru.illine.drinking.ponies.model.base.WaterAmountType
 import ru.illine.drinking.ponies.service.button.impl.ReplyButtonFactoryImpl
@@ -30,14 +30,14 @@ class ReplyButtonFactoryTest {
     fun setUp() {
         val snoozeStrategy = SnoozeApplyReplyButtonStrategy(
             mock(TelegramClient::class.java),
-            mock(NotificationAccessService::class.java),
+            mock(NotificationSettingsService::class.java),
             mock(WaterStatisticService::class.java),
             mock(MessageEditorService::class.java),
             Clock.systemUTC()
         )
         val waterAmountStrategy = WaterAmountApplyReplyButtonStrategy(
             mock(TelegramClient::class.java),
-            mock(NotificationAccessService::class.java),
+            mock(NotificationSettingsService::class.java),
             mock(WaterStatisticService::class.java),
             mock(MessageEditorService::class.java),
             Clock.systemUTC()

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/interval/IntervalApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/interval/IntervalApplyReplyButtonStrategyTest.kt
@@ -13,7 +13,7 @@ import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
@@ -29,16 +29,16 @@ class IntervalApplyReplyButtonStrategyTest {
     private val messageId = 3
 
     private lateinit var sender: TelegramClient
-    private lateinit var notificationAccessService: NotificationAccessService
+    private lateinit var notificationSettingsService: NotificationSettingsService
     private lateinit var messageEditorService: MessageEditorService
     private lateinit var strategy: IntervalApplyReplyButtonStrategy
 
     @BeforeEach
     fun setUp() {
         sender = mock(TelegramClient::class.java)
-        notificationAccessService = mock(NotificationAccessService::class.java)
+        notificationSettingsService = mock(NotificationSettingsService::class.java)
         messageEditorService = mock(MessageEditorService::class.java)
-        strategy = IntervalApplyReplyButtonStrategy(sender, notificationAccessService, messageEditorService)
+        strategy = IntervalApplyReplyButtonStrategy(sender, notificationSettingsService, messageEditorService)
     }
 
     @ParameterizedTest
@@ -47,7 +47,7 @@ class IntervalApplyReplyButtonStrategyTest {
     fun `reply deletes reply markup`(intervalType: IntervalNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
         `when`(
-            notificationAccessService.updateNotificationSettings(userId, chatId, intervalType)
+            notificationSettingsService.changeInterval(userId, chatId, intervalType)
         ).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(intervalType.queryData.toString())
@@ -62,13 +62,13 @@ class IntervalApplyReplyButtonStrategyTest {
     fun `reply updates notification settings`(intervalType: IntervalNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
         `when`(
-            notificationAccessService.updateNotificationSettings(userId, chatId, intervalType)
+            notificationSettingsService.changeInterval(userId, chatId, intervalType)
         ).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(intervalType.queryData.toString())
         strategy.reply(callbackQuery)
 
-        verify(notificationAccessService).updateNotificationSettings(userId, chatId, intervalType)
+        verify(notificationSettingsService).changeInterval(userId, chatId, intervalType)
     }
 
     @ParameterizedTest
@@ -77,7 +77,7 @@ class IntervalApplyReplyButtonStrategyTest {
     fun `reply sends confirmation message`(intervalType: IntervalNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
         `when`(
-            notificationAccessService.updateNotificationSettings(userId, chatId, intervalType)
+            notificationSettingsService.changeInterval(userId, chatId, intervalType)
         ).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(intervalType.queryData.toString())
@@ -99,13 +99,13 @@ class IntervalApplyReplyButtonStrategyTest {
     fun `reply falls back to TWO_HOURS for unknown queryData`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
         `when`(
-            notificationAccessService.updateNotificationSettings(userId, chatId, IntervalNotificationType.TWO_HOURS)
+            notificationSettingsService.changeInterval(userId, chatId, IntervalNotificationType.TWO_HOURS)
         ).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery("00000000-0000-0000-0000-000000000000")
         strategy.reply(callbackQuery)
 
-        verify(notificationAccessService).updateNotificationSettings(userId, chatId, IntervalNotificationType.TWO_HOURS)
+        verify(notificationSettingsService).changeInterval(userId, chatId, IntervalNotificationType.TWO_HOURS)
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/interval/IntervalMenuReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/interval/IntervalMenuReplyButtonStrategyTest.kt
@@ -13,7 +13,7 @@ import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.base.SettingsType
 import ru.illine.drinking.ponies.service.button.ButtonDataService
@@ -31,7 +31,7 @@ class IntervalMenuReplyButtonStrategyTest {
     private val messageId = 3
 
     private lateinit var sender: TelegramClient
-    private lateinit var notificationAccessService: NotificationAccessService
+    private lateinit var notificationSettingsService: NotificationSettingsService
     private lateinit var messageEditorService: MessageEditorService
     private lateinit var settingsButtonDataService: ButtonDataService<SettingsType>
     private lateinit var strategy: IntervalMenuReplyButtonStrategy
@@ -39,12 +39,12 @@ class IntervalMenuReplyButtonStrategyTest {
     @BeforeEach
     fun setUp() {
         sender = mock(TelegramClient::class.java)
-        notificationAccessService = mock(NotificationAccessService::class.java)
+        notificationSettingsService = mock(NotificationSettingsService::class.java)
         messageEditorService = mock(MessageEditorService::class.java)
         @Suppress("UNCHECKED_CAST")
         settingsButtonDataService = mock(ButtonDataService::class.java) as ButtonDataService<SettingsType>
         strategy = IntervalMenuReplyButtonStrategy(
-            sender, notificationAccessService, messageEditorService, settingsButtonDataService
+            sender, notificationSettingsService, messageEditorService, settingsButtonDataService
         )
     }
 
@@ -53,7 +53,7 @@ class IntervalMenuReplyButtonStrategyTest {
     @DisplayName("reply(): deletes reply markup on original message")
     fun `reply deletes reply markup`(intervalType: IntervalNotificationType) {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, notificationInterval = intervalType)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(dto)
 
         strategy.reply(buildCallbackQuery())
 
@@ -65,7 +65,7 @@ class IntervalMenuReplyButtonStrategyTest {
     @DisplayName("reply(): sends current interval greeting message with markdown")
     fun `reply sends current interval greeting message`(intervalType: IntervalNotificationType) {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, notificationInterval = intervalType)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(dto)
 
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
         strategy.reply(buildCallbackQuery())
@@ -85,7 +85,7 @@ class IntervalMenuReplyButtonStrategyTest {
     @DisplayName("reply(): sends interval buttons message with keyboard excluding current interval")
     fun `reply sends interval buttons message with keyboard`(intervalType: IntervalNotificationType) {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, notificationInterval = intervalType)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(dto)
 
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
         strategy.reply(buildCallbackQuery())

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategyTest.kt
@@ -14,7 +14,7 @@ import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
@@ -37,7 +37,7 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
 
     private lateinit var sender: TelegramClient
     private lateinit var messageEditorService: MessageEditorService
-    private lateinit var notificationAccessService: NotificationAccessService
+    private lateinit var notificationSettingsService: NotificationSettingsService
     private lateinit var waterStatisticService: WaterStatisticService
     private lateinit var strategy: CancelAnswerNotificationReplyButtonStrategy
 
@@ -45,12 +45,12 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     fun setUp() {
         sender = mock(TelegramClient::class.java)
         messageEditorService = mock(MessageEditorService::class.java)
-        notificationAccessService = mock(NotificationAccessService::class.java)
+        notificationSettingsService = mock(NotificationSettingsService::class.java)
         waterStatisticService = mock(WaterStatisticService::class.java)
         strategy = CancelAnswerNotificationReplyButtonStrategy(
             sender,
             messageEditorService,
-            notificationAccessService,
+            notificationSettingsService,
             waterStatisticService,
             fixedClock
         )
@@ -60,7 +60,7 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): edits original message with CANCEL display name")
     fun `reply edits original message`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
@@ -73,18 +73,18 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): updates last notification time to now(clock)")
     fun `reply updates notification time`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
-        verify(notificationAccessService).updateTimeOfLastNotification(userId, fixedNow)
+        verify(notificationSettingsService).resetNotificationTimer(userId, fixedNow)
     }
 
     @Test
     @DisplayName("reply(): records water statistic with CANCEL event type")
     fun `reply records statistic`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
@@ -95,7 +95,7 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): sends CANCEL confirmation message")
     fun `reply sends confirmation message`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
 
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
         strategy.reply(buildCallbackQuery())
@@ -132,7 +132,7 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): sends CANCEL confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
         doThrow(RuntimeException("statistic error")).`when`(waterStatisticService)
             .recordEvent(any(), any(), anyInt())
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/pause/PauseNotificationReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/pause/PauseNotificationReplyButtonStrategyTest.kt
@@ -16,7 +16,7 @@ import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.model.base.PauseNotificationType
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
@@ -33,16 +33,16 @@ class PauseNotificationReplyButtonStrategyTest {
     private val messageId = 3
 
     private lateinit var sender: TelegramClient
-    private lateinit var notificationAccessService: NotificationAccessService
+    private lateinit var notificationSettingsService: NotificationSettingsService
     private lateinit var messageEditorService: MessageEditorService
     private lateinit var strategy: PauseNotificationReplyButtonStrategy
 
     @BeforeEach
     fun setUp() {
         sender = mock(TelegramClient::class.java)
-        notificationAccessService = mock(NotificationAccessService::class.java)
+        notificationSettingsService = mock(NotificationSettingsService::class.java)
         messageEditorService = mock(MessageEditorService::class.java)
-        strategy = PauseNotificationReplyButtonStrategy(sender, notificationAccessService, messageEditorService)
+        strategy = PauseNotificationReplyButtonStrategy(sender, notificationSettingsService, messageEditorService)
     }
 
     @ParameterizedTest
@@ -50,7 +50,7 @@ class PauseNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): deletes reply markup on original message")
     fun `reply deletes reply markup`(pauseType: PauseNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(pauseType.queryData.toString()))
 
@@ -62,11 +62,11 @@ class PauseNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): updates notification time to now + pauseMinutes")
     fun `reply updates notification time`(pauseType: PauseNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(pauseType.queryData.toString()))
 
-        verify(notificationAccessService).updateTimeOfLastNotification(eq(userId), any<LocalDateTime>())
+        verify(notificationSettingsService).resetNotificationTimer(eq(userId), any<LocalDateTime>())
     }
 
     @ParameterizedTest
@@ -74,7 +74,7 @@ class PauseNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): sends confirmation message with pause displayName")
     fun `reply sends confirmation message`(pauseType: PauseNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
 
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
         strategy.reply(buildCallbackQuery(pauseType.queryData.toString()))
@@ -92,7 +92,7 @@ class PauseNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): deletes reply markup on original message")
     fun `reply deletes reply markup`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(PauseNotificationType.RESET.queryData.toString()))
 
@@ -103,18 +103,18 @@ class PauseNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): resets notification time to now + interval minutes")
     fun `reply updates notification time`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(PauseNotificationType.RESET.queryData.toString()))
 
-        verify(notificationAccessService).updateTimeOfLastNotification(eq(userId), any<LocalDateTime>())
+        verify(notificationSettingsService).resetNotificationTimer(eq(userId), any<LocalDateTime>())
     }
 
     @Test
     @DisplayName("reply(): sends reset message with interval displayName")
     fun `reply sends reset message`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
 
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
         strategy.reply(buildCallbackQuery(PauseNotificationType.RESET.queryData.toString()))

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategyTest.kt
@@ -14,7 +14,7 @@ import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
 import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
@@ -37,7 +37,7 @@ class SnoozeApplyReplyButtonStrategyTest {
     private val fixedClock = Clock.fixed(fixedNow.toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
 
     private lateinit var sender: TelegramClient
-    private lateinit var notificationAccessService: NotificationAccessService
+    private lateinit var notificationSettingsService: NotificationSettingsService
     private lateinit var messageEditorService: MessageEditorService
     private lateinit var waterStatisticService: WaterStatisticService
     private lateinit var strategy: SnoozeApplyReplyButtonStrategy
@@ -45,12 +45,12 @@ class SnoozeApplyReplyButtonStrategyTest {
     @BeforeEach
     fun setUp() {
         sender = mock(TelegramClient::class.java)
-        notificationAccessService = mock(NotificationAccessService::class.java)
+        notificationSettingsService = mock(NotificationSettingsService::class.java)
         messageEditorService = mock(MessageEditorService::class.java)
         waterStatisticService = mock(WaterStatisticService::class.java)
         strategy = SnoozeApplyReplyButtonStrategy(
             sender,
-            notificationAccessService,
+            notificationSettingsService,
             waterStatisticService,
             messageEditorService,
             fixedClock
@@ -62,8 +62,8 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): deletes reply markup on original message")
     fun `reply deletes reply markup`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
-        `when`(notificationAccessService.updateTimeOfLastNotification(eq(userId), any())).thenReturn(notificationDto)
+        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(eq(userId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         strategy.reply(callbackQuery)
@@ -76,15 +76,15 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): next notification fires exactly snoozeMinutes from now")
     fun `reply updates notification time`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
-        `when`(notificationAccessService.updateTimeOfLastNotification(eq(userId), any())).thenReturn(notificationDto)
+        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(eq(userId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         strategy.reply(callbackQuery)
 
         val interval = notificationDto.notificationInterval.minutes
         val expectedTime = fixedNow.minusMinutes(interval).plusMinutes(snoozeType.minutes)
-        verify(notificationAccessService).updateTimeOfLastNotification(userId, expectedTime)
+        verify(notificationSettingsService).resetNotificationTimer(userId, expectedTime)
     }
 
     @ParameterizedTest
@@ -92,8 +92,8 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): sends confirmation message with snooze display name")
     fun `reply sends confirmation message`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
-        `when`(notificationAccessService.updateTimeOfLastNotification(eq(userId), any())).thenReturn(notificationDto)
+        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(eq(userId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
@@ -113,15 +113,15 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): falls back to TEN_MINS when queryData doesn't match any SnoozeNotificationType")
     fun `reply falls back to TEN_MINS for unknown queryData`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
-        `when`(notificationAccessService.updateTimeOfLastNotification(eq(userId), any())).thenReturn(notificationDto)
+        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(eq(userId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery("00000000-0000-0000-0000-000000000000")
         strategy.reply(callbackQuery)
 
         val interval = notificationDto.notificationInterval.minutes
         val expectedTime = fixedNow.minusMinutes(interval).plusMinutes(SnoozeNotificationType.TEN_MINS.minutes)
-        verify(notificationAccessService).updateTimeOfLastNotification(userId, expectedTime)
+        verify(notificationSettingsService).resetNotificationTimer(userId, expectedTime)
     }
 
     @ParameterizedTest
@@ -129,8 +129,8 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): records water statistic with SNOOZE event type")
     fun `reply records statistic any type`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
-        `when`(notificationAccessService.updateTimeOfLastNotification(eq(userId), any())).thenReturn(notificationDto)
+        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(eq(userId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
 
@@ -165,8 +165,8 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): sends snooze confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
-        `when`(notificationAccessService.updateTimeOfLastNotification(any(), any())).thenReturn(notificationDto)
+        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(any(), any())).thenReturn(notificationDto)
         doThrow(RuntimeException("statistic error")).`when`(waterStatisticService)
             .recordEvent(any(), any(), anyInt())
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
@@ -14,7 +14,7 @@ import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.WaterAmountType
 import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
@@ -37,7 +37,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
     private val fixedClock = Clock.fixed(fixedNow.toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
 
     private lateinit var sender: TelegramClient
-    private lateinit var notificationAccessService: NotificationAccessService
+    private lateinit var notificationSettingsService: NotificationSettingsService
     private lateinit var waterStatisticService: WaterStatisticService
     private lateinit var messageEditorService: MessageEditorService
     private lateinit var strategy: WaterAmountApplyReplyButtonStrategy
@@ -45,12 +45,12 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @BeforeEach
     fun setUp() {
         sender = mock(TelegramClient::class.java)
-        notificationAccessService = mock(NotificationAccessService::class.java)
+        notificationSettingsService = mock(NotificationSettingsService::class.java)
         waterStatisticService = mock(WaterStatisticService::class.java)
         messageEditorService = mock(MessageEditorService::class.java)
         strategy = WaterAmountApplyReplyButtonStrategy(
             sender,
-            notificationAccessService,
+            notificationSettingsService,
             waterStatisticService,
             messageEditorService,
             fixedClock
@@ -62,7 +62,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): deletes reply markup on original message")
     fun `reply deletes reply markup`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
@@ -74,11 +74,11 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): updates last notification time to now()")
     fun `reply updates notification time`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
-        verify(notificationAccessService).updateTimeOfLastNotification(userId, fixedNow)
+        verify(notificationSettingsService).resetNotificationTimer(userId, fixedNow)
     }
 
     @ParameterizedTest
@@ -86,7 +86,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): sends YES confirmation message")
     fun `reply sends confirmation message`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
 
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
@@ -102,7 +102,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): records water statistic with correct water amount")
     fun `reply records statistic with correct water amount`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
@@ -117,7 +117,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): falls back to ML_250 when queryData doesn't match any WaterAmountType")
     fun `reply falls back to ML_250 for unknown queryData`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery("00000000-0000-0000-0000-000000000000"))
 
@@ -132,13 +132,13 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): executes operations in correct order")
     fun `reply executes in correct order`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(WaterAmountType.ML_250.queryData.toString()))
 
-        val inOrder = inOrder(messageEditorService, notificationAccessService, waterStatisticService, sender)
+        val inOrder = inOrder(messageEditorService, notificationSettingsService, waterStatisticService, sender)
         inOrder.verify(messageEditorService).deleteReplyMarkup(chatId, messageId)
-        inOrder.verify(notificationAccessService).updateTimeOfLastNotification(userId, fixedNow)
+        inOrder.verify(notificationSettingsService).resetNotificationTimer(userId, fixedNow)
         inOrder.verify(waterStatisticService).recordEvent(
             notificationDto.telegramUser,
             AnswerNotificationType.YES,
@@ -173,7 +173,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): sends YES confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, fixedNow)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
         doThrow(RuntimeException("statistic error")).`when`(waterStatisticService)
             .recordEvent(any(), any(), anyInt())
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsServiceTest.kt
@@ -1,19 +1,21 @@
 package ru.illine.drinking.ponies.service.notification
 
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
-import org.mockito.Mockito
+import org.mockito.Mockito.*
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.service.notification.impl.NotificationSettingsServiceImpl
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 @UnitTest
@@ -31,9 +33,9 @@ class NotificationSettingsServiceTest {
 
     @BeforeEach
     fun setUp() {
-        notificationAccessService = Mockito.mock(NotificationAccessService::class.java)
-        messageEditorService = Mockito.mock(MessageEditorService::class.java)
-        sender = Mockito.mock(TelegramClient::class.java)
+        notificationAccessService = mock(NotificationAccessService::class.java)
+        messageEditorService = mock(MessageEditorService::class.java)
+        sender = mock(TelegramClient::class.java)
         service = NotificationSettingsServiceImpl(notificationAccessService, messageEditorService, sender)
     }
 
@@ -42,12 +44,12 @@ class NotificationSettingsServiceTest {
     fun `changeQuietMode updates quiet mode`() {
         val start = LocalTime.of(22, 0)
         val end = LocalTime.of(8, 0)
-        val notificationDto = DtoGenerator.Companion.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
-        Mockito.`when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
 
         service.changeQuietMode(userId, messageId, start, end)
 
-        Mockito.verify(notificationAccessService).changeQuietMode(userId, start, end)
+        verify(notificationAccessService).changeQuietMode(userId, start, end)
     }
 
     @Test
@@ -55,12 +57,12 @@ class NotificationSettingsServiceTest {
     fun `changeQuietMode deletes reply markup`() {
         val start = LocalTime.of(22, 0)
         val end = LocalTime.of(8, 0)
-        val notificationDto = DtoGenerator.Companion.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
-        Mockito.`when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
 
         service.changeQuietMode(userId, messageId, start, end)
 
-        Mockito.verify(messageEditorService).deleteReplyMarkup(chatId, messageId)
+        verify(messageEditorService).deleteReplyMarkup(chatId, messageId)
     }
 
     @Test
@@ -68,16 +70,16 @@ class NotificationSettingsServiceTest {
     fun `changeQuietMode sends confirmation message`() {
         val start = LocalTime.of(22, 0)
         val end = LocalTime.of(8, 0)
-        val notificationDto = DtoGenerator.Companion.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
-        Mockito.`when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
 
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
         service.changeQuietMode(userId, messageId, start, end)
 
-        Mockito.verify(sender).execute(captor.capture())
+        verify(sender).execute(captor.capture())
         val sent = captor.value
-        Assertions.assertEquals(chatId.toString(), sent.chatId)
-        Assertions.assertEquals(
+        assertEquals(chatId.toString(), sent.chatId)
+        assertEquals(
             TelegramMessageConstants.SETTINGS_QUIET_MODE_TIME_NOTIFICATION_CHANGING.format(start, end),
             sent.text
         )
@@ -88,7 +90,7 @@ class NotificationSettingsServiceTest {
     fun `changeQuietMode throws when start equals end`() {
         val time = LocalTime.of(10, 0)
 
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(IllegalArgumentException::class.java) {
             service.changeQuietMode(userId, messageId, time, time)
         }
     }
@@ -98,6 +100,56 @@ class NotificationSettingsServiceTest {
     fun `disableQuietMode disables quiet mode`() {
         service.disableQuietMode(userId)
 
-        Mockito.verify(notificationAccessService).disableQuietMode(userId)
+        verify(notificationAccessService).disableQuietMode(userId)
+    }
+
+    @Test
+    @DisplayName("getNotificationSettings(): delegates to access service")
+    fun `getNotificationSettings delegates to access service`() {
+        val expected = DtoGenerator.generateNotificationDto(externalUserId = userId)
+        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(expected)
+
+        val result = service.getNotificationSettings(userId)
+
+        assertEquals(expected, result)
+        verify(notificationAccessService).findNotificationSettingByTelegramUserId(userId)
+    }
+
+    @Test
+    @DisplayName("getAllNotificationSettings(): delegates to access service")
+    fun `getAllNotificationSettings delegates to access service`() {
+        val expected = setOf(DtoGenerator.generateNotificationDto())
+        `when`(notificationAccessService.findAllNotificationSettings()).thenReturn(expected)
+
+        val result = service.getAllNotificationSettings()
+
+        assertEquals(expected, result)
+        verify(notificationAccessService).findAllNotificationSettings()
+    }
+
+    @Test
+    @DisplayName("resetNotificationTimer(): delegates to access service and returns DTO")
+    fun `resetNotificationTimer delegates to access service`() {
+        val time = LocalDateTime.of(2026, 4, 5, 12, 0)
+        val expected = DtoGenerator.generateNotificationDto(externalUserId = userId)
+        `when`(notificationAccessService.updateTimeOfLastNotification(userId, time)).thenReturn(expected)
+
+        val result = service.resetNotificationTimer(userId, time)
+
+        assertEquals(expected, result)
+        verify(notificationAccessService).updateTimeOfLastNotification(userId, time)
+    }
+
+    @Test
+    @DisplayName("changeInterval(): delegates to access service and returns DTO")
+    fun `changeInterval delegates to access service`() {
+        val interval = IntervalNotificationType.TWO_HOURS
+        val expected = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        `when`(notificationAccessService.updateNotificationSettings(userId, chatId, interval)).thenReturn(expected)
+
+        val result = service.changeInterval(userId, chatId, interval)
+
+        assertEquals(expected, result)
+        verify(notificationAccessService).updateNotificationSettings(userId, chatId, interval)
     }
 }


### PR DESCRIPTION
## Summary
- Add 4 new methods to NotificationSettingsService: getNotificationSettings, getAllNotificationSettings, resetNotificationTimer, changeInterval
- Replace direct NotificationAccessService usage with NotificationSettingsService in 6 button strategies (WaterAmountApply, CancelAnswerNotification, SnoozeApply, PauseNotification, IntervalApply, IntervalMenu)
- Replace direct NotificationAccessService usage with NotificationSettingsService in NotificationScheduler
- NotificationAccessService is now only called from notification service layer, not from strategies or scheduler directly

## Test plan
- [x] Unit tests for new NotificationSettingsService methods (getNotificationSettings, getAllNotificationSettings, resetNotificationTimer, changeInterval)
- [x] All existing strategy tests updated and passing
- [x] NotificationScheduler tests updated and passing
- [x] ReplyButtonFactoryTest updated and passing
- [x] 100% line and branch coverage on all changed classes