### PR TITLE
DPTB-137: skip YouTrack version fields for ineligible Subsystem

### DIFF
--- a/.post.gitlab-ci.yml
+++ b/.post.gitlab-ci.yml
@@ -72,47 +72,56 @@ update-youtrack-build:
 
       echo "Found issue: ${ISSUE_ID}"
 
-      # Find-or-create build value
-      echo "Find-or-create build value '${BUILD_NAME}'"
-      HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+      # Сборка/Версия are guarded by conditional visibility on Subsystem in {Backend-Bot, Frontend-MiniApp}.
+      # REST rejects the update otherwise (HTTP 400). Skip Сборка/Версия (and bundle find-or-create) for ineligible Subsystem.
+      SUBSYSTEM=$(curl -sf \
         -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
-        -H "Content-Type: application/json" \
-        "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/build/${YOUTRACK_BUILD_BUNDLE_ID}/values" \
-        -d "{\"name\": \"${BUILD_NAME}\"}")
+        "${YOUTRACK_URL}/api/issues/${ISSUE_ID}?fields=customFields(name,value(name))" \
+        | jq -r '.customFields[] | select(.name == "Subsystem") | .value.name // empty') || SUBSYSTEM=""
+      echo "Issue subsystem: ${SUBSYSTEM:-<none>}"
 
-      if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
-        echo "Build value created"
-      elif [ "${HTTP_CODE}" = "409" ]; then
-        echo "Build value already exists"
-      else
-        echo "Warning: build value response ${HTTP_CODE}"
-      fi
+      case "${SUBSYSTEM}" in
+        Backend-Bot|Frontend-MiniApp)
+          echo "Find-or-create build value '${BUILD_NAME}'"
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+            -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
+            -H "Content-Type: application/json" \
+            "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/build/${YOUTRACK_BUILD_BUNDLE_ID}/values" \
+            -d "{\"name\": \"${BUILD_NAME}\"}")
+          if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
+            echo "Build value created"
+          elif [ "${HTTP_CODE}" = "409" ]; then
+            echo "Build value already exists"
+          else
+            echo "Warning: build value response ${HTTP_CODE}"
+          fi
 
-      # Find-or-create version value (unreleased)
-      echo "Find-or-create version value '${VERSION_NAME}'"
-      HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-        -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
-        -H "Content-Type: application/json" \
-        "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/version/${YOUTRACK_VERSION_BUNDLE_ID}/values" \
-        -d "{\"name\": \"${VERSION_NAME}\", \"released\": false}")
+          echo "Find-or-create version value '${VERSION_NAME}'"
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+            -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
+            -H "Content-Type: application/json" \
+            "${YOUTRACK_URL}/api/admin/customFieldSettings/bundles/version/${YOUTRACK_VERSION_BUNDLE_ID}/values" \
+            -d "{\"name\": \"${VERSION_NAME}\", \"released\": false}")
+          if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
+            echo "Version value created"
+          elif [ "${HTTP_CODE}" = "409" ]; then
+            echo "Version value already exists"
+          else
+            echo "Warning: version value response ${HTTP_CODE}"
+          fi
 
-      if [ "${HTTP_CODE}" = "200" ] || [ "${HTTP_CODE}" = "201" ]; then
-        echo "Version value created"
-      elif [ "${HTTP_CODE}" = "409" ]; then
-        echo "Version value already exists"
-      else
-        echo "Warning: version value response ${HTTP_CODE}"
-      fi
-
-      # Update issue: set both Сборка and Версия
-      echo "Updating ${ISSUE_ID}"
-      FIELDS_JSON="[{\"id\": \"${YOUTRACK_BUILD_FIELD_ID}\", \"\$type\": \"SingleBuildIssueCustomField\", \"value\": {\"name\": \"${BUILD_NAME}\"}}, {\"id\": \"${YOUTRACK_VERSION_FIELD_ID}\", \"\$type\": \"SingleVersionIssueCustomField\", \"value\": {\"name\": \"${VERSION_NAME}\"}}]"
-
-      curl -sf -o /dev/null -X POST \
-        -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
-        -H "Content-Type: application/json" \
-        "${YOUTRACK_URL}/api/issues/${ISSUE_ID}" \
-        -d "{\"customFields\": ${FIELDS_JSON}}" || echo "Warning: failed to update fields for ${ISSUE_ID}"
+          echo "Updating ${ISSUE_ID} fields"
+          FIELDS_JSON="[{\"id\": \"${YOUTRACK_BUILD_FIELD_ID}\", \"\$type\": \"SingleBuildIssueCustomField\", \"value\": {\"name\": \"${BUILD_NAME}\"}}, {\"id\": \"${YOUTRACK_VERSION_FIELD_ID}\", \"\$type\": \"SingleVersionIssueCustomField\", \"value\": {\"name\": \"${VERSION_NAME}\"}}]"
+          curl -sf -o /dev/null -X POST \
+            -H "Authorization: Bearer ${YOUTRACK_TOKEN}" \
+            -H "Content-Type: application/json" \
+            "${YOUTRACK_URL}/api/issues/${ISSUE_ID}" \
+            -d "{\"customFields\": ${FIELDS_JSON}}" || echo "Warning: failed to update fields for ${ISSUE_ID}"
+          ;;
+        *)
+          echo "Subsystem '${SUBSYSTEM:-<none>}' is not Backend-Bot/Frontend-MiniApp - skip Сборка/Версия (only pipeline comment will be posted)"
+          ;;
+      esac
 
       # Unpin existing pipeline comments
       PINNED_IDS=$(curl -sf \


### PR DESCRIPTION
## Summary
- Follow-up to #106. After merging the original DPTB-137 fix, observed `Warning: failed to update fields` in `update-youtrack-build` job for the DPTB-137 issue itself (Subsystem=Infra). Сборка/Версия were not populated.
- Root cause: contrary to the assumption baked into #106, YouTrack REST API **does enforce** conditional visibility. POST to `/api/issues/{id}` updating Сборка/Версия for a task whose Subsystem ∉ {Backend-Bot, Frontend-MiniApp} returns HTTP 400 with `«Вы можете обновлять значение поля Сборка, только когда значение поля Subsystem равно Backend-Bot, Frontend-MiniApp»`. Verified empirically: DPTB-137 (Infra) -> HTTP 400; DPTB-138 (Backend-Bot) -> HTTP 200.
- Fix: in `update-youtrack-build`, GET issue Subsystem before update. Only Backend-Bot/Frontend-MiniApp issues run find-or-create + field update; Infra/Design/empty skip the bundle write and field update entirely (avoids polluting the bundle with orphan unreleased values for non-product tasks).
- Pinned pipeline comment is unaffected - still posted regardless of Subsystem.

## Test plan
- [x] Empirical verification of conditional visibility: HTTP 400 on DPTB-137 (Infra) vs HTTP 200 on DPTB-138 (Backend-Bot)
- [x] DevOps reviewer pass on guard logic
- [x] CI pipeline on `bugfix/DPTB-137` succeeds: https://gitlab.com/dptb/drinking-ponies-telegram-bot/-/pipelines/2525895796
- [x] jq filter manually validated against null/missing/valid `value` cases (no stderr noise)

## Post-merge follow-up
- DPTB-137 issue itself (Subsystem=Infra) will NOT get fields populated even after this fix - it's not Backend-Bot. Conditional visibility is honored as designed.
- Verify on the next Backend-Bot merge: pipeline log should show `Issue subsystem: Backend-Bot` followed by `Updating ${ID} fields` without Warning.