### PR TITLE
DPTB-138: backend endpoint for manual water entry

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/builder/WaterStatisticBuilder.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/builder/WaterStatisticBuilder.kt
@@ -15,7 +15,8 @@ object WaterStatisticBuilder {
             telegramUser = user,
             eventTime = entity.eventTime,
             eventType = entity.eventType,
-            waterAmountMl = entity.waterAmountMl
+            waterAmountMl = entity.waterAmountMl,
+            source = entity.source
         )
 
     fun toEntity(dto: WaterStatisticDto, user: TelegramUserEntity): WaterStatisticEntity =
@@ -24,7 +25,8 @@ object WaterStatisticBuilder {
             telegramUser = user,
             eventTime = dto.eventTime,
             eventType = dto.eventType,
-            waterAmountMl = dto.waterAmountMl
+            waterAmountMl = dto.waterAmountMl,
+            source = dto.source
         )
 
     fun toWaterEntry(dto: WaterStatisticDto): WaterEntry =

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/StatisticsController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/StatisticsController.kt
@@ -3,21 +3,28 @@ package ru.illine.drinking.ponies.controller
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 import ru.illine.drinking.ponies.builder.StatisticsBuilder
 import ru.illine.drinking.ponies.builder.WaterStatisticBuilder
 import ru.illine.drinking.ponies.model.base.StatisticsPeriodType
 import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.request.WaterEntryRequest
 import ru.illine.drinking.ponies.model.dto.response.StatisticsResponse
 import ru.illine.drinking.ponies.model.dto.response.StatisticsTodayResponse
 import ru.illine.drinking.ponies.service.statistic.StatisticsService
+import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
 
 @RestController
 @RequestMapping("/statistics")
+@Validated
 @Tag(name = "Statistics", description = "Water intake statistics")
 class StatisticsController(
     private val statisticsService: StatisticsService,
+    private val waterStatisticService: WaterStatisticService,
 ) {
 
     @GetMapping("/today")
@@ -41,5 +48,20 @@ class StatisticsController(
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
     ): StatisticsResponse =
         StatisticsBuilder.toResponse(statisticsService.getStatistics(telegramUser.telegramId, period))
+
+    @PostMapping("/water")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Record a manual water intake entry at an arbitrary time")
+    fun recordWaterEntry(
+        @Parameter(hidden = true)
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @Valid @RequestBody request: WaterEntryRequest,
+    ) {
+        waterStatisticService.manualRecordEvent(
+            externalUserId = telegramUser.telegramId,
+            consumedAt = request.consumedAt,
+            amountMl = request.amountMl,
+        )
+    }
 
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/base/WaterEntrySourceType.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/base/WaterEntrySourceType.kt
@@ -1,0 +1,8 @@
+package ru.illine.drinking.ponies.model.base
+
+enum class WaterEntrySourceType {
+
+    NOTIFICATION,
+    MANUAL
+
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/WaterStatisticDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/WaterStatisticDto.kt
@@ -1,6 +1,7 @@
 package ru.illine.drinking.ponies.model.dto.internal
 
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
 import java.time.LocalDateTime
 
 data class WaterStatisticDto(
@@ -12,5 +13,7 @@ data class WaterStatisticDto(
 
     val eventType: AnswerNotificationType,
 
-    val waterAmountMl: Int = 0
+    val waterAmountMl: Int = 0,
+
+    val source: WaterEntrySourceType = WaterEntrySourceType.NOTIFICATION
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/WaterEntryRequest.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/WaterEntryRequest.kt
@@ -1,0 +1,18 @@
+package ru.illine.drinking.ponies.model.dto.request
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.PastOrPresent
+import ru.illine.drinking.ponies.util.water.WaterEntryConstants
+import java.time.Instant
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class WaterEntryRequest(
+    @field:PastOrPresent
+    val consumedAt: Instant,
+
+    @field:Min(WaterEntryConstants.MIN_ML)
+    @field:Max(WaterEntryConstants.MAX_ML)
+    val amountMl: Int,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/entity/WaterStatisticEntity.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/entity/WaterStatisticEntity.kt
@@ -2,6 +2,7 @@ package ru.illine.drinking.ponies.model.entity
 
 import jakarta.persistence.*
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
 import java.time.LocalDateTime
 
 @Entity
@@ -35,7 +36,11 @@ class WaterStatisticEntity(
     var eventType: AnswerNotificationType,
 
     @Column(name = "water_amount_ml", nullable = false)
-    var waterAmountMl: Int = 0
+    var waterAmountMl: Int = 0,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source", nullable = false)
+    var source: WaterEntrySourceType = WaterEntrySourceType.NOTIFICATION
 
 ) {
 
@@ -49,6 +54,7 @@ class WaterStatisticEntity(
         if (eventTime != other.eventTime) return false
         if (eventType != other.eventType) return false
         if (waterAmountMl != other.waterAmountMl) return false
+        if (source != other.source) return false
 
         return true
     }
@@ -58,6 +64,7 @@ class WaterStatisticEntity(
         result = 31 * result + eventTime.hashCode()
         result = 31 * result + eventType.hashCode()
         result = 31 * result + waterAmountMl
+        result = 31 * result + source.hashCode()
         return result
     }
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticService.kt
@@ -2,11 +2,14 @@ package ru.illine.drinking.ponies.service.statistic
 
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
+import java.time.Instant
 
 interface WaterStatisticService {
 
     fun recordEvent(telegramUser: TelegramUserDto, eventType: AnswerNotificationType, waterAmountMl: Int = 0)
 
     fun recordEvents(telegramUsers: Collection<TelegramUserDto>, eventType: AnswerNotificationType)
+
+    fun manualRecordEvent(externalUserId: Long, consumedAt: Instant, amountMl: Int)
 
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/impl/WaterStatisticServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/impl/WaterStatisticServiceImpl.kt
@@ -4,11 +4,16 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
+import ru.illine.drinking.ponies.util.water.WaterEntryConstants
 import java.time.Clock
+import java.time.Instant
 import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 
 @Service
 class WaterStatisticServiceImpl(
@@ -47,6 +52,37 @@ class WaterStatisticServiceImpl(
                     eventType = eventType
                 )
             }
+        )
+    }
+
+    override fun manualRecordEvent(externalUserId: Long, consumedAt: Instant, amountMl: Int) {
+        require(amountMl.toLong() in WaterEntryConstants.MIN_ML..WaterEntryConstants.MAX_ML) {
+            "Water amount must be between ${WaterEntryConstants.MIN_ML} and ${WaterEntryConstants.MAX_ML} ml, got: $amountMl"
+        }
+
+        val now = Instant.now(clock)
+        require(!consumedAt.isAfter(now)) {
+            "consumedAt must not be in the future, got: $consumedAt (now: $now)"
+        }
+        require(!consumedAt.isBefore(now.minus(WaterEntryConstants.MAX_DAYS_AGO, ChronoUnit.DAYS))) {
+            "consumedAt must not be older than ${WaterEntryConstants.MAX_DAYS_AGO} days, got: $consumedAt"
+        }
+
+        logger.info(
+            "Recording manual water entry for user [{}], amount [{}] ml at [{}]",
+            externalUserId,
+            amountMl,
+            consumedAt
+        )
+
+        waterStatisticAccessService.save(
+            WaterStatisticDto(
+                telegramUser = TelegramUserDto.create(externalUserId),
+                eventTime = LocalDateTime.ofInstant(consumedAt, ZoneOffset.UTC),
+                eventType = AnswerNotificationType.YES,
+                waterAmountMl = amountMl,
+                source = WaterEntrySourceType.MANUAL
+            )
         )
     }
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/water/WaterEntryConstants.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/water/WaterEntryConstants.kt
@@ -1,0 +1,9 @@
+package ru.illine.drinking.ponies.util.water
+
+object WaterEntryConstants {
+
+    const val MIN_ML: Long = 50
+    const val MAX_ML: Long = 1000
+    const val MAX_DAYS_AGO: Long = 30
+
+}

--- a/src/main/resources/liquibase/8.3.0/changes.yaml
+++ b/src/main/resources/liquibase/8.3.0/changes.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 8.3.0
+      author: illine
+      comment: Release 8.3.0
+      changes:
+        - tagDatabase:
+            tag: 8.3.0
+
+  # DDL
+  - include:
+      file: ddl/01_water_statistics_add_source.sql
+      relativeToChangelogFile: true

--- a/src/main/resources/liquibase/8.3.0/ddl/01_water_statistics_add_source.sql
+++ b/src/main/resources/liquibase/8.3.0/ddl/01_water_statistics_add_source.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+
+--changeset illine:8.3.0/ddl/water_statistics_add_source
+--rollback alter table water_statistics drop column source;
+
+alter table water_statistics
+    add column source varchar(32) not null default 'NOTIFICATION';
+
+comment on column water_statistics.source is 'Source of the water entry: NOTIFICATION = recorded via Telegram callback, MANUAL = recorded via MiniApp manual entry';

--- a/src/main/resources/liquibase/changelog.yaml
+++ b/src/main/resources/liquibase/changelog.yaml
@@ -28,3 +28,6 @@ databaseChangeLog:
   - include:
       file: 8.0.0/changes.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 8.3.0/changes.yaml
+      relativeToChangelogFile: true

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
@@ -8,15 +8,18 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import ru.illine.drinking.ponies.exception.NotificationSettingsNotFoundException
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
@@ -28,10 +31,12 @@ import ru.illine.drinking.ponies.model.dto.TelegramUserDto
 import ru.illine.drinking.ponies.model.dto.response.StatisticsResponse
 import ru.illine.drinking.ponies.model.dto.response.StatisticsTodayResponse
 import ru.illine.drinking.ponies.service.statistic.StatisticsService
+import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
 import java.time.DayOfWeek
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -47,6 +52,9 @@ class StatisticsControllerTest @Autowired constructor(
 
     @MockitoBean
     private lateinit var statisticsService: StatisticsService
+
+    @MockitoBean
+    private lateinit var waterStatisticService: WaterStatisticService
 
     private val telegramUser = TelegramUserDto(
         telegramId = 1L,
@@ -277,6 +285,146 @@ class StatisticsControllerTest @Autowired constructor(
 
             assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
             verify(statisticsService).getStatistics(telegramUser.telegramId, StatisticsPeriodType.WEEK)
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /statistics/water")
+    inner class PostWater {
+
+        private fun jsonHeaders(): HttpHeaders {
+            return buildHeaders().apply {
+                contentType = MediaType.APPLICATION_JSON
+            }
+        }
+
+        private fun jsonBody(consumedAt: Instant, amountMl: Int): String =
+            """{"consumedAt":"$consumedAt","amountMl":$amountMl}"""
+
+        /**
+         * Returns an instant that is safely in the past relative to the server clock.
+         * Margin avoids flakiness against @PastOrPresent caused by clock drift between
+         * test thread and validator invocation.
+         */
+        private fun pastInstant(): Instant = Instant.now().minus(Duration.ofMinutes(5))
+
+        @Test
+        @DisplayName("valid request - returns 201 and calls service with parsed args")
+        fun `returns 201 on valid request`() {
+            val consumedAt = pastInstant()
+            val body = jsonBody(consumedAt, 250)
+
+            val response = restTemplate.exchange(
+                "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
+            )
+
+            assertEquals(HttpStatus.CREATED, response.statusCode)
+            val userIdCaptor = argumentCaptor<Long>()
+            val consumedAtCaptor = argumentCaptor<Instant>()
+            val amountCaptor = argumentCaptor<Int>()
+            verify(waterStatisticService).manualRecordEvent(
+                userIdCaptor.capture(), consumedAtCaptor.capture(), amountCaptor.capture()
+            )
+            assertEquals(telegramUser.telegramId, userIdCaptor.firstValue)
+            assertEquals(consumedAt, consumedAtCaptor.firstValue)
+            assertEquals(250, amountCaptor.firstValue)
+        }
+
+        @Test
+        @DisplayName("service throws IllegalArgumentException - returns 400 (handler maps to BAD_REQUEST)")
+        fun `returns 400 on service IllegalArgumentException`() {
+            doThrow(IllegalArgumentException("invalid"))
+                .`when`(waterStatisticService).manualRecordEvent(any(), any(), any())
+            val body = jsonBody(pastInstant(), 250)
+
+            val response = restTemplate.exchange(
+                "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
+            )
+
+            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        }
+
+        @ParameterizedTest(name = "[{index}] amountMl={0} fails bean validation")
+        @ValueSource(ints = [Int.MIN_VALUE, -1, 0, 49, 1001, Int.MAX_VALUE])
+        @DisplayName("amountMl outside [MIN_ML, MAX_ML] - returns 400 (bean validation)")
+        fun `returns 400 on amount out of bounds`(amount: Int) {
+            val body = jsonBody(pastInstant(), amount)
+
+            val response = restTemplate.exchange(
+                "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
+            )
+
+            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+            verifyNoInteractions(waterStatisticService)
+        }
+
+        @Test
+        @DisplayName("consumedAt in the future - returns 400 (bean validation)")
+        fun `returns 400 on future consumedAt`() {
+            val body = jsonBody(Instant.now().plus(Duration.ofHours(1)), 250)
+
+            val response = restTemplate.exchange(
+                "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
+            )
+
+            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+            verifyNoInteractions(waterStatisticService)
+        }
+
+        @ParameterizedTest(name = "[{index}] body={0}")
+        @MethodSource("ru.illine.drinking.ponies.controller.StatisticsControllerTest#malformedBodies")
+        @DisplayName("malformed/missing JSON body fields - returns 400")
+        fun `returns 400 on malformed body`(body: String?) {
+            val entity: HttpEntity<*> = if (body == null) HttpEntity<Void>(jsonHeaders()) else HttpEntity(body, jsonHeaders())
+
+            val response = restTemplate.exchange(
+                "/statistics/water", HttpMethod.POST, entity, Void::class.java
+            )
+
+            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+            verifyNoInteractions(waterStatisticService)
+        }
+
+        @Test
+        @DisplayName("missing auth header - returns 401")
+        fun `returns 401 on missing auth header`() {
+            val body = jsonBody(pastInstant(), 250)
+            val headers = HttpHeaders().apply { contentType = MediaType.APPLICATION_JSON }
+
+            val response = restTemplate.exchange(
+                "/statistics/water", HttpMethod.POST, HttpEntity(body, headers), Void::class.java
+            )
+
+            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+            verifyNoInteractions(waterStatisticService)
+        }
+
+        @Test
+        @DisplayName("invalid signature - returns 403")
+        fun `returns 403 on invalid signature`() {
+            `when`(telegramValidatorService.verifySignature(any())).thenReturn(false)
+            val body = jsonBody(pastInstant(), 250)
+
+            val response = restTemplate.exchange(
+                "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
+            )
+
+            assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
+            verifyNoInteractions(waterStatisticService)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun malformedBodies(): List<String?> {
+            val pastIso = Instant.now().minus(Duration.ofMinutes(5)).toString()
+            return listOf(
+                null,
+                """{"consumedAt":"$pastIso"}""",
+                """{"amountMl":250}""",
+                """{"consumedAt":"not-a-date","amountMl":250}""",
+                """{}""",
+            )
         }
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
@@ -1,21 +1,29 @@
 package ru.illine.drinking.ponies.service.statistic
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.service.statistic.impl.WaterStatisticServiceImpl
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
+import ru.illine.drinking.ponies.util.water.WaterEntryConstants
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 
 @UnitTest
 @DisplayName("WaterStatisticService Unit Test")
@@ -34,7 +42,7 @@ class WaterStatisticServiceTest {
     }
 
     @Test
-    @DisplayName("recordEvent(): saves statistic with correct eventType and waterAmountMl")
+    @DisplayName("recordEvent(): saves statistic with correct fields and source=NOTIFICATION")
     fun `recordEvent saves statistic with correct fields`() {
         val telegramUser = DtoGenerator.generateNotificationDto().telegramUser
         val captor = argumentCaptor<WaterStatisticDto>()
@@ -47,10 +55,11 @@ class WaterStatisticServiceTest {
         assertEquals(AnswerNotificationType.YES, saved.eventType)
         assertEquals(250, saved.waterAmountMl)
         assertEquals(fixedNow, saved.eventTime)
+        assertEquals(WaterEntrySourceType.NOTIFICATION, saved.source)
     }
 
     @Test
-    @DisplayName("recordEvent(): defaults waterAmountMl to 0")
+    @DisplayName("recordEvent(): defaults waterAmountMl to 0 and uses source=NOTIFICATION")
     fun `recordEvent defaults waterAmountMl to zero`() {
         val telegramUser = DtoGenerator.generateNotificationDto().telegramUser
         val captor = argumentCaptor<WaterStatisticDto>()
@@ -59,23 +68,12 @@ class WaterStatisticServiceTest {
 
         verify(waterStatisticAccessService).save(captor.capture())
         assertEquals(0, captor.firstValue.waterAmountMl)
+        assertEquals(AnswerNotificationType.SNOOZE, captor.firstValue.eventType)
+        assertEquals(WaterEntrySourceType.NOTIFICATION, captor.firstValue.source)
     }
 
     @Test
-    @DisplayName("recordEvent(): explicit waterAmountMl=0 produces same result as default")
-    fun `recordEvent explicit zero waterAmountMl`() {
-        val telegramUser = DtoGenerator.generateNotificationDto().telegramUser
-        val captor = argumentCaptor<WaterStatisticDto>()
-
-        service.recordEvent(telegramUser, AnswerNotificationType.CANCEL, 0)
-
-        verify(waterStatisticAccessService).save(captor.capture())
-        assertEquals(0, captor.firstValue.waterAmountMl)
-        assertEquals(AnswerNotificationType.CANCEL, captor.firstValue.eventType)
-    }
-
-    @Test
-    @DisplayName("recordEvents(): saves all statistics with correct eventType")
+    @DisplayName("recordEvents(): saves all statistics with correct eventType and source=NOTIFICATION")
     fun `recordEvents saves all statistics`() {
         val users = listOf(
             DtoGenerator.generateNotificationDto(externalUserId = 1L).telegramUser,
@@ -94,7 +92,93 @@ class WaterStatisticServiceTest {
             assertEquals(AnswerNotificationType.CANCEL, it.eventType)
             assertEquals(0, it.waterAmountMl)
             assertEquals(fixedNow, it.eventTime)
+            assertEquals(WaterEntrySourceType.NOTIFICATION, it.source)
         }
+    }
+
+    @Test
+    @DisplayName("manualRecordEvent(): saves statistic with source=MANUAL, eventType=YES and converts consumedAt to UTC LocalDateTime")
+    fun `manualRecordEvent saves statistic with manual source`() {
+        val externalUserId = 12345L
+        val consumedAt = fixedClock.instant().minus(2, ChronoUnit.HOURS)
+        val captor = argumentCaptor<WaterStatisticDto>()
+
+        service.manualRecordEvent(externalUserId, consumedAt, 250)
+
+        verify(waterStatisticAccessService).save(captor.capture())
+        val saved = captor.firstValue
+        assertEquals(externalUserId, saved.telegramUser.externalUserId)
+        assertEquals(AnswerNotificationType.YES, saved.eventType)
+        assertEquals(250, saved.waterAmountMl)
+        assertEquals(WaterEntrySourceType.MANUAL, saved.source)
+        assertEquals(LocalDateTime.ofInstant(consumedAt, ZoneOffset.UTC), saved.eventTime)
+    }
+
+    @ParameterizedTest(name = "[{index}] amount={0} ml is accepted (boundary)")
+    @ValueSource(ints = [50, 250, 1000])
+    @DisplayName("manualRecordEvent(): accepts amount within [MIN_ML, MAX_ML]")
+    fun `manualRecordEvent accepts amount within bounds`(amount: Int) {
+        val captor = argumentCaptor<WaterStatisticDto>()
+
+        service.manualRecordEvent(1L, fixedClock.instant(), amount)
+
+        verify(waterStatisticAccessService).save(captor.capture())
+        assertEquals(amount, captor.firstValue.waterAmountMl)
+    }
+
+    @ParameterizedTest(name = "[{index}] amount={0} ml is rejected")
+    @ValueSource(ints = [Int.MIN_VALUE, -1, 0, 49, 1001, Int.MAX_VALUE])
+    @DisplayName("manualRecordEvent(): rejects amount outside [MIN_ML, MAX_ML]")
+    fun `manualRecordEvent rejects amount out of bounds`(amount: Int) {
+        assertThrows(IllegalArgumentException::class.java) {
+            service.manualRecordEvent(1L, fixedClock.instant(), amount)
+        }
+        verify(waterStatisticAccessService, never()).save(any())
+    }
+
+    @Test
+    @DisplayName("manualRecordEvent(): rejects consumedAt strictly in the future")
+    fun `manualRecordEvent rejects future consumedAt`() {
+        val future = fixedClock.instant().plus(1, ChronoUnit.SECONDS)
+        assertThrows(IllegalArgumentException::class.java) {
+            service.manualRecordEvent(1L, future, 250)
+        }
+        verify(waterStatisticAccessService, never()).save(any())
+    }
+
+    @Test
+    @DisplayName("manualRecordEvent(): accepts consumedAt exactly equal to now (boundary)")
+    fun `manualRecordEvent accepts consumedAt at now`() {
+        val captor = argumentCaptor<WaterStatisticDto>()
+
+        service.manualRecordEvent(1L, fixedClock.instant(), 250)
+
+        verify(waterStatisticAccessService).save(captor.capture())
+        assertEquals(fixedNow, captor.firstValue.eventTime)
+    }
+
+    @Test
+    @DisplayName("manualRecordEvent(): accepts consumedAt exactly MAX_DAYS_AGO ago (boundary)")
+    fun `manualRecordEvent accepts consumedAt at max days ago`() {
+        val edge = fixedClock.instant().minus(WaterEntryConstants.MAX_DAYS_AGO, ChronoUnit.DAYS)
+        val captor = argumentCaptor<WaterStatisticDto>()
+
+        service.manualRecordEvent(1L, edge, 250)
+
+        verify(waterStatisticAccessService).save(captor.capture())
+        assertEquals(LocalDateTime.ofInstant(edge, ZoneOffset.UTC), captor.firstValue.eventTime)
+    }
+
+    @Test
+    @DisplayName("manualRecordEvent(): rejects consumedAt older than MAX_DAYS_AGO")
+    fun `manualRecordEvent rejects consumedAt older than max days`() {
+        val tooOld = fixedClock.instant()
+            .minus(WaterEntryConstants.MAX_DAYS_AGO, ChronoUnit.DAYS)
+            .minus(1, ChronoUnit.SECONDS)
+        assertThrows(IllegalArgumentException::class.java) {
+            service.manualRecordEvent(1L, tooOld, 250)
+        }
+        verify(waterStatisticAccessService, never()).save(any())
     }
 
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
@@ -2,6 +2,7 @@ package ru.illine.drinking.ponies.test.generator
 
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
+import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
@@ -55,6 +56,7 @@ class DtoGenerator {
             eventType: AnswerNotificationType = AnswerNotificationType.YES,
             waterAmountMl: Int = 250,
             userTimeZone: String = "Europe/Moscow",
+            source: WaterEntrySourceType = WaterEntrySourceType.NOTIFICATION,
         ): WaterStatisticDto {
             val user = TelegramUserDto(
                 externalUserId = externalUserId,
@@ -65,6 +67,7 @@ class DtoGenerator {
                 eventTime = eventTime,
                 eventType = eventType,
                 waterAmountMl = waterAmountMl,
+                source = source,
             )
         }
     }


### PR DESCRIPTION
## Summary
- Add `POST /statistics/water` endpoint to record water intake from MiniApp with custom `consumedAt` (now / today / yesterday)
- Introduce `WaterEntryRequest` with validation: volume bounds and `consumedAt` window (not in future, not older than yesterday in user TZ)
- Add `source` column to `water_statistics` via Liquibase 8.3.0 migration and `WaterEntrySourceType` enum to distinguish manual MiniApp entries from bot-driven ones
- Ensure `consumedAt` is respected when aggregating daily progress (start-of-day in user TZ)
- Cover controller and service with unit tests

## Test plan
- [x] Unit tests for `StatisticsController` (`StatisticsControllerTest`)
- [x] Unit tests for `WaterStatisticService` (`WaterStatisticServiceTest`)
- [x] Liquibase migration applies cleanly on local DB