### PR TITLE
DPTB-158: pin ci-templates include ref to v1.0.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 include:
   - project: dptb/drinking-ponies-ci-templates
-    ref: develop
+    ref: v1.0.0
     file: dptb-ci.gitlab-ci.yml
   - local: .ansible.gitlab-ci.yml
 


### PR DESCRIPTION
## Summary
- Pin the ci-templates `include` ref from `develop` to the stable `v1.0.0` tag (released in INFRA-16), so the bot pipeline tracks a fixed version instead of the moving branch.

## Test plan
- [x] Pipeline green on feature/DPTB-158 (GitLab mirror)
- [ ] Pipeline green on develop after merge
