### PR TITLE
DPTB-143: accept null consumedAt in manual water entry

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/WaterEntryRequest.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/WaterEntryRequest.kt
@@ -1,6 +1,7 @@
 package ru.illine.drinking.ponies.model.dto.request
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.PastOrPresent
@@ -8,11 +9,24 @@ import ru.illine.drinking.ponies.util.water.WaterEntryConstants
 import java.time.Instant
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "Manual water intake entry payload")
 data class WaterEntryRequest(
     @field:PastOrPresent
-    val consumedAt: Instant,
+    @Schema(
+        description = "Consumption time in ISO 8601 UTC format. " +
+            "If null or omitted, server's current time is used.",
+        example = "2025-01-01T14:00:00Z",
+        nullable = true,
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val consumedAt: Instant?,
 
     @field:Min(WaterEntryConstants.MIN_ML)
     @field:Max(WaterEntryConstants.MAX_ML)
+    @Schema(
+        description = "Water amount in milliliters",
+        example = "250",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val amountMl: Int,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticService.kt
@@ -10,6 +10,6 @@ interface WaterStatisticService {
 
     fun recordEvents(telegramUsers: Collection<TelegramUserDto>, eventType: AnswerNotificationType)
 
-    fun manualRecordEvent(externalUserId: Long, consumedAt: Instant, amountMl: Int)
+    fun manualRecordEvent(externalUserId: Long, consumedAt: Instant?, amountMl: Int)
 
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/impl/WaterStatisticServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/impl/WaterStatisticServiceImpl.kt
@@ -55,30 +55,36 @@ class WaterStatisticServiceImpl(
         )
     }
 
-    override fun manualRecordEvent(externalUserId: Long, consumedAt: Instant, amountMl: Int) {
+    override fun manualRecordEvent(externalUserId: Long, consumedAt: Instant?, amountMl: Int) {
         require(amountMl.toLong() in WaterEntryConstants.MIN_ML..WaterEntryConstants.MAX_ML) {
             "Water amount must be between ${WaterEntryConstants.MIN_ML} and ${WaterEntryConstants.MAX_ML} ml, got: $amountMl"
         }
 
         val now = Instant.now(clock)
-        require(!consumedAt.isAfter(now)) {
-            "consumedAt must not be in the future, got: $consumedAt (now: $now)"
-        }
-        require(!consumedAt.isBefore(now.minus(WaterEntryConstants.MAX_DAYS_AGO, ChronoUnit.DAYS))) {
-            "consumedAt must not be older than ${WaterEntryConstants.MAX_DAYS_AGO} days, got: $consumedAt"
-        }
+        val eventInstant = consumedAt?.also {
+            require(!it.isAfter(now)) {
+                "consumedAt must not be in the future, got: $it (now: $now)"
+            }
+            require(
+                !it.isBefore(
+                    now.minus(WaterEntryConstants.MAX_DAYS_AGO, ChronoUnit.DAYS)
+                )
+            ) {
+                "consumedAt must not be older than ${WaterEntryConstants.MAX_DAYS_AGO} days, got: $it"
+            }
+        } ?: now.also { logger.debug("consumedAt not passed, now will be used") }
 
         logger.info(
             "Recording manual water entry for user [{}], amount [{}] ml at [{}]",
             externalUserId,
             amountMl,
-            consumedAt
+            eventInstant
         )
 
         waterStatisticAccessService.save(
             WaterStatisticDto(
                 telegramUser = TelegramUserDto.create(externalUserId),
-                eventTime = LocalDateTime.ofInstant(consumedAt, ZoneOffset.UTC),
+                eventTime = LocalDateTime.ofInstant(eventInstant, ZoneOffset.UTC),
                 eventType = AnswerNotificationType.YES,
                 waterAmountMl = amountMl,
                 source = WaterEntrySourceType.MANUAL

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
@@ -1,7 +1,9 @@
 package ru.illine.drinking.ponies.controller
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -13,6 +15,7 @@ import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.Mockito.*
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.nullableArgumentCaptor
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.http.HttpEntity
@@ -28,6 +31,7 @@ import ru.illine.drinking.ponies.model.dto.BestDayDto
 import ru.illine.drinking.ponies.model.dto.StatisticsDto
 import ru.illine.drinking.ponies.model.dto.StatisticsPointDto
 import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.request.WaterEntryRequest
 import ru.illine.drinking.ponies.model.dto.response.StatisticsResponse
 import ru.illine.drinking.ponies.model.dto.response.StatisticsTodayResponse
 import ru.illine.drinking.ponies.service.statistic.StatisticsService
@@ -44,7 +48,8 @@ import java.time.LocalDateTime
 @SpringIntegrationTest
 @DisplayName("StatisticsController Spring Integration Test")
 class StatisticsControllerTest @Autowired constructor(
-    private val restTemplate: TestRestTemplate
+    private val restTemplate: TestRestTemplate,
+    private val objectMapper: ObjectMapper
 ) {
 
     @MockitoBean
@@ -298,9 +303,6 @@ class StatisticsControllerTest @Autowired constructor(
             }
         }
 
-        private fun jsonBody(consumedAt: Instant, amountMl: Int): String =
-            """{"consumedAt":"$consumedAt","amountMl":$amountMl}"""
-
         /**
          * Returns an instant that is safely in the past relative to the server clock.
          * Margin avoids flakiness against @PastOrPresent caused by clock drift between
@@ -312,7 +314,7 @@ class StatisticsControllerTest @Autowired constructor(
         @DisplayName("valid request - returns 201 and calls service with parsed args")
         fun `returns 201 on valid request`() {
             val consumedAt = pastInstant()
-            val body = jsonBody(consumedAt, 250)
+            val body = objectMapper.writeValueAsString(WaterEntryRequest(consumedAt, 250))
 
             val response = restTemplate.exchange(
                 "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
@@ -331,11 +333,32 @@ class StatisticsControllerTest @Autowired constructor(
         }
 
         @Test
+        @DisplayName("valid request - returns 201 and calls service with parsed args")
+        fun `returns 201 on valid request on null consumerAt`() {
+            val body = objectMapper.writeValueAsString(WaterEntryRequest(null, 250))
+
+            val response = restTemplate.exchange(
+                "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
+            )
+
+            assertEquals(HttpStatus.CREATED, response.statusCode)
+            val userIdCaptor = argumentCaptor<Long>()
+            val consumedAtCaptor = nullableArgumentCaptor<Instant>()
+            val amountCaptor = argumentCaptor<Int>()
+            verify(waterStatisticService).manualRecordEvent(
+                userIdCaptor.capture(), consumedAtCaptor.capture(), amountCaptor.capture()
+            )
+            assertEquals(telegramUser.telegramId, userIdCaptor.firstValue)
+            assertEquals(250, amountCaptor.firstValue)
+            assertNull(consumedAtCaptor.firstValue)
+        }
+
+        @Test
         @DisplayName("service throws IllegalArgumentException - returns 400 (handler maps to BAD_REQUEST)")
         fun `returns 400 on service IllegalArgumentException`() {
             doThrow(IllegalArgumentException("invalid"))
                 .`when`(waterStatisticService).manualRecordEvent(any(), any(), any())
-            val body = jsonBody(pastInstant(), 250)
+            val body = objectMapper.writeValueAsString(WaterEntryRequest(pastInstant(), 250))
 
             val response = restTemplate.exchange(
                 "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
@@ -348,7 +371,7 @@ class StatisticsControllerTest @Autowired constructor(
         @ValueSource(ints = [Int.MIN_VALUE, -1, 0, 49, 1001, Int.MAX_VALUE])
         @DisplayName("amountMl outside [MIN_ML, MAX_ML] - returns 400 (bean validation)")
         fun `returns 400 on amount out of bounds`(amount: Int) {
-            val body = jsonBody(pastInstant(), amount)
+            val body = objectMapper.writeValueAsString(WaterEntryRequest(pastInstant(), amount))
 
             val response = restTemplate.exchange(
                 "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
@@ -361,7 +384,9 @@ class StatisticsControllerTest @Autowired constructor(
         @Test
         @DisplayName("consumedAt in the future - returns 400 (bean validation)")
         fun `returns 400 on future consumedAt`() {
-            val body = jsonBody(Instant.now().plus(Duration.ofHours(1)), 250)
+            val body = objectMapper.writeValueAsString(
+                WaterEntryRequest(Instant.now().plus(Duration.ofHours(1)), 250)
+            )
 
             val response = restTemplate.exchange(
                 "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
@@ -388,7 +413,7 @@ class StatisticsControllerTest @Autowired constructor(
         @Test
         @DisplayName("missing auth header - returns 401")
         fun `returns 401 on missing auth header`() {
-            val body = jsonBody(pastInstant(), 250)
+            val body = objectMapper.writeValueAsString(WaterEntryRequest(pastInstant(), 250))
             val headers = HttpHeaders().apply { contentType = MediaType.APPLICATION_JSON }
 
             val response = restTemplate.exchange(
@@ -403,7 +428,7 @@ class StatisticsControllerTest @Autowired constructor(
         @DisplayName("invalid signature - returns 403")
         fun `returns 403 on invalid signature`() {
             `when`(telegramValidatorService.verifySignature(any())).thenReturn(false)
-            val body = jsonBody(pastInstant(), 250)
+            val body = objectMapper.writeValueAsString(WaterEntryRequest(pastInstant(), 250))
 
             val response = restTemplate.exchange(
                 "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
@@ -421,7 +446,6 @@ class StatisticsControllerTest @Autowired constructor(
             return listOf(
                 null,
                 """{"consumedAt":"$pastIso"}""",
-                """{"amountMl":250}""",
                 """{"consumedAt":"not-a-date","amountMl":250}""",
                 """{}""",
             )

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
@@ -99,7 +99,7 @@ class WaterStatisticServiceTest {
     @Test
     @DisplayName("manualRecordEvent(): saves statistic with source=MANUAL, eventType=YES and converts consumedAt to UTC LocalDateTime")
     fun `manualRecordEvent saves statistic with manual source`() {
-        val externalUserId = 12345L
+        val externalUserId = 1L
         val consumedAt = fixedClock.instant().minus(2, ChronoUnit.HOURS)
         val captor = argumentCaptor<WaterStatisticDto>()
 
@@ -112,6 +112,23 @@ class WaterStatisticServiceTest {
         assertEquals(250, saved.waterAmountMl)
         assertEquals(WaterEntrySourceType.MANUAL, saved.source)
         assertEquals(LocalDateTime.ofInstant(consumedAt, ZoneOffset.UTC), saved.eventTime)
+    }
+
+    @Test
+    @DisplayName("manualRecordEvent(): uses clock's current time when consumedAt is null")
+    fun `manualRecordEvent uses now when consumedAt is null`() {
+        val externalUserId = 1L
+        val captor = argumentCaptor<WaterStatisticDto>()
+
+        service.manualRecordEvent(externalUserId, null, 250)
+
+        verify(waterStatisticAccessService).save(captor.capture())
+        val saved = captor.firstValue
+        assertEquals(externalUserId, saved.telegramUser.externalUserId)
+        assertEquals(AnswerNotificationType.YES, saved.eventType)
+        assertEquals(250, saved.waterAmountMl)
+        assertEquals(WaterEntrySourceType.MANUAL, saved.source)
+        assertEquals(fixedNow, saved.eventTime)
     }
 
     @ParameterizedTest(name = "[{index}] amount={0} ml is accepted (boundary)")


### PR DESCRIPTION
## Summary
- Make `WaterEntryRequest.consumedAt` nullable so clients can omit it or send `null` for the "now" case. Server substitutes `Instant.now()` from injected `Clock` when value is absent, removing client/server clock-skew issues at the `@PastOrPresent` boundary.
- Range validation (future / older than `MAX_DAYS_AGO`) is applied only when `consumedAt` is provided. `null` means "use server time" and needs no checks.
- Add `@Schema` annotations on `WaterEntryRequest` fields: `consumedAt` marked `nullable = true` + `requiredMode = NOT_REQUIRED` with description of null semantics; `amountMl` marked `REQUIRED` with example for symmetry. Class-level `@Schema` description added.

## Test plan
- [x] Unit test: `manualRecordEvent uses now when consumedAt is null` verifies clock substitution and MANUAL source
- [x] Controller integration test: `returns 201 on valid request on null consumerAt` covers happy path with null payload
- [x] Existing tests adjusted: `malformedBodies` no longer treats missing `consumedAt` as malformed; parametrized amount test regression fixed; `nullableArgumentCaptor` used for null capture
- [x] Manual smoke-check via MiniApp by reporter