### PR TITLE
DPTB-137: fix YouTrack version assignment for multi-service projects

### DIFF
--- a/.ansible.gitlab-ci.yml
+++ b/.ansible.gitlab-ci.yml
@@ -9,8 +9,6 @@ build-ansible-image:
   allow_failure: true
   image: docker:27
   rules:
-    - if: '$PIPELINE_TYPE == "version-tag"'
-      when: never
     - when: manual
   before_script:
     - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
@@ -67,8 +65,6 @@ rollback-database:
     LIQUIBASE_COMMAND: "rollback"
     LIQUIBASE_ROLLBACK_TAG: "" # must be overridden when the job will be run
   rules:
-    - if: '$PIPELINE_TYPE == "version-tag"'
-      when: never
     - if: '$CI_COMMIT_BRANCH == "master"'
       when: manual
       variables:

--- a/.common.gitlab-ci.yml
+++ b/.common.gitlab-ci.yml
@@ -2,9 +2,3 @@
   tags:
     - self-hosted
     - docker
-
-.branch-only:
-  rules:
-    - if: '$PIPELINE_TYPE == "version-tag"'
-      when: never
-    - when: on_success

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,10 +13,6 @@ stages:
 
 workflow:
   rules:
-    - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
-      when: always
-      variables:
-        PIPELINE_TYPE: "version-tag"
     - if: '$CI_COMMIT_MESSAGE =~ /\[skip gitlab-ci\]/'
       when: never
     - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH'
@@ -27,15 +23,14 @@ variables:
   GRADLE_JVM_OPTS: "-Xmx4096m"
   GRADLE_OPTS: "-Dorg.gradle.workers.max=4"
   SERVICE_NAME: "dptb"
+  SERVICE_DISPLAY_NAME: "Bot"
   YOUTRACK_PROJECT: "DPTB"
 
 default:
   interruptible: true
 
 generate-version:
-  extends:
-    - .default-tags
-    - .branch-only
+  extends: .default-tags
   stage: pre
   image:
     name: gittools/gitversion:6.5.0
@@ -56,9 +51,7 @@ generate-version:
       - gitversion.properties
 
 test:
-  extends:
-    - .default-tags
-    - .branch-only
+  extends: .default-tags
   stage: test
   image: gradle:8.4-jdk17
   variables:
@@ -97,9 +90,7 @@ test:
         path: "build/jacoco/coverage.xml"
 
 build-jar:
-  extends:
-    - .default-tags
-    - .branch-only
+  extends: .default-tags
   stage: build
   image: gradle:8.4-jdk17
   needs:
@@ -118,9 +109,7 @@ build-jar:
       - build/libs/drinking-ponies.jar
 
 build-image:
-  extends:
-    - .default-tags
-    - .branch-only
+  extends: .default-tags
   stage: build
   image: docker:27
   needs:

--- a/.post.gitlab-ci.yml
+++ b/.post.gitlab-ci.yml
@@ -1,9 +1,3 @@
-variables:
-  YOUTRACK_BUILD_BUNDLE_ID: "146-1"
-  YOUTRACK_BUILD_FIELD_ID: "143-24"
-  YOUTRACK_VERSION_BUNDLE_ID: "128-3"
-  YOUTRACK_VERSION_FIELD_ID: "143-30"
-
 tag-build:
   extends: .default-tags
   stage: post
@@ -63,8 +57,10 @@ update-youtrack-build:
     - apk add --no-cache curl jq
   script:
     - |
-      TAG_NAME="build-${GitVersion_SemVer}"
-      echo "Tag: ${TAG_NAME}"
+      set -o pipefail
+      BUILD_NAME="${SERVICE_DISPLAY_NAME}/build-${GitVersion_SemVer}"
+      VERSION_NAME="${SERVICE_DISPLAY_NAME}/${GitVersion_MajorMinorPatch}"
+      echo "Build: ${BUILD_NAME}, Version: ${VERSION_NAME}"
 
       # Extract issue ID from current commit message
       ISSUE_ID=$(echo "${CI_COMMIT_MESSAGE}" | grep -oE "${YOUTRACK_PROJECT}-[0-9]+" | head -1) || true
@@ -76,44 +72,42 @@ update-youtrack-build:
 
       echo "Found issue: ${ISSUE_ID}"
 
-      # Create build value
-      echo "Creating build value '${TAG_NAME}'"
+      # Find-or-create build value
+      echo "Find-or-create build value '${BUILD_NAME}'"
       HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
         -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
         -H "Content-Type: application/json" \
         "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/build/${YOUTRACK_BUILD_BUNDLE_ID}/values" \
-        -d "{\"name\": \"${TAG_NAME}\"}")
+        -d "{\"name\": \"${BUILD_NAME}\"}")
 
       if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
         echo "Build value created"
       elif [ "${HTTP_CODE}" = "409" ]; then
         echo "Build value already exists"
       else
-        echo "Warning: response ${HTTP_CODE}"
+        echo "Warning: build value response ${HTTP_CODE}"
       fi
 
-      # Find latest unreleased version to assign
-      VERSION_NAME=$(curl -sf \
+      # Find-or-create version value (unreleased)
+      echo "Find-or-create version value '${VERSION_NAME}'"
+      HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
         -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
-        "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/version/${YOUTRACK_VERSION_BUNDLE_ID}/values?fields=name,released" \
-        | jq -r '[.[] | select(.released == false)] | last | .name // empty') || VERSION_NAME=""
+        -H "Content-Type: application/json" \
+        "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/version/${YOUTRACK_VERSION_BUNDLE_ID}/values" \
+        -d "{\"name\": \"${VERSION_NAME}\", \"released\": false}")
 
-      if [ -n "${VERSION_NAME}" ]; then
-        echo "Assigning unreleased version: ${VERSION_NAME}"
+      if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
+        echo "Version value created"
+      elif [ "${HTTP_CODE}" = "409" ]; then
+        echo "Version value already exists"
       else
-        echo "No unreleased version found, skipping version assignment"
+        echo "Warning: version value response ${HTTP_CODE}"
       fi
 
-      # Update issue
+      # Update issue: set both Сборка and Версия
       echo "Updating ${ISSUE_ID}"
+      FIELDS_JSON="[{\"id\": \"${YOUTRACK_BUILD_FIELD_ID}\", \"\$type\": \"SingleBuildIssueCustomField\", \"value\": {\"name\": \"${BUILD_NAME}\"}}, {\"id\": \"${YOUTRACK_VERSION_FIELD_ID}\", \"\$type\": \"SingleVersionIssueCustomField\", \"value\": {\"name\": \"${VERSION_NAME}\"}}]"
 
-      # Build custom fields payload
-      FIELDS_JSON="[{\"id\": \"${YOUTRACK_BUILD_FIELD_ID}\", \"\$type\": \"SingleBuildIssueCustomField\", \"value\": {\"name\": \"${TAG_NAME}\"}}]"
-      if [ -n "${VERSION_NAME}" ]; then
-        FIELDS_JSON="[{\"id\": \"${YOUTRACK_BUILD_FIELD_ID}\", \"\$type\": \"SingleBuildIssueCustomField\", \"value\": {\"name\": \"${TAG_NAME}\"}}, {\"id\": \"${YOUTRACK_VERSION_FIELD_ID}\", \"\$type\": \"SingleVersionIssueCustomField\", \"value\": {\"name\": \"${VERSION_NAME}\"}}]"
-      fi
-
-      # Set fields
       curl -sf -o /dev/null -X POST \
         -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
         -H "Content-Type: application/json" \
@@ -126,7 +120,8 @@ update-youtrack-build:
         "${YOUTRACK_URL}/api/issues/${ISSUE_ID}/comments?fields=id,text,pinned" \
         | jq -r '.[] | select(.pinned == true and (.text | test("GitLab Pipeline:"))) | .id') || PINNED_IDS=""
 
-      for COMMENT_ID in ${PINNED_IDS}; do
+      printf '%s\n' "${PINNED_IDS}" | while IFS= read -r COMMENT_ID; do
+        [ -z "${COMMENT_ID}" ] && continue
         curl -sf -o /dev/null -X POST \
           -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
           -H "Content-Type: application/json" \
@@ -149,9 +144,11 @@ update-youtrack-build:
 close-youtrack-version:
   extends: .default-tags
   stage: post
-  image: alpine:3.21
   needs:
+    - job: generate-version
+      artifacts: true
     - job: tag-build
+  image: alpine:3.21
   rules:
     - if: '$CI_COMMIT_BRANCH == "master"'
       when: on_success
@@ -160,59 +157,73 @@ close-youtrack-version:
     - apk add --no-cache curl jq
   script:
     - |
-      # Find latest unreleased version
+      set -o pipefail
+      VERSION_NAME="${SERVICE_DISPLAY_NAME}/${GitVersion_MajorMinorPatch}"
+      RELEASE_DATE=$(($(date +%s) * 1000))
+      echo "Closing version: ${VERSION_NAME}"
+
+      # Find by name (returns {} if not found, so downstream jq stays safe)
       VERSION_DATA=$(curl -sf \
         -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
         "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/version/${YOUTRACK_VERSION_BUNDLE_ID}/values?fields=id,name,released" \
-        | jq -r '[.[] | select(.released == false)] | last') || { echo "Failed to fetch versions"; exit 1; }
-      VERSION_NAME=$(echo "${VERSION_DATA}" | jq -r '.name // empty')
+        | jq -c --arg n "${VERSION_NAME}" 'first(.[] | select(.name == $n)) // {}') || { echo "Failed to fetch versions"; exit 1; }
       VERSION_ID=$(echo "${VERSION_DATA}" | jq -r '.id // empty')
+      VERSION_RELEASED=$(echo "${VERSION_DATA}" | jq -r '.released // empty')
 
-      if [ -z "${VERSION_ID}" ] || [ "${VERSION_ID}" = "null" ]; then
-        echo "No unreleased version found"
+      if [ -n "${VERSION_ID}" ]; then
+        if [ "${VERSION_RELEASED}" = "true" ]; then
+          echo "Version '${VERSION_NAME}' (${VERSION_ID}) already released, skip"
+          exit 0
+        fi
+        echo "Found '${VERSION_NAME}' (${VERSION_ID}), marking released"
+        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+          -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
+          -H "Content-Type: application/json" \
+          "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/version/${YOUTRACK_VERSION_BUNDLE_ID}/values/${VERSION_ID}" \
+          -d "{\"released\": true, \"releaseDate\": ${RELEASE_DATE}}")
+        if [ "${HTTP_CODE}" = "200" ]; then
+          echo "Version closed"
+        else
+          echo "Warning: close response ${HTTP_CODE}"
+        fi
         exit 0
       fi
 
-      RELEASE_DATE=$(($(date +%s) * 1000))
-      echo "Closing version '${VERSION_NAME}' (${VERSION_ID}): released=true"
-
-      HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-        -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
-        -H "Content-Type: application/json" \
-        "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/version/${YOUTRACK_VERSION_BUNDLE_ID}/values/${VERSION_ID}" \
-        -d "{\"released\": true, \"releaseDate\": ${RELEASE_DATE}}")
-
-      if [ "${HTTP_CODE}" = "200" ]; then
-        echo "Version closed"
-      else
-        echo "Warning: response ${HTTP_CODE}"
-      fi
-
-create-youtrack-version:
-  extends: .default-tags
-  stage: post
-  image: alpine:3.21
-  rules:
-    - if: '$PIPELINE_TYPE == "version-tag"'
-      when: on_success
-    - when: never
-  before_script:
-    - apk add --no-cache curl
-  script:
-    - |
-      VERSION_NAME="${CI_COMMIT_TAG#v}"
-      echo "Creating YouTrack version: ${VERSION_NAME} (unreleased)"
-
+      # Not found (develop pipeline failed earlier or skipped) - create as released
+      echo "Version '${VERSION_NAME}' not found, creating as released"
       HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
         -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
         -H "Content-Type: application/json" \
         "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/version/${YOUTRACK_VERSION_BUNDLE_ID}/values" \
-        -d "{\"name\": \"${VERSION_NAME}\", \"released\": false}")
+        -d "{\"name\": \"${VERSION_NAME}\", \"released\": true, \"releaseDate\": ${RELEASE_DATE}}")
 
       if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
-        echo "Version created"
-      elif [ "${HTTP_CODE}" = "409" ]; then
-        echo "Version already exists"
-      else
-        echo "Warning: response ${HTTP_CODE}"
+        echo "Version created as released"
+        exit 0
       fi
+
+      if [ "${HTTP_CODE}" = "409" ]; then
+        # Race with parallel develop pipeline: someone created unreleased between our find and create. Re-fetch and patch.
+        echo "Race detected (409), re-fetching and patching"
+        VERSION_ID=$(curl -sf \
+          -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
+          "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/version/${YOUTRACK_VERSION_BUNDLE_ID}/values?fields=id,name" \
+          | jq -r --arg n "${VERSION_NAME}" 'first(.[] | select(.name == $n) | .id) // empty')
+        if [ -z "${VERSION_ID}" ]; then
+          echo "Warning: 409 but version still not found"
+          exit 0
+        fi
+        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+          -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
+          -H "Content-Type: application/json" \
+          "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/version/${YOUTRACK_VERSION_BUNDLE_ID}/values/${VERSION_ID}" \
+          -d "{\"released\": true, \"releaseDate\": ${RELEASE_DATE}}")
+        if [ "${HTTP_CODE}" = "200" ]; then
+          echo "Version closed after race resolution"
+        else
+          echo "Warning: post-race close response ${HTTP_CODE}"
+        fi
+        exit 0
+      fi
+
+      echo "Warning: create-as-released response ${HTTP_CODE}"


### PR DESCRIPTION
## Summary
- Fix bug: YouTrack issue's `Версия` field got stale value (e.g. `7.9.0` instead of actual `8.x.0`) on develop merges. Previous logic picked "last unreleased" version which was never refreshed.
- Replace lookup with idempotent find-or-create by `${SERVICE_DISPLAY_NAME}/${GitVersion_MajorMinorPatch}` (e.g. `Bot/8.3.0`). Both `Сборка` and `Версия` derive from CI variables, ready for future multi-service split (Bot, MiniApp, etc).
- `close-youtrack-version` (master) now finds the version by name and marks it released; falls back to create-as-released with race handling (POST 409 -> re-fetch id -> patch).
- Move YouTrack bundle/field IDs from `.post.gitlab-ci.yml` to GitLab group variables (`YOUTRACK_BUILD_BUNDLE_ID`, `YOUTRACK_BUILD_FIELD_ID`, `YOUTRACK_VERSION_BUNDLE_ID`, `YOUTRACK_VERSION_FIELD_ID`), so future repos under the `dptb` group reuse them.
- Cleanup: remove obsolete `create-youtrack-version` job and dead `PIPELINE_TYPE=version-tag` workflow rules; drop now-noop `.branch-only` extends helper.

## Test plan
- [x] GitLab CI pipeline on `bugfix/DPTB-137` succeeds (test + build-jar + build-image): https://gitlab.com/dptb/drinking-ponies-telegram-bot/-/pipelines/2525838152
- [x] Final DevOps review pass (race handling, jq edge cases on empty result, `set -o pipefail` in YouTrack jobs)
- [x] YouTrack-side prerequisites: Subsystem renamed to `Backend-Bot`/`Frontend-MiniApp`; conditional visibility on `Сборка`/`Версия` re-saved under new values (verified via screenshot)

## Post-merge follow-up (manual, owned by reporter)
- After first develop merge: verify YouTrack issue gets `Bot/build-X.Y.Z` in `Сборка` and `Bot/X.Y.Z` in `Версия` (no stale 7.9.0).
- After first master release: verify version is closed (`released=true` with `releaseDate`).
- Re-trigger develop pipeline on the same commit to exercise the 409 idempotency path.