### PR TITLE
DPTB-88: fix CORS configuration to support multiple origins

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/WebConfig.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/WebConfig.kt
@@ -23,18 +23,16 @@ class WebConfig(
     }
 
     override fun addCorsMappings(registry: CorsRegistry) {
-        corsProperties.allowedOrigins.forEach {
-            registry.addMapping(defaultAllowedMapping)
-                .allowedOrigins(it)
-                .allowedMethods(
-                    HttpMethod.GET.name(),
-                    HttpMethod.POST.name(),
-                    HttpMethod.PUT.name(),
-                    HttpMethod.PATCH.name(),
-                    HttpMethod.DELETE.name()
-                )
-                .allowedHeaders(defaultAllowedHeaders)
-                .allowCredentials(true)
-        }
+        registry.addMapping(defaultAllowedMapping)
+            .allowedOrigins(*corsProperties.allowedOrigins.toTypedArray())
+            .allowedMethods(
+                HttpMethod.GET.name(),
+                HttpMethod.POST.name(),
+                HttpMethod.PUT.name(),
+                HttpMethod.PATCH.name(),
+                HttpMethod.DELETE.name()
+            )
+            .allowedHeaders(defaultAllowedHeaders)
+            .allowCredentials(true)
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigTest.kt
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.http.HttpHeaders
@@ -19,12 +21,12 @@ class WebConfigTest @Autowired constructor(
     private val restTemplate: TestRestTemplate
 ) {
 
-    private val allowedOrigin = "http://localhost:3000"
     private val url = "/settings/modes/silent"
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = ["http://localhost:3000", "http://localhost:4000"])
     @DisplayName("CORS: OPTIONS request from allowed origin - returns 200 with CORS headers")
-    fun `cors preflight from allowed origin returns cors headers`() {
+    fun `cors preflight from allowed origin returns cors headers`(allowedOrigin: String) {
         val headers = HttpHeaders().apply {
             set("Origin", allowedOrigin)
             set("Access-Control-Request-Method", "PUT")

--- a/src/test/resources/application-integration-test.yaml
+++ b/src/test/resources/application-integration-test.yaml
@@ -35,7 +35,7 @@ spring:
     import:
       - ${BUTTONS_CONFIG_PATH:classpath:buttons.yaml}
   cors:
-    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:4000}
 
 telegram-bot:
   version: integration-test


### PR DESCRIPTION
## Summary
- Fix `WebConfig.addCorsMappings()` registering each origin in a separate `addMapping("/**")` call - Spring MVC keeps only the last registration, so only the last origin works
- Replace `forEach` loop with a single registration using `allowedOrigins(*array)` spread
- Add parameterized CORS test covering multiple origins

## Test plan
- [x] Parameterized test verifies CORS preflight for both allowed origins
- [x] Test verifies disallowed origin is rejected
- [x] All project tests pass
- [x] Verified on test environment