### PR TITLE
DPTB-140: unify Telegram user id naming to externalUserId

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptor.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptor.kt
@@ -27,7 +27,7 @@ class AdminAuthInterceptor : HandlerInterceptor {
             return true
         }
 
-        logger.warn("Forbidden admin access for telegramId [{}]", telegramUser.telegramId)
+        logger.warn("Forbidden admin access for externalUserId [{}]", telegramUser.externalUserId)
         response.status = HttpServletResponse.SC_FORBIDDEN
         response.setHeader(AuthErrorType.HEADER_NAME, AuthErrorType.FORBIDDEN_ADMIN.value)
         return false

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptor.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptor.kt
@@ -49,7 +49,7 @@ class TelegramAuthInterceptor(
 
         if (validSignature) {
             val telegramUser = telegramValidatorService.map(initData)
-            val isAdmin = telegramUserAccessService.findIsAdminByExternalUserId(telegramUser.telegramId)
+            val isAdmin = telegramUserAccessService.findIsAdminByExternalUserId(telegramUser.externalUserId)
             val enriched = telegramUser.copy(isAdmin = isAdmin)
             request.setAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE, enriched)
             return true

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/NotificationController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/NotificationController.kt
@@ -28,7 +28,7 @@ class NotificationController(
         @Parameter(hidden = true)
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
     ): NotificationNextResponse {
-        val nextAt = notificationSettingsService.getNextNotificationAt(telegramUser.telegramId)
+        val nextAt = notificationSettingsService.getNextNotificationAt(telegramUser.externalUserId)
         return NotificationNextResponse(nextNotificationAt = nextAt)
     }
 
@@ -37,7 +37,7 @@ class NotificationController(
     fun getPauseState(
         @Parameter(hidden = true)
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
-    ): PauseStateResponse = notificationSettingsService.getPauseState(telegramUser.telegramId)
+    ): PauseStateResponse = notificationSettingsService.getPauseState(telegramUser.externalUserId)
 
     @PutMapping("/pause")
     @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -49,9 +49,9 @@ class NotificationController(
         @RequestParam(name = "minutes", required = true) @Min(0) @Max(300) minutes: Long
     ) {
         if (minutes == 0L) {
-            notificationSettingsService.cancelPause(telegramUser.telegramId)
+            notificationSettingsService.cancelPause(telegramUser.externalUserId)
         } else {
-            notificationSettingsService.pauseNotifications(telegramUser.telegramId, minutes)
+            notificationSettingsService.pauseNotifications(telegramUser.externalUserId, minutes)
         }
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/SettingController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/SettingController.kt
@@ -27,7 +27,7 @@ class SettingController(
         @Parameter(hidden = true)
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
     ): SettingResponse {
-        val settings = notificationSettingsService.getAllSettings(telegramUser.telegramId)
+        val settings = notificationSettingsService.getAllSettings(telegramUser.externalUserId)
         return SettingResponse(
             interval = settings.interval,
             intervalDisplayName = settings.intervalDisplayName,
@@ -51,7 +51,7 @@ class SettingController(
         @Parameter(description = "End time in HH:mm format", example = "08:00", schema = Schema(type = "string", pattern = "HH:mm"))
         @RequestParam(name = "end", required = true) @DateTimeFormat(pattern = "HH:mm") end: LocalTime
     ) {
-        notificationSettingsService.changeQuietMode(telegramUser.telegramId, start, end)
+        notificationSettingsService.changeQuietMode(telegramUser.externalUserId, start, end)
     }
 
     @PutMapping("/timezone")
@@ -63,7 +63,7 @@ class SettingController(
         @Parameter(description = "IANA timezone identifier", example = "Europe/Moscow")
         @RequestParam(name = "timezone", required = true) timezone: String
     ) {
-        notificationSettingsService.changeTimezone(telegramUser.telegramId, timezone)
+        notificationSettingsService.changeTimezone(telegramUser.externalUserId, timezone)
     }
 
     @PutMapping("/interval")
@@ -75,7 +75,7 @@ class SettingController(
         @Parameter(description = "Notification interval enum value", example = "HOUR")
         @RequestParam(name = "interval", required = true) interval: IntervalNotificationType
     ) {
-        notificationSettingsService.changeInterval(telegramUser.telegramId, interval)
+        notificationSettingsService.changeInterval(telegramUser.externalUserId, interval)
     }
 
     @PutMapping("/notification-status")
@@ -87,7 +87,7 @@ class SettingController(
         @Parameter(description = "Enable or disable notifications", example = "true")
         @RequestParam(name = "active", required = true) active: Boolean
     ) {
-        notificationSettingsService.changeNotificationStatus(telegramUser.telegramId, active)
+        notificationSettingsService.changeNotificationStatus(telegramUser.externalUserId, active)
     }
 
     @PutMapping("/goal")
@@ -102,6 +102,6 @@ class SettingController(
         )
         @RequestParam(name = "goalMl", required = true) goalMl: Int
     ) {
-        notificationSettingsService.changeDailyGoal(telegramUser.telegramId, goalMl)
+        notificationSettingsService.changeDailyGoal(telegramUser.externalUserId, goalMl)
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/StatisticsController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/StatisticsController.kt
@@ -35,7 +35,7 @@ class StatisticsController(
         @Parameter(hidden = true)
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
     ): StatisticsTodayResponse {
-        val entries = statisticsService.getToday(telegramUser.telegramId)
+        val entries = statisticsService.getToday(telegramUser.externalUserId)
         return StatisticsTodayResponse(
             entries = entries.map(WaterStatisticBuilder::toWaterEntry),
         )
@@ -59,7 +59,7 @@ class StatisticsController(
         )
         @RequestParam(name = "to", required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
     ): StatisticsResponse =
-        StatisticsBuilder.toResponse(statisticsService.getStatistics(telegramUser.telegramId, from, to))
+        StatisticsBuilder.toResponse(statisticsService.getStatistics(telegramUser.externalUserId, from, to))
 
     @PostMapping("/water")
     @ResponseStatus(HttpStatus.CREATED)
@@ -70,7 +70,7 @@ class StatisticsController(
         @Valid @RequestBody request: WaterEntryRequest,
     ) {
         waterStatisticService.manualRecordEvent(
-            externalUserId = telegramUser.telegramId,
+            externalUserId = telegramUser.externalUserId,
             consumedAt = request.consumedAt,
             amountMl = request.amountMl,
         )

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/UserController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/UserController.kt
@@ -22,7 +22,7 @@ class UserController {
         @Parameter(hidden = true)
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
     ): MeResponse = MeResponse(
-        telegramUserId = telegramUser.telegramId,
+        externalUserId = telegramUser.externalUserId,
         isAdmin = telegramUser.isAdmin,
     )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessService.kt
@@ -11,9 +11,9 @@ interface NotificationAccessService {
 
     fun findAllNotificationSettings(): Set<NotificationSettingDto>
 
-    fun findNotificationSettingByTelegramUserId(telegramUserId: Long): NotificationSettingDto
+    fun findNotificationSettingByExternalUserId(externalUserId: Long): NotificationSettingDto
 
-    fun existsByTelegramUserId(telegramUserId: Long): Boolean
+    fun existsByExternalUserId(externalUserId: Long): Boolean
 
     fun save(
         user: TelegramUserDto,
@@ -22,27 +22,27 @@ interface NotificationAccessService {
     ): TelegramUserDto
 
     fun updateNotificationSettings(
-        telegramUserId: Long, notificationInterval: IntervalNotificationType
+        externalUserId: Long, notificationInterval: IntervalNotificationType
     ): NotificationSettingDto
 
-    fun updateTimeOfLastNotification(telegramUserId: Long, time: LocalDateTime): NotificationSettingDto
+    fun updateTimeOfLastNotification(externalUserId: Long, time: LocalDateTime): NotificationSettingDto
 
     fun updateNotificationSettings(settings: Collection<NotificationSettingDto>): Set<NotificationSettingDto>
 
-    fun isEnabledNotifications(telegramUserId: Long): Boolean
+    fun isEnabledNotifications(externalUserId: Long): Boolean
 
-    fun enableNotifications(telegramUserId: Long)
+    fun enableNotifications(externalUserId: Long)
 
-    fun disableNotifications(telegramUserId: Long)
+    fun disableNotifications(externalUserId: Long)
 
-    fun changeQuietMode(userId: Long, start: LocalTime, end: LocalTime)
+    fun changeQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime)
 
-    fun disableQuietMode(userId: Long)
+    fun disableQuietMode(externalUserId: Long)
 
-    fun changeTimezone(telegramUserId: Long, timezone: String)
+    fun changeTimezone(externalUserId: Long, timezone: String)
 
-    fun setPause(telegramUserId: Long, pauseUntil: LocalDateTime?): NotificationSettingDto
+    fun setPause(externalUserId: Long, pauseUntil: LocalDateTime?): NotificationSettingDto
 
-    fun updateDailyGoal(telegramUserId: Long, goalMl: Int)
+    fun updateDailyGoal(externalUserId: Long, goalMl: Int)
 
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
@@ -44,10 +44,10 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun findNotificationSettingByTelegramUserId(telegramUserId: Long): NotificationSettingDto {
-        logger.debug("Finding a Notification by telegramUserId [$telegramUserId]")
+    override fun findNotificationSettingByExternalUserId(externalUserId: Long): NotificationSettingDto {
+        logger.debug("Finding a Notification by externalUserId [$externalUserId]")
 
-        return requireSettings(telegramUserId).let {
+        return requireSettings(externalUserId).let {
             val user = TelegramUserBuilder.toDto(it.telegramUser)
             val chat = TelegramChatBuilder.toDto(it.telegramChat, user)
             NotificationSettingBuilder.toDto(it, user, chat)
@@ -55,9 +55,9 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun existsByTelegramUserId(telegramUserId: Long): Boolean {
-        logger.debug("Does a notification exist for the telegramUserId: [$telegramUserId]?")
-        return userRepository.existsByExternalUserId(telegramUserId)
+    override fun existsByExternalUserId(externalUserId: Long): Boolean {
+        logger.debug("Does a notification exist for the externalUserId: [$externalUserId]?")
+        return userRepository.existsByExternalUserId(externalUserId)
     }
 
     @Transactional
@@ -92,11 +92,11 @@ class NotificationAccessServiceImpl(
 
     @Transactional
     override fun updateNotificationSettings(
-        telegramUserId: Long, notificationInterval: IntervalNotificationType
+        externalUserId: Long, notificationInterval: IntervalNotificationType
     ): NotificationSettingDto {
-        logger.debug("The Notification Settings will be updated for an existed entity by id: [${telegramUserId}]")
+        logger.debug("The Notification Settings will be updated for an existed entity by id: [${externalUserId}]")
 
-        val settings = requireSettings(telegramUserId)
+        val settings = requireSettings(externalUserId)
 
         if (settings.notificationInterval != notificationInterval) {
             // Reset timer so the new interval counts from now, not from the last notification time.
@@ -117,16 +117,16 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional
-    override fun enableNotifications(telegramUserId: Long) {
-        logger.debug("A notification settings will be enabled (enabled = true) by telegramUserId [$telegramUserId]")
-        settingRepository.switchEnabled(telegramUserId, true)
+    override fun enableNotifications(externalUserId: Long) {
+        logger.debug("A notification settings will be enabled (enabled = true) by externalUserId [$externalUserId]")
+        settingRepository.switchEnabled(externalUserId, true)
     }
 
     @Transactional
-    override fun disableNotifications(telegramUserId: Long) {
-        logger.debug("A notification settings will be disabled (enabled = false) by telegramUserId [$telegramUserId]")
-        settingRepository.clearPause(telegramUserId)
-        settingRepository.switchEnabled(telegramUserId, false)
+    override fun disableNotifications(externalUserId: Long) {
+        logger.debug("A notification settings will be disabled (enabled = false) by externalUserId [$externalUserId]")
+        settingRepository.clearPause(externalUserId)
+        settingRepository.switchEnabled(externalUserId, false)
     }
 
     @Transactional
@@ -149,10 +149,10 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional
-    override fun updateTimeOfLastNotification(telegramUserId: Long, time: LocalDateTime): NotificationSettingDto {
-        logger.debug("Updating a time of last notification by telegramUserId [$telegramUserId]")
+    override fun updateTimeOfLastNotification(externalUserId: Long, time: LocalDateTime): NotificationSettingDto {
+        logger.debug("Updating a time of last notification by externalUserId [$externalUserId]")
 
-        val setting = requireSettings(telegramUserId)
+        val setting = requireSettings(externalUserId)
 
         return setting
             .apply {
@@ -168,41 +168,41 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun isEnabledNotifications(telegramUserId: Long): Boolean {
-        logger.debug("Checking if notifications are active by telegramUserId: [$telegramUserId]")
-        return settingRepository.isEnabledByTelegramUserId(telegramUserId)
+    override fun isEnabledNotifications(externalUserId: Long): Boolean {
+        logger.debug("Checking if notifications are active by externalUserId: [$externalUserId]")
+        return settingRepository.isEnabledByExternalUserId(externalUserId)
     }
 
     @Transactional
-    override fun changeQuietMode(userId: Long, start: LocalTime, end: LocalTime) {
-        logger.debug("The quiet mod will be updated for a user [{}], start time: [{}], end time: [{}]", userId, start, end)
-        settingRepository.clearPause(userId)
-        settingRepository.updateQuietMode(userId, start, end)
+    override fun changeQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime) {
+        logger.debug("The quiet mod will be updated for a user [{}], start time: [{}], end time: [{}]", externalUserId, start, end)
+        settingRepository.clearPause(externalUserId)
+        settingRepository.updateQuietMode(externalUserId, start, end)
     }
 
     @Transactional
-    override fun disableQuietMode(userId: Long) {
-        logger.debug("The quiet mod will be disabled for a user [$userId]")
-        settingRepository.clearPause(userId)
-        settingRepository.updateQuietMode(userId)
+    override fun disableQuietMode(externalUserId: Long) {
+        logger.debug("The quiet mod will be disabled for a user [$externalUserId]")
+        settingRepository.clearPause(externalUserId)
+        settingRepository.updateQuietMode(externalUserId)
     }
 
     @Transactional
-    override fun changeTimezone(telegramUserId: Long, timezone: String) {
-        logger.debug("Changing timezone for user [$telegramUserId] to [$timezone]")
+    override fun changeTimezone(externalUserId: Long, timezone: String) {
+        logger.debug("Changing timezone for user [$externalUserId] to [$timezone]")
         val user = requireNotNull(
-            userRepository.findByExternalUserId(telegramUserId),
-            { "Not found a Telegram User by telegramUserId [$telegramUserId]" }
+            userRepository.findByExternalUserId(externalUserId),
+            { "Not found a Telegram User by externalUserId [$externalUserId]" }
         )
         user.userTimeZone = timezone
         userRepository.save(user)
     }
 
     @Transactional
-    override fun setPause(telegramUserId: Long, pauseUntil: LocalDateTime?): NotificationSettingDto {
-        logger.debug("Setting pause for telegramUserId [$telegramUserId] to [$pauseUntil]")
+    override fun setPause(externalUserId: Long, pauseUntil: LocalDateTime?): NotificationSettingDto {
+        logger.debug("Setting pause for externalUserId [$externalUserId] to [$pauseUntil]")
 
-        val setting = requireSettings(telegramUserId)
+        val setting = requireSettings(externalUserId)
         val now = LocalDateTime.now(clock)
 
         return setting
@@ -229,14 +229,14 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional
-    override fun updateDailyGoal(telegramUserId: Long, goalMl: Int) {
-        logger.debug("Updating daily goal for telegramUserId [$telegramUserId] to [$goalMl] ml")
-        settingRepository.updateDailyGoal(telegramUserId, goalMl)
+    override fun updateDailyGoal(externalUserId: Long, goalMl: Int) {
+        logger.debug("Updating daily goal for externalUserId [$externalUserId] to [$goalMl] ml")
+        settingRepository.updateDailyGoal(externalUserId, goalMl)
     }
 
-    private fun requireSettings(telegramUserId: Long): NotificationSettingEntity =
-        settingRepository.findByTelegramUser_ExternalUserId(telegramUserId)
+    private fun requireSettings(externalUserId: Long): NotificationSettingEntity =
+        settingRepository.findByTelegramUser_ExternalUserId(externalUserId)
             ?: throw NotificationSettingsNotFoundException(
-                "Not found a Notification Setting by telegramUserId [$telegramUserId]"
+                "Not found a Notification Setting by externalUserId [$externalUserId]"
             )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/NotificationSettingRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/NotificationSettingRepository.kt
@@ -20,7 +20,7 @@ interface NotificationSettingRepository : JpaRepository<NotificationSettingEntit
         """,
         nativeQuery = true
     )
-    fun isEnabledByTelegramUserId(@Param("externalUserId") externalUserId: Long): Boolean
+    fun isEnabledByExternalUserId(@Param("externalUserId") externalUserId: Long): Boolean
 
     @Modifying
     @Query(

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/TelegramUserRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/TelegramUserRepository.kt
@@ -5,9 +5,9 @@ import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 
 interface TelegramUserRepository : JpaRepository<TelegramUserEntity, Long> {
 
-    fun findByExternalUserId(telegramUserId: Long): TelegramUserEntity?
+    fun findByExternalUserId(externalUserId: Long): TelegramUserEntity?
 
-    fun findAllByExternalUserIdIn(telegramUserId: Collection<Long>): Set<TelegramUserEntity>
+    fun findAllByExternalUserIdIn(externalUserId: Collection<Long>): Set<TelegramUserEntity>
 
-    fun existsByExternalUserId(telegramUserId: Long): Boolean
+    fun existsByExternalUserId(externalUserId: Long): Boolean
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/TelegramUserDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/TelegramUserDto.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class TelegramUserDto(
     @JsonProperty("id")
-    val telegramId: Long,
+    val externalUserId: Long,
     @JsonProperty("first_name")
     val firstName: String?,
     @JsonProperty("last_name")

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/MeResponse.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/MeResponse.kt
@@ -1,11 +1,15 @@
 package ru.illine.drinking.ponies.model.dto.response
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "Current user identity")
 data class MeResponse(
+    // Kotlin field unified to externalUserId across the codebase (DPTB-140).
+    // The JSON key is intentionally kept as "telegramUserId" - it is the public /users/me contract consumed by the MiniApp.
+    @JsonProperty("telegramUserId")
     @Schema(description = "Telegram user id", example = "123456789")
-    val telegramUserId: Long,
+    val externalUserId: Long,
     @Schema(description = "Whether the user has admin privileges", example = "false")
     val isAdmin: Boolean,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategy.kt
@@ -32,7 +32,7 @@ class SnoozeApplyReplyButtonStrategy(
             callbackQuery.message.messageId
         )
 
-        val userId = callbackQuery.from.id
+        val externalUserId = callbackQuery.from.id
         val chatId = callbackQuery.message.chatId
         val queryData = callbackQuery.data
 
@@ -40,12 +40,12 @@ class SnoozeApplyReplyButtonStrategy(
 
         logger.info(
             "A telegram user [{}] for telegram chat [{}] will snooze notification for [{}] minutes",
-            userId,
+            externalUserId,
             chatId,
             snoozeType.minutes
         )
 
-        val notificationSetting = notificationSettingsService.getNotificationSettings(userId)
+        val notificationSetting = notificationSettingsService.getNotificationSettings(externalUserId)
         val nextNotificationTime =
             TimeHelper.nextNotificationTimeByNow(
                 clock,
@@ -53,7 +53,7 @@ class SnoozeApplyReplyButtonStrategy(
                 snoozeType.minutes
             )
 
-        notificationSettingsService.resetNotificationTimer(userId, nextNotificationTime)
+        notificationSettingsService.resetNotificationTimer(externalUserId, nextNotificationTime)
             .also { setting ->
                 runCatching {
                     waterStatisticService.recordEvent(setting.telegramUser, AnswerNotificationType.SNOOZE)

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategy.kt
@@ -32,7 +32,7 @@ class WaterAmountApplyReplyButtonStrategy(
             callbackQuery.message.messageId
         )
 
-        val userId = callbackQuery.from.id
+        val externalUserId = callbackQuery.from.id
         val chatId = callbackQuery.message.chatId
         val queryData = callbackQuery.data
 
@@ -44,12 +44,12 @@ class WaterAmountApplyReplyButtonStrategy(
 
         logger.info(
             "A telegram user [{}] for telegram chat [{}] drank [{}] ml of water",
-            userId,
+            externalUserId,
             chatId,
             waterAmountType.amountMl
         )
 
-        notificationSettingsService.resetNotificationTimer(userId, LocalDateTime.now(clock))
+        notificationSettingsService.resetNotificationTimer(externalUserId, LocalDateTime.now(clock))
             .also { setting ->
                 runCatching {
                     waterStatisticService.recordEvent(

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsService.kt
@@ -10,36 +10,36 @@ import java.time.LocalTime
 
 interface NotificationSettingsService {
 
-    fun getAllSettings(telegramUserId: Long): SettingDto
+    fun getAllSettings(externalUserId: Long): SettingDto
 
-    fun getNextNotificationAt(telegramUserId: Long): Instant
+    fun getNextNotificationAt(externalUserId: Long): Instant
 
-    fun getNotificationSettings(telegramUserId: Long): NotificationSettingDto
+    fun getNotificationSettings(externalUserId: Long): NotificationSettingDto
 
     fun getAllNotificationSettings(): Collection<NotificationSettingDto>
 
-    fun getQuietMode(telegramUserId: Long): Pair<LocalTime, LocalTime>
+    fun getQuietMode(externalUserId: Long): Pair<LocalTime, LocalTime>
 
-    fun resetNotificationTimer(telegramUserId: Long, time: LocalDateTime): NotificationSettingDto
+    fun resetNotificationTimer(externalUserId: Long, time: LocalDateTime): NotificationSettingDto
 
-    fun changeInterval(telegramUserId: Long, notificationInterval: IntervalNotificationType): NotificationSettingDto
+    fun changeInterval(externalUserId: Long, notificationInterval: IntervalNotificationType): NotificationSettingDto
 
-    fun changeQuietMode(userId: Long, start: LocalTime, end: LocalTime)
+    fun changeQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime)
 
-    fun disableQuietMode(userId: Long)
+    fun disableQuietMode(externalUserId: Long)
 
-    fun isEnabledNotifications(telegramUserId: Long): Boolean
+    fun isEnabledNotifications(externalUserId: Long): Boolean
 
-    fun changeNotificationStatus(telegramUserId: Long, active: Boolean)
+    fun changeNotificationStatus(externalUserId: Long, active: Boolean)
 
-    fun changeTimezone(telegramUserId: Long, timezone: String)
+    fun changeTimezone(externalUserId: Long, timezone: String)
 
-    fun pauseNotifications(telegramUserId: Long, minutes: Long)
+    fun pauseNotifications(externalUserId: Long, minutes: Long)
 
-    fun cancelPause(telegramUserId: Long)
+    fun cancelPause(externalUserId: Long)
 
-    fun getPauseState(telegramUserId: Long): PauseStateResponse
+    fun getPauseState(externalUserId: Long): PauseStateResponse
 
-    fun changeDailyGoal(telegramUserId: Long, goalMl: Int)
+    fun changeDailyGoal(externalUserId: Long, goalMl: Int)
 
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
@@ -27,15 +27,15 @@ class NotificationServiceImpl(
             TelegramMessageConstants.START_GREETING_MESSAGE.format(messageContext.user().userName)
         ).apply { sender.execute(this) }
 
-        val userId = messageContext.user().id
+        val externalUserId = messageContext.user().id
         val chatId = messageContext.chatId()
 
-        val setting = notificationAccessService.existsByTelegramUserId(userId).check(
+        val setting = notificationAccessService.existsByExternalUserId(externalUserId).check(
             ifTrue = {
-                notificationAccessService.findNotificationSettingByTelegramUserId(userId)
+                notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
             },
             ifFalse = {
-                createNewUser(userId, chatId)
+                createNewUser(externalUserId, chatId)
             }
         )
 
@@ -46,14 +46,14 @@ class NotificationServiceImpl(
     }
 
     private fun createNewUser(
-        userId: Long,
+        externalUserId: Long,
         chatId: Long
     ): NotificationSettingDto {
-        val user = TelegramUserDto.create(userId)
+        val user = TelegramUserDto.create(externalUserId)
         val chat = TelegramChatDto.create(chatId, user)
         val setting = NotificationSettingDto.create(user, chat)
 
         notificationAccessService.save(user, chat, setting)
-        return notificationAccessService.findNotificationSettingByTelegramUserId(userId)
+        return notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSettingsServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSettingsServiceImpl.kt
@@ -23,28 +23,28 @@ class NotificationSettingsServiceImpl(
 
     private val logger = LoggerFactory.getLogger("SERVICE")
 
-    override fun getNextNotificationAt(telegramUserId: Long): Instant {
-        logger.info("Getting next notification time for telegram user [$telegramUserId]")
-        val settings = notificationAccessService.findNotificationSettingByTelegramUserId(telegramUserId)
+    override fun getNextNotificationAt(externalUserId: Long): Instant {
+        logger.info("Getting next notification time for telegram user [$externalUserId]")
+        val settings = notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
         return notificationTimeService.calculateNextNotificationAt(settings)
     }
 
-    override fun getAllSettings(telegramUserId: Long): SettingDto {
-        logger.info("Getting all notification settings for telegram user [$telegramUserId]")
+    override fun getAllSettings(externalUserId: Long): SettingDto {
+        logger.info("Getting all notification settings for telegram user [$externalUserId]")
 
-        val active = notificationAccessService.isEnabledNotifications(telegramUserId)
+        val active = notificationAccessService.isEnabledNotifications(externalUserId)
         if (!active) {
-            logger.debug("Not enabled notifications for telegramUserId [$telegramUserId], returning empty settings")
+            logger.debug("Not enabled notifications for externalUserId [$externalUserId], returning empty settings")
             return SettingDto(notificationActive = false)
         }
 
-        logger.debug("Settings for telegramUserId [$telegramUserId] has been enabled")
-        return getNotificationSettings(telegramUserId).let { SettingBuilder.toDto(it) }
+        logger.debug("Settings for externalUserId [$externalUserId] has been enabled")
+        return getNotificationSettings(externalUserId).let { SettingBuilder.toDto(it) }
     }
 
-    override fun getNotificationSettings(telegramUserId: Long): NotificationSettingDto {
-        logger.info("Getting notification settings for telegram user [$telegramUserId]")
-        return notificationAccessService.findNotificationSettingByTelegramUserId(telegramUserId)
+    override fun getNotificationSettings(externalUserId: Long): NotificationSettingDto {
+        logger.info("Getting notification settings for telegram user [$externalUserId]")
+        return notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
     }
 
     override fun getAllNotificationSettings(): Collection<NotificationSettingDto> {
@@ -52,91 +52,91 @@ class NotificationSettingsServiceImpl(
         return notificationAccessService.findAllNotificationSettings()
     }
 
-    override fun getQuietMode(telegramUserId: Long): Pair<LocalTime, LocalTime> {
-        logger.info("Getting quiet mode for telegram user [$telegramUserId]")
-        val settings = notificationAccessService.findNotificationSettingByTelegramUserId(telegramUserId)
+    override fun getQuietMode(externalUserId: Long): Pair<LocalTime, LocalTime> {
+        logger.info("Getting quiet mode for telegram user [$externalUserId]")
+        val settings = notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
         val start =
             checkNotNull(settings.quietModeStart) {
-                "Quiet mode start is not configured for user [$telegramUserId]"
+                "Quiet mode start is not configured for user [$externalUserId]"
             }
         val end =
             checkNotNull(settings.quietModeEnd) {
-                "Quiet mode end is not configured for user [$telegramUserId]"
+                "Quiet mode end is not configured for user [$externalUserId]"
             }
         return start to end
     }
 
-    override fun resetNotificationTimer(telegramUserId: Long, time: LocalDateTime): NotificationSettingDto {
-        logger.info("Resetting notification timer for telegram user [$telegramUserId] to [$time]")
-        return notificationAccessService.updateTimeOfLastNotification(telegramUserId, time)
+    override fun resetNotificationTimer(externalUserId: Long, time: LocalDateTime): NotificationSettingDto {
+        logger.info("Resetting notification timer for telegram user [$externalUserId] to [$time]")
+        return notificationAccessService.updateTimeOfLastNotification(externalUserId, time)
     }
 
     override fun changeInterval(
-        telegramUserId: Long,
+        externalUserId: Long,
         notificationInterval: IntervalNotificationType
     ): NotificationSettingDto {
-        logger.info("Changing notification interval for telegram user [$telegramUserId] to [$notificationInterval]")
-        return notificationAccessService.updateNotificationSettings(telegramUserId, notificationInterval)
+        logger.info("Changing notification interval for telegram user [$externalUserId] to [$notificationInterval]")
+        return notificationAccessService.updateNotificationSettings(externalUserId, notificationInterval)
     }
 
-    override fun changeQuietMode(userId: Long, start: LocalTime, end: LocalTime) {
-        logger.info("Change time of quiet mode for telegram user [$userId], start: [$start], end: [$end]")
+    override fun changeQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime) {
+        logger.info("Change time of quiet mode for telegram user [$externalUserId], start: [$start], end: [$end]")
         require(start != end) { "Start must be before end" }
-        notificationAccessService.changeQuietMode(userId, start, end)
+        notificationAccessService.changeQuietMode(externalUserId, start, end)
     }
 
-    override fun disableQuietMode(userId: Long) {
-        logger.info("Disabling quiet mode for user [$userId]")
-        notificationAccessService.disableQuietMode(userId)
+    override fun disableQuietMode(externalUserId: Long) {
+        logger.info("Disabling quiet mode for user [$externalUserId]")
+        notificationAccessService.disableQuietMode(externalUserId)
     }
 
-    override fun isEnabledNotifications(telegramUserId: Long): Boolean {
-        logger.info("Checking if notifications are enabled for telegram user [$telegramUserId]")
-        return notificationAccessService.isEnabledNotifications(telegramUserId)
+    override fun isEnabledNotifications(externalUserId: Long): Boolean {
+        logger.info("Checking if notifications are enabled for telegram user [$externalUserId]")
+        return notificationAccessService.isEnabledNotifications(externalUserId)
     }
 
-    override fun changeNotificationStatus(telegramUserId: Long, active: Boolean) {
-        logger.info("Changing notification status for telegram user [$telegramUserId] to [$active]")
+    override fun changeNotificationStatus(externalUserId: Long, active: Boolean) {
+        logger.info("Changing notification status for telegram user [$externalUserId] to [$active]")
         if (active) {
-            notificationAccessService.enableNotifications(telegramUserId)
+            notificationAccessService.enableNotifications(externalUserId)
         } else {
-            notificationAccessService.disableNotifications(telegramUserId)
+            notificationAccessService.disableNotifications(externalUserId)
         }
     }
 
-    override fun changeTimezone(telegramUserId: Long, timezone: String) {
-        logger.info("Changing timezone for telegram user [$telegramUserId] to [$timezone]")
+    override fun changeTimezone(externalUserId: Long, timezone: String) {
+        logger.info("Changing timezone for telegram user [$externalUserId] to [$timezone]")
         try {
             ZoneId.of(timezone)
         } catch (e: Exception) {
             throw IllegalArgumentException("Invalid timezone: $timezone", e)
         }
-        notificationAccessService.changeTimezone(telegramUserId, timezone)
+        notificationAccessService.changeTimezone(externalUserId, timezone)
     }
 
-    override fun pauseNotifications(telegramUserId: Long, minutes: Long) {
-        logger.info("Pausing notifications for telegram user [$telegramUserId] for [$minutes] minutes")
+    override fun pauseNotifications(externalUserId: Long, minutes: Long) {
+        logger.info("Pausing notifications for telegram user [$externalUserId] for [$minutes] minutes")
         require(minutes > 0) { "Pause duration must be positive: $minutes" }
         val pauseUntil = LocalDateTime.now(clock).plusMinutes(minutes)
-        notificationAccessService.setPause(telegramUserId, pauseUntil)
+        notificationAccessService.setPause(externalUserId, pauseUntil)
     }
 
-    override fun cancelPause(telegramUserId: Long) {
-        logger.info("Cancelling pause for telegram user [$telegramUserId]")
-        notificationAccessService.setPause(telegramUserId, null)
+    override fun cancelPause(externalUserId: Long) {
+        logger.info("Cancelling pause for telegram user [$externalUserId]")
+        notificationAccessService.setPause(externalUserId, null)
     }
 
-    override fun changeDailyGoal(telegramUserId: Long, goalMl: Int) {
-        logger.info("Changing daily goal for telegram user [$telegramUserId] to [$goalMl] ml")
+    override fun changeDailyGoal(externalUserId: Long, goalMl: Int) {
+        logger.info("Changing daily goal for telegram user [$externalUserId] to [$goalMl] ml")
         require(goalMl in TelegramDailyGoalConstants.ALLOWED_VALUES_ML) {
             "Daily goal must be one of ${TelegramDailyGoalConstants.ALLOWED_VALUES_ML} ml, got: $goalMl"
         }
-        notificationAccessService.updateDailyGoal(telegramUserId, goalMl)
+        notificationAccessService.updateDailyGoal(externalUserId, goalMl)
     }
 
-    override fun getPauseState(telegramUserId: Long): PauseStateResponse {
-        logger.info("Getting pause state for telegram user [$telegramUserId]")
-        val settings = notificationAccessService.findNotificationSettingByTelegramUserId(telegramUserId)
+    override fun getPauseState(externalUserId: Long): PauseStateResponse {
+        logger.info("Getting pause state for telegram user [$externalUserId]")
+        val settings = notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
         val now = LocalDateTime.now(clock)
         val activePauseUntil = settings.pauseUntil
             ?.takeIf { it.isAfter(now) }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsService.kt
@@ -6,8 +6,8 @@ import java.time.LocalDate
 
 interface StatisticsService {
 
-    fun getToday(telegramUserId: Long): List<WaterStatisticDto>
+    fun getToday(externalUserId: Long): List<WaterStatisticDto>
 
-    fun getStatistics(telegramUserId: Long, from: LocalDate, to: LocalDate): StatisticsDto
+    fun getStatistics(externalUserId: Long, from: LocalDate, to: LocalDate): StatisticsDto
 
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/impl/StatisticsServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/impl/StatisticsServiceImpl.kt
@@ -31,22 +31,22 @@ class StatisticsServiceImpl(
     private val logger = LoggerFactory.getLogger("SERVICE")
 
     // Returns RAW events (unfiltered by YES) for the home widget's per-event diary.
-    override fun getToday(telegramUserId: Long): List<WaterStatisticDto> {
-        logger.debug("Getting today entries for telegram user [{}]", telegramUserId)
+    override fun getToday(externalUserId: Long): List<WaterStatisticDto> {
+        logger.debug("Getting today entries for telegram user [{}]", externalUserId)
 
-        val ctx = userTimeContext(telegramUserId)
+        val ctx = userTimeContext(externalUserId)
         val (startInclusive, endExclusive) =
             StatisticsPeriodHelper.localDayBoundsToUtc(ctx.today, ctx.today.plusDays(1), ctx.zone)
 
-        return waterStatisticAccessService.findByUserAndEventTimeBetween(telegramUserId, startInclusive, endExclusive)
+        return waterStatisticAccessService.findByUserAndEventTimeBetween(externalUserId, startInclusive, endExclusive)
     }
 
-    override fun getStatistics(telegramUserId: Long, from: LocalDate, to: LocalDate): StatisticsDto {
-        logger.debug("Getting [{} - {}] statistics for telegram user [{}]", from, to, telegramUserId)
+    override fun getStatistics(externalUserId: Long, from: LocalDate, to: LocalDate): StatisticsDto {
+        logger.debug("Getting [{} - {}] statistics for telegram user [{}]", from, to, externalUserId)
 
         require(from <= to) { "Invalid parameter: 'from' must be before or equal to 'to'" }
 
-        val ctx = userTimeContext(telegramUserId)
+        val ctx = userTimeContext(externalUserId)
 
         require(from <= ctx.today) { "Invalid parameter: 'from' must not be in the future" }
 
@@ -60,7 +60,7 @@ class StatisticsServiceImpl(
         val fetchStart = minOf(from, streakWindowStart)
         val fetchEndExclusive = maxOf(to, ctx.today).plusDays(1)
 
-        val allEvents = fetchYesEvents(telegramUserId, fetchStart, fetchEndExclusive, ctx.zone)
+        val allEvents = fetchYesEvents(externalUserId, fetchStart, fetchEndExclusive, ctx.zone)
         val byDate = StatisticsAggregator.sumByLocalDate(allEvents, ctx.zone)
 
         // Points are built from events in the requested [from..to] window only.
@@ -87,7 +87,7 @@ class StatisticsServiceImpl(
                 ctx.settings.dailyGoalMl
             )
         )
-        val firstEntryAt = waterStatisticAccessService.findEarliestEventTimeByUser(telegramUserId)?.toUtcInstant()
+        val firstEntryAt = waterStatisticAccessService.findEarliestEventTimeByUser(externalUserId)?.toUtcInstant()
 
         return StatisticsDto(
             points = points,
@@ -101,18 +101,18 @@ class StatisticsServiceImpl(
     }
 
     private fun fetchYesEvents(
-        telegramUserId: Long,
+        externalUserId: Long,
         startLocal: LocalDate,
         endLocalExclusive: LocalDate,
         zone: ZoneId
     ): List<WaterStatisticDto> {
         val (startUtc, endUtc) = StatisticsPeriodHelper.localDayBoundsToUtc(startLocal, endLocalExclusive, zone)
-        return waterStatisticAccessService.findByUserAndEventTimeBetween(telegramUserId, startUtc, endUtc)
+        return waterStatisticAccessService.findByUserAndEventTimeBetween(externalUserId, startUtc, endUtc)
             .filter { it.eventType == AnswerNotificationType.YES }
     }
 
-    private fun userTimeContext(telegramUserId: Long): UserTimeContext {
-        val settings = notificationAccessService.findNotificationSettingByTelegramUserId(telegramUserId)
+    private fun userTimeContext(externalUserId: Long): UserTimeContext {
+        val settings = notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
         val zone = ZoneId.of(settings.telegramUser.userTimeZone)
         val today = LocalDate.now(clock.withZone(zone))
         return UserTimeContext(settings, zone, today)

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorIntegrationTest.kt
@@ -55,7 +55,7 @@ class AdminAuthInterceptorIntegrationTest @Autowired constructor(
     private val NON_ADMIN_USER_ID = 2L
 
     private val telegramUser = TelegramUserDto(
-        telegramId = ADMIN_USER_ID,
+        externalUserId = ADMIN_USER_ID,
         firstName = "First Name",
         lastName = null,
         username = "username"
@@ -91,7 +91,7 @@ class AdminAuthInterceptorIntegrationTest @Autowired constructor(
         @Test
         @DisplayName("non-admin user - returns 403 with X-Auth-Error-Code forbidden_admin")
         fun `non-admin user returns 403 with forbidden_admin header`() {
-            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(telegramId = NON_ADMIN_USER_ID))
+            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
 
             val response = restTemplate.exchange(
                 "/systems/admin-test", HttpMethod.GET, HttpEntity<Void>(buildHeaders()), Void::class.java

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorTest.kt
@@ -26,7 +26,7 @@ class AdminAuthInterceptorTest {
     private lateinit var interceptor: AdminAuthInterceptor
 
     private val adminUser = TelegramUserDto(
-        telegramId = 1L,
+        externalUserId = 1L,
         firstName = "Admin",
         lastName = null,
         username = null,
@@ -34,7 +34,7 @@ class AdminAuthInterceptorTest {
     )
 
     private val nonAdminUser = TelegramUserDto(
-        telegramId = 2L,
+        externalUserId = 2L,
         firstName = "User",
         lastName = null,
         username = null,

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptorTest.kt
@@ -108,7 +108,7 @@ class TelegramAuthInterceptorTest {
     @DisplayName("preHandle(): valid signature - enriches isAdmin=true and sets telegramUser attribute")
     fun `preHandle valid signature enriches isAdmin true`() {
         val initData = "valid-init-data"
-        val telegramUser = TelegramUserDto(telegramId = 1L, firstName = "Test", lastName = null, username = null)
+        val telegramUser = TelegramUserDto(externalUserId = 1L, firstName = "Test", lastName = null, username = null)
         `when`(request.method).thenReturn("POST")
         `when`(request.getHeader(headerName)).thenReturn(initData)
         `when`(validatorService.verifySignature(any())).thenReturn(true)
@@ -129,7 +129,7 @@ class TelegramAuthInterceptorTest {
     @DisplayName("preHandle(): valid signature - enriches isAdmin=false when access service returns false")
     fun `preHandle valid signature enriches isAdmin false`() {
         val initData = "valid-init-data"
-        val telegramUser = TelegramUserDto(telegramId = 2L, firstName = "Test", lastName = null, username = null)
+        val telegramUser = TelegramUserDto(externalUserId = 2L, firstName = "Test", lastName = null, username = null)
         `when`(request.method).thenReturn("POST")
         `when`(request.getHeader(headerName)).thenReturn(initData)
         `when`(validatorService.verifySignature(any())).thenReturn(true)

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/NotificationControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/NotificationControllerTest.kt
@@ -194,7 +194,7 @@ class NotificationControllerTest @Autowired constructor(
             )
 
             assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
-            verify(notificationSettingsService).pauseNotifications(telegramUser.telegramId, 60)
+            verify(notificationSettingsService).pauseNotifications(telegramUser.externalUserId, 60)
             verify(notificationSettingsService, never()).cancelPause(anyLong())
         }
 
@@ -208,7 +208,7 @@ class NotificationControllerTest @Autowired constructor(
             )
 
             assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
-            verify(notificationSettingsService).cancelPause(telegramUser.telegramId)
+            verify(notificationSettingsService).cancelPause(telegramUser.externalUserId)
             verify(notificationSettingsService, never()).pauseNotifications(anyLong(), anyLong())
         }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/SettingControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/SettingControllerTest.kt
@@ -274,7 +274,7 @@ class SettingControllerTest @Autowired constructor(
             val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
 
             assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
-            verify(notificationSettingsService).changeNotificationStatus(telegramUser.telegramId, active)
+            verify(notificationSettingsService).changeNotificationStatus(telegramUser.externalUserId, active)
         }
 
         @Test
@@ -324,7 +324,7 @@ class SettingControllerTest @Autowired constructor(
             val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
 
             assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
-            verify(notificationSettingsService).changeDailyGoal(telegramUser.telegramId, 2500)
+            verify(notificationSettingsService).changeDailyGoal(telegramUser.externalUserId, 2500)
         }
 
         @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
@@ -69,19 +69,19 @@ class StatisticsControllerTest @Autowired constructor(
         fun `returns 200 with serialized entries`() {
             val entries = listOf(
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = telegramUser.telegramId,
+                    externalUserId = telegramUser.externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 7, 8, 15, 0),
                     eventType = AnswerNotificationType.YES,
                     waterAmountMl = 250,
                 ),
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = telegramUser.telegramId,
+                    externalUserId = telegramUser.externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 7, 13, 0, 0),
                     eventType = AnswerNotificationType.YES,
                     waterAmountMl = 500,
                 ),
             )
-            `when`(statisticsService.getToday(telegramUser.telegramId)).thenReturn(entries)
+            `when`(statisticsService.getToday(telegramUser.externalUserId)).thenReturn(entries)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -96,13 +96,13 @@ class StatisticsControllerTest @Autowired constructor(
             assertEquals(250, body.entries[0].amountMl)
             assertEquals(Instant.parse("2026-05-07T13:00:00Z"), body.entries[1].eventTime)
             assertEquals(500, body.entries[1].amountMl)
-            verify(statisticsService).getToday(telegramUser.telegramId)
+            verify(statisticsService).getToday(telegramUser.externalUserId)
         }
 
         @Test
         @DisplayName("empty list - returns 200 with empty entries")
         fun `returns 200 with empty entries`() {
-            `when`(statisticsService.getToday(telegramUser.telegramId)).thenReturn(emptyList())
+            `when`(statisticsService.getToday(telegramUser.externalUserId)).thenReturn(emptyList())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -148,7 +148,7 @@ class StatisticsControllerTest @Autowired constructor(
         @DisplayName("valid range - returns 200 with full body and forwards from/to to service")
         fun `valid range returns 200`() {
             val dto = dailyDto()
-            `when`(statisticsService.getStatistics(eq(telegramUser.telegramId), eq(from), eq(to))).thenReturn(dto)
+            `when`(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(from), eq(to))).thenReturn(dto)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -170,7 +170,7 @@ class StatisticsControllerTest @Autowired constructor(
             assertEquals(Instant.parse("2026-04-15T10:30:00Z"), body.firstEntryAt)
             val fromCaptor = argumentCaptor<LocalDate>()
             val toCaptor = argumentCaptor<LocalDate>()
-            verify(statisticsService).getStatistics(eq(telegramUser.telegramId), fromCaptor.capture(), toCaptor.capture())
+            verify(statisticsService).getStatistics(eq(telegramUser.externalUserId), fromCaptor.capture(), toCaptor.capture())
             assertEquals(from, fromCaptor.firstValue)
             assertEquals(to, toCaptor.firstValue)
         }
@@ -179,7 +179,7 @@ class StatisticsControllerTest @Autowired constructor(
         @DisplayName("from == to - returns 200 with 24 hourly buckets")
         fun `from equals to returns hourly`() {
             val day = LocalDate.of(2026, 5, 12)
-            `when`(statisticsService.getStatistics(eq(telegramUser.telegramId), eq(day), eq(day))).thenReturn(hourlyDto())
+            `when`(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(day), eq(day))).thenReturn(hourlyDto())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -196,7 +196,7 @@ class StatisticsControllerTest @Autowired constructor(
         @Test
         @DisplayName("firstEntryAt = null is rendered as null in response")
         fun `null firstEntryAt rendered as null`() {
-            `when`(statisticsService.getStatistics(eq(telegramUser.telegramId), eq(from), eq(to)))
+            `when`(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(from), eq(to)))
                 .thenReturn(dailyDto(firstEntryAt = null))
             val headers = buildHeaders()
 
@@ -329,13 +329,13 @@ class StatisticsControllerTest @Autowired constructor(
             )
 
             assertEquals(HttpStatus.CREATED, response.statusCode)
-            val userIdCaptor = argumentCaptor<Long>()
+            val externalUserIdCaptor = argumentCaptor<Long>()
             val consumedAtCaptor = argumentCaptor<Instant>()
             val amountCaptor = argumentCaptor<Int>()
             verify(waterStatisticService).manualRecordEvent(
-                userIdCaptor.capture(), consumedAtCaptor.capture(), amountCaptor.capture()
+                externalUserIdCaptor.capture(), consumedAtCaptor.capture(), amountCaptor.capture()
             )
-            assertEquals(telegramUser.telegramId, userIdCaptor.firstValue)
+            assertEquals(telegramUser.externalUserId, externalUserIdCaptor.firstValue)
             assertEquals(consumedAt, consumedAtCaptor.firstValue)
             assertEquals(250, amountCaptor.firstValue)
         }
@@ -350,13 +350,13 @@ class StatisticsControllerTest @Autowired constructor(
             )
 
             assertEquals(HttpStatus.CREATED, response.statusCode)
-            val userIdCaptor = argumentCaptor<Long>()
+            val externalUserIdCaptor = argumentCaptor<Long>()
             val consumedAtCaptor = nullableArgumentCaptor<Instant>()
             val amountCaptor = argumentCaptor<Int>()
             verify(waterStatisticService).manualRecordEvent(
-                userIdCaptor.capture(), consumedAtCaptor.capture(), amountCaptor.capture()
+                externalUserIdCaptor.capture(), consumedAtCaptor.capture(), amountCaptor.capture()
             )
-            assertEquals(telegramUser.telegramId, userIdCaptor.firstValue)
+            assertEquals(telegramUser.externalUserId, externalUserIdCaptor.firstValue)
             assertEquals(250, amountCaptor.firstValue)
             assertNull(consumedAtCaptor.firstValue)
         }

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/UserControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/UserControllerTest.kt
@@ -49,7 +49,7 @@ class UserControllerTest @Autowired constructor(
     private val NON_ADMIN_USER_ID = 2L
     private val MISSING_USER_ID = 0L
 
-    private val telegramUser = DtoGenerator.generateTelegramUserDto(telegramId = ADMIN_USER_ID)
+    private val telegramUser = DtoGenerator.generateTelegramUserDto(externalUserId = ADMIN_USER_ID)
 
     @BeforeEach
     fun setUp() {
@@ -79,14 +79,14 @@ class UserControllerTest @Autowired constructor(
 
             assertEquals(HttpStatus.OK, response.statusCode)
             assertNotNull(response.body)
-            assertEquals(ADMIN_USER_ID, response.body!!.telegramUserId)
+            assertEquals(ADMIN_USER_ID, response.body!!.externalUserId)
             assertEquals(true, response.body!!.isAdmin)
         }
 
         @Test
         @DisplayName("non-admin user - returns 200 with isAdmin=false")
         fun `returns 200 with isAdmin false for non-admin`() {
-            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(telegramId = NON_ADMIN_USER_ID))
+            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -95,14 +95,14 @@ class UserControllerTest @Autowired constructor(
 
             assertEquals(HttpStatus.OK, response.statusCode)
             assertNotNull(response.body)
-            assertEquals(NON_ADMIN_USER_ID, response.body!!.telegramUserId)
+            assertEquals(NON_ADMIN_USER_ID, response.body!!.externalUserId)
             assertEquals(false, response.body!!.isAdmin)
         }
 
         @Test
         @DisplayName("user not in DB - returns 200 with isAdmin=false")
         fun `returns 200 with isAdmin false for user not in db`() {
-            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(telegramId = MISSING_USER_ID))
+            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = MISSING_USER_ID))
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -111,7 +111,7 @@ class UserControllerTest @Autowired constructor(
 
             assertEquals(HttpStatus.OK, response.statusCode)
             assertNotNull(response.body)
-            assertEquals(MISSING_USER_ID, response.body!!.telegramUserId)
+            assertEquals(MISSING_USER_ID, response.body!!.externalUserId)
             assertEquals(false, response.body!!.isAdmin)
         }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessServiceTest.kt
@@ -37,8 +37,8 @@ class NotificationAccessServiceTest @Autowired constructor(
 
     private val DEFAULT_ID = 1L
     private val NOT_EXISTED_USER_ID = 0L
-    private val DEFAULT_TELEGRAM_USER_ID = 1L
-    private val DISABLED_TELEGRAM_USER_ID = 2L
+    private val DEFAULT_EXTERNAL_USER_ID = 1L
+    private val DISABLED_EXTERNAL_USER_ID = 2L
     private val WITHOUT_NOTIFICATION_ATTEMPTS = 0
 
     private fun getMutableClock() = clock as ClockHelperTest.MutableClock
@@ -55,30 +55,30 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("findNotificationSettingByTelegramUserId(): returns a found record")
-    fun `successful findNotificationSettingByTelegramUserId`() {
-        assertDoesNotThrow { accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID) }
+    @DisplayName("findNotificationSettingByExternalUserId(): returns a found record")
+    fun `successful findNotificationSettingByExternalUserId`() {
+        assertDoesNotThrow { accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID) }
     }
 
     @Test
-    @DisplayName("existsByTelegramUserId(): returns a true")
-    fun `successful existsByTelegramUserId true`() {
+    @DisplayName("existsByExternalUserId(): returns a true")
+    fun `successful existsByExternalUserId true`() {
         val actual =
             assertDoesNotThrow(
                 ThrowingSupplier {
-                    accessService.existsByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+                    accessService.existsByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
                 }
             )
         assertTrue(actual)
     }
 
     @Test
-    @DisplayName("existsByTelegramUserId(): returns a false")
-    fun `successful existsByTelegramUserId false`() {
+    @DisplayName("existsByExternalUserId(): returns a false")
+    fun `successful existsByExternalUserId false`() {
         val actual =
             assertDoesNotThrow(
                 ThrowingSupplier {
-                    accessService.existsByTelegramUserId(NOT_EXISTED_USER_ID)
+                    accessService.existsByExternalUserId(NOT_EXISTED_USER_ID)
                 }
             )
         assertFalse(actual)
@@ -96,13 +96,13 @@ class NotificationAccessServiceTest @Autowired constructor(
                 }
             )
         assertNotNull(actual.id)
-        assertNotEquals(DEFAULT_TELEGRAM_USER_ID, actual.externalUserId)
+        assertNotEquals(DEFAULT_EXTERNAL_USER_ID, actual.externalUserId)
     }
 
     @Test
     @DisplayName("save(): returns an existed record")
     fun `successful save update`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = DEFAULT_TELEGRAM_USER_ID)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = DEFAULT_EXTERNAL_USER_ID)
 
         val actual =
             assertDoesNotThrow(
@@ -111,15 +111,15 @@ class NotificationAccessServiceTest @Autowired constructor(
                 }
             )
         assertEquals(DEFAULT_ID, actual.id)
-        assertEquals(DEFAULT_TELEGRAM_USER_ID, actual.externalUserId)
+        assertEquals(DEFAULT_EXTERNAL_USER_ID, actual.externalUserId)
     }
 
     @Test
     @DisplayName("save(): reuses existing chat entity when externalChatId already exists")
     fun `successful save with existing chat`() {
         val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = DEFAULT_TELEGRAM_USER_ID,
-            externalChatId = DEFAULT_TELEGRAM_USER_ID
+            externalUserId = DEFAULT_EXTERNAL_USER_ID,
+            externalChatId = DEFAULT_EXTERNAL_USER_ID
         )
 
         val actual =
@@ -128,7 +128,7 @@ class NotificationAccessServiceTest @Autowired constructor(
                     accessService.save(dto.telegramUser, dto.telegramChat, dto)
                 }
             )
-        assertEquals(DEFAULT_TELEGRAM_USER_ID, actual.externalUserId)
+        assertEquals(DEFAULT_EXTERNAL_USER_ID, actual.externalUserId)
     }
 
     @Test
@@ -139,7 +139,7 @@ class NotificationAccessServiceTest @Autowired constructor(
         val actual =
             assertDoesNotThrow(
                 ThrowingSupplier {
-                    accessService.updateTimeOfLastNotification(DEFAULT_TELEGRAM_USER_ID, time)
+                    accessService.updateTimeOfLastNotification(DEFAULT_EXTERNAL_USER_ID, time)
                 }
             )
 
@@ -150,7 +150,7 @@ class NotificationAccessServiceTest @Autowired constructor(
     @Test
     @DisplayName("updateNotificationSettings(): returns an updated set of records")
     fun `successful updateNotificationSettings`() {
-        val existed = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val existed = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
 
         val actual =
             assertDoesNotThrow(
@@ -168,10 +168,10 @@ class NotificationAccessServiceTest @Autowired constructor(
     fun `successful enableNotifications`() {
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.enableNotifications(DISABLED_TELEGRAM_USER_ID)
+                accessService.enableNotifications(DISABLED_EXTERNAL_USER_ID)
             }
         )
-        assertTrue(accessService.isEnabledNotifications(DISABLED_TELEGRAM_USER_ID))
+        assertTrue(accessService.isEnabledNotifications(DISABLED_EXTERNAL_USER_ID))
     }
 
     @Test
@@ -179,10 +179,10 @@ class NotificationAccessServiceTest @Autowired constructor(
     fun `successful disableNotifications`() {
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.disableNotifications(DEFAULT_TELEGRAM_USER_ID)
+                accessService.disableNotifications(DEFAULT_EXTERNAL_USER_ID)
             }
         )
-        assertFalse(accessService.isEnabledNotifications(DEFAULT_TELEGRAM_USER_ID))
+        assertFalse(accessService.isEnabledNotifications(DEFAULT_EXTERNAL_USER_ID))
     }
 
     @Test
@@ -192,7 +192,7 @@ class NotificationAccessServiceTest @Autowired constructor(
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.updateNotificationSettings(DEFAULT_TELEGRAM_USER_ID, newInterval)
+                accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, newInterval)
             }
         )
 
@@ -206,7 +206,7 @@ class NotificationAccessServiceTest @Autowired constructor(
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.updateNotificationSettings(DEFAULT_TELEGRAM_USER_ID, sameInterval)
+                accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, sameInterval)
             }
         )
 
@@ -221,11 +221,11 @@ class NotificationAccessServiceTest @Autowired constructor(
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.changeQuietMode(DEFAULT_TELEGRAM_USER_ID, expectedStart, expectedEnd)
+                accessService.changeQuietMode(DEFAULT_EXTERNAL_USER_ID, expectedStart, expectedEnd)
             }
         )
 
-        val actual = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertEquals(expectedStart, actual.quietModeStart)
         assertEquals(expectedEnd, actual.quietModeEnd)
     }
@@ -233,15 +233,15 @@ class NotificationAccessServiceTest @Autowired constructor(
     @Test
     @DisplayName("disableQuietMode(): clears quiet mode start and end times")
     fun `successful disableQuietMode`() {
-        accessService.changeQuietMode(DEFAULT_TELEGRAM_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
+        accessService.changeQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.disableQuietMode(DEFAULT_TELEGRAM_USER_ID)
+                accessService.disableQuietMode(DEFAULT_EXTERNAL_USER_ID)
             }
         )
 
-        val actual = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertNull(actual.quietModeStart)
         assertNull(actual.quietModeEnd)
     }
@@ -253,11 +253,11 @@ class NotificationAccessServiceTest @Autowired constructor(
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.changeTimezone(DEFAULT_TELEGRAM_USER_ID, newTimezone)
+                accessService.changeTimezone(DEFAULT_EXTERNAL_USER_ID, newTimezone)
             }
         )
 
-        val actual = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertEquals(newTimezone, actual.telegramUser.userTimeZone)
     }
 
@@ -270,13 +270,13 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("findNotificationSettingByTelegramUserId(): throws NotificationSettingsNotFoundException when record not found by telegramUserId")
-    fun `failure findNotificationSettingByTelegramUserId not found`() {
-        assertThrows<NotificationSettingsNotFoundException> { accessService.findNotificationSettingByTelegramUserId(NOT_EXISTED_USER_ID) }
+    @DisplayName("findNotificationSettingByExternalUserId(): throws NotificationSettingsNotFoundException when record not found by externalUserId")
+    fun `failure findNotificationSettingByExternalUserId not found`() {
+        assertThrows<NotificationSettingsNotFoundException> { accessService.findNotificationSettingByExternalUserId(NOT_EXISTED_USER_ID) }
     }
 
     @Test
-    @DisplayName("updateTimeOfLastNotification(): throws NotificationSettingsNotFoundException when record not found by telegramUserId")
+    @DisplayName("updateTimeOfLastNotification(): throws NotificationSettingsNotFoundException when record not found by externalUserId")
     fun `failure updateTimeOfLastNotification not found`() {
         val time = LocalDateTime.now()
         assertThrows<NotificationSettingsNotFoundException> { accessService.updateTimeOfLastNotification(NOT_EXISTED_USER_ID, time) }
@@ -290,7 +290,7 @@ class NotificationAccessServiceTest @Autowired constructor(
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.updateNotificationSettings(DEFAULT_TELEGRAM_USER_ID, IntervalNotificationType.HALF_HOUR)
+                accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, IntervalNotificationType.HALF_HOUR)
             }
         )
 
@@ -302,11 +302,11 @@ class NotificationAccessServiceTest @Autowired constructor(
     @Test
     @DisplayName("updateNotificationSettings(): does not reset timeOfLastNotification and notificationAttempts when interval is the same")
     fun `successful updateNotificationSettings does not reset timeOfLastNotification and notificationAttempts on same interval`() {
-        val before = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.updateNotificationSettings(DEFAULT_TELEGRAM_USER_ID, IntervalNotificationType.TWO_HOURS)
+                accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, IntervalNotificationType.TWO_HOURS)
             }
         )
 
@@ -315,7 +315,7 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("updateNotificationSettings(): throws NotificationSettingsNotFoundException when record not found by telegramUserId")
+    @DisplayName("updateNotificationSettings(): throws NotificationSettingsNotFoundException when record not found by externalUserId")
     fun `failure updateNotificationSettings not found`() {
         assertThrows<NotificationSettingsNotFoundException> {
             accessService.updateNotificationSettings(NOT_EXISTED_USER_ID, IntervalNotificationType.HOUR)
@@ -327,11 +327,11 @@ class NotificationAccessServiceTest @Autowired constructor(
     fun `successful updateNotificationSettings clears pauseUntil on interval change`() {
         getMutableClock().setTime("2025-06-15T10:00:00Z")
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        accessService.setPause(DEFAULT_TELEGRAM_USER_ID, pauseUntil)
+        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.updateNotificationSettings(DEFAULT_TELEGRAM_USER_ID, IntervalNotificationType.HALF_HOUR)
+                accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, IntervalNotificationType.HALF_HOUR)
             }
         )
 
@@ -344,12 +344,12 @@ class NotificationAccessServiceTest @Autowired constructor(
     @DisplayName("setPause(): sets pauseUntil and shifts timeOfLastNotification to pauseUntil minus interval")
     fun `successful setPause sets pauseUntil and shifts timeOfLastNotification`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        // SQL fixture sets DEFAULT_TELEGRAM_USER_ID with TWO_HOURS interval (120 minutes)
+        // SQL fixture sets DEFAULT_EXTERNAL_USER_ID with TWO_HOURS interval (120 minutes)
         val expectedTimeOfLastNotification = pauseUntil.minusMinutes(IntervalNotificationType.TWO_HOURS.minutes)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_TELEGRAM_USER_ID, pauseUntil)
+                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
             }
         )
 
@@ -361,12 +361,12 @@ class NotificationAccessServiceTest @Autowired constructor(
     @DisplayName("setPause(): does NOT reset notificationAttempts when pause is set")
     fun `successful setPause keeps notificationAttempts`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        // SQL fixture seeds notification_attempts = 1 for DEFAULT_TELEGRAM_USER_ID
-        val before = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        // SQL fixture seeds notification_attempts = 1 for DEFAULT_EXTERNAL_USER_ID
+        val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_TELEGRAM_USER_ID, pauseUntil)
+                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
             }
         )
 
@@ -379,11 +379,11 @@ class NotificationAccessServiceTest @Autowired constructor(
         getMutableClock().setTime("2025-06-15T14:00:00Z")
         val expectedTime = LocalDateTime.now(clock)
         // First put user into paused state
-        accessService.setPause(DEFAULT_TELEGRAM_USER_ID, LocalDateTime.of(2025, 6, 15, 18, 0))
+        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, LocalDateTime.of(2025, 6, 15, 18, 0))
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_TELEGRAM_USER_ID, null)
+                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, null)
             }
         )
 
@@ -394,11 +394,11 @@ class NotificationAccessServiceTest @Autowired constructor(
     @Test
     @DisplayName("setPause(): cancel does NOT reset notificationAttempts")
     fun `successful setPause cancel keeps notificationAttempts`() {
-        val before = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_TELEGRAM_USER_ID, null)
+                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, null)
             }
         )
 
@@ -410,11 +410,11 @@ class NotificationAccessServiceTest @Autowired constructor(
     fun `successful setPause re-pause overwrites`() {
         val firstPause = LocalDateTime.of(2025, 6, 15, 14, 0)
         val secondPause = LocalDateTime.of(2025, 6, 15, 18, 0)
-        accessService.setPause(DEFAULT_TELEGRAM_USER_ID, firstPause)
+        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, firstPause)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_TELEGRAM_USER_ID, secondPause)
+                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, secondPause)
             }
         )
 
@@ -430,14 +430,14 @@ class NotificationAccessServiceTest @Autowired constructor(
     fun `successful setPause persists pauseUntil`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
 
-        accessService.setPause(DEFAULT_TELEGRAM_USER_ID, pauseUntil)
+        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
 
-        val reloaded = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val reloaded = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertEquals(pauseUntil, reloaded.pauseUntil)
     }
 
     @Test
-    @DisplayName("setPause(): throws NotificationSettingsNotFoundException when record not found by telegramUserId")
+    @DisplayName("setPause(): throws NotificationSettingsNotFoundException when record not found by externalUserId")
     fun `failure setPause not found`() {
         assertThrows<NotificationSettingsNotFoundException> {
             accessService.setPause(NOT_EXISTED_USER_ID, LocalDateTime.of(2025, 6, 15, 14, 0))
@@ -445,7 +445,7 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("setPause(): throws NotificationSettingsNotFoundException when record not found by telegramUserId on cancel")
+    @DisplayName("setPause(): throws NotificationSettingsNotFoundException when record not found by externalUserId on cancel")
     fun `failure setPause cancel not found`() {
         assertThrows<NotificationSettingsNotFoundException> {
             accessService.setPause(NOT_EXISTED_USER_ID, null)
@@ -456,7 +456,7 @@ class NotificationAccessServiceTest @Autowired constructor(
     @DisplayName("setPause(): throws NotificationSettingsNotFoundException for disabled user (filtered by @SQLRestriction)")
     fun `failure setPause disabled user`() {
         assertThrows<NotificationSettingsNotFoundException> {
-            accessService.setPause(DISABLED_TELEGRAM_USER_ID, LocalDateTime.of(2025, 6, 15, 14, 0))
+            accessService.setPause(DISABLED_EXTERNAL_USER_ID, LocalDateTime.of(2025, 6, 15, 14, 0))
         }
     }
 
@@ -464,15 +464,15 @@ class NotificationAccessServiceTest @Autowired constructor(
     @DisplayName("changeQuietMode(): clears active pauseUntil")
     fun `changeQuietMode clears active pauseUntil`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        accessService.setPause(DEFAULT_TELEGRAM_USER_ID, pauseUntil)
+        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.changeQuietMode(DEFAULT_TELEGRAM_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
+                accessService.changeQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
             }
         )
 
-        val actual = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertNull(actual.pauseUntil)
         assertEquals(LocalTime.of(22, 0), actual.quietModeStart)
         assertEquals(LocalTime.of(8, 0), actual.quietModeEnd)
@@ -482,16 +482,16 @@ class NotificationAccessServiceTest @Autowired constructor(
     @DisplayName("disableQuietMode(): clears active pauseUntil")
     fun `disableQuietMode clears active pauseUntil`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        accessService.changeQuietMode(DEFAULT_TELEGRAM_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
-        accessService.setPause(DEFAULT_TELEGRAM_USER_ID, pauseUntil)
+        accessService.changeQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
+        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.disableQuietMode(DEFAULT_TELEGRAM_USER_ID)
+                accessService.disableQuietMode(DEFAULT_EXTERNAL_USER_ID)
             }
         )
 
-        val actual = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertNull(actual.pauseUntil)
         assertNull(actual.quietModeStart)
         assertNull(actual.quietModeEnd)
@@ -501,17 +501,17 @@ class NotificationAccessServiceTest @Autowired constructor(
     @DisplayName("disableNotifications(): clears active pauseUntil before disabling")
     fun `disableNotifications clears active pauseUntil`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        accessService.setPause(DEFAULT_TELEGRAM_USER_ID, pauseUntil)
+        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.disableNotifications(DEFAULT_TELEGRAM_USER_ID)
+                accessService.disableNotifications(DEFAULT_EXTERNAL_USER_ID)
             }
         )
         // While disabled the entity is filtered out by @SQLRestriction, so re-enable to read it.
-        accessService.enableNotifications(DEFAULT_TELEGRAM_USER_ID)
+        accessService.enableNotifications(DEFAULT_EXTERNAL_USER_ID)
 
-        val actual = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertNull(actual.pauseUntil)
     }
 
@@ -522,11 +522,11 @@ class NotificationAccessServiceTest @Autowired constructor(
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.updateDailyGoal(DEFAULT_TELEGRAM_USER_ID, newGoalMl)
+                accessService.updateDailyGoal(DEFAULT_EXTERNAL_USER_ID, newGoalMl)
             }
         )
 
-        val actual = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertEquals(newGoalMl, actual.dailyGoalMl)
     }
 
@@ -544,15 +544,15 @@ class NotificationAccessServiceTest @Autowired constructor(
     @DisplayName("updateDailyGoal(): does not affect dailyGoalMl of other users")
     fun `successful updateDailyGoal does not affect other users`() {
         val newGoalForFirst = 2500
-        val before = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
-        // DISABLED_TELEGRAM_USER_ID is filtered by @SQLRestriction, so re-enable to read it back.
-        accessService.enableNotifications(DISABLED_TELEGRAM_USER_ID)
-        val secondBefore = accessService.findNotificationSettingByTelegramUserId(DISABLED_TELEGRAM_USER_ID)
+        val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+        // DISABLED_EXTERNAL_USER_ID is filtered by @SQLRestriction, so re-enable to read it back.
+        accessService.enableNotifications(DISABLED_EXTERNAL_USER_ID)
+        val secondBefore = accessService.findNotificationSettingByExternalUserId(DISABLED_EXTERNAL_USER_ID)
 
-        accessService.updateDailyGoal(DEFAULT_TELEGRAM_USER_ID, newGoalForFirst)
+        accessService.updateDailyGoal(DEFAULT_EXTERNAL_USER_ID, newGoalForFirst)
 
-        val firstAfter = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
-        val secondAfter = accessService.findNotificationSettingByTelegramUserId(DISABLED_TELEGRAM_USER_ID)
+        val firstAfter = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+        val secondAfter = accessService.findNotificationSettingByExternalUserId(DISABLED_EXTERNAL_USER_ID)
         assertNotEquals(before.dailyGoalMl, firstAfter.dailyGoalMl)
         assertEquals(newGoalForFirst, firstAfter.dailyGoalMl)
         assertEquals(secondBefore.dailyGoalMl, secondAfter.dailyGoalMl)
@@ -563,7 +563,7 @@ class NotificationAccessServiceTest @Autowired constructor(
     fun `setPause cancel after pause expired keeps timeOfLastNotification`() {
         getMutableClock().setTime("2025-06-15T10:00:00Z")
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 11, 0)
-        accessService.setPause(DEFAULT_TELEGRAM_USER_ID, pauseUntil)
+        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
         val timerWhilePaused = pauseUntil.minusMinutes(IntervalNotificationType.TWO_HOURS.minutes)
 
         // Advance clock past pauseUntil so the pause is expired.
@@ -571,7 +571,7 @@ class NotificationAccessServiceTest @Autowired constructor(
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_TELEGRAM_USER_ID, null)
+                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, null)
             }
         )
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategyTest.kt
@@ -29,7 +29,7 @@ import java.time.ZoneOffset
 @DisplayName("CancelAnswerNotificationReplyButtonStrategy Unit Test")
 class CancelAnswerNotificationReplyButtonStrategyTest {
 
-    private val userId = 1L
+    private val externalUserId = 1L
     private val chatId = 2L
     private val messageId = 3
     private val fixedNow = LocalDateTime.of(2025, 1, 1, 14, 0, 0)
@@ -59,8 +59,8 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): edits original message with CANCEL display name")
     fun `reply edits original message`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
@@ -72,19 +72,19 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): updates last notification time to now(clock)")
     fun `reply updates notification time`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
-        verify(notificationSettingsService).resetNotificationTimer(userId, fixedNow)
+        verify(notificationSettingsService).resetNotificationTimer(externalUserId, fixedNow)
     }
 
     @Test
     @DisplayName("reply(): records water statistic with CANCEL event type")
     fun `reply records statistic`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
@@ -94,8 +94,8 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): sends CANCEL confirmation message")
     fun `reply sends confirmation message`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
         strategy.reply(buildCallbackQuery())
@@ -131,8 +131,8 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): sends CANCEL confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
         doThrow(RuntimeException("statistic error")).`when`(waterStatisticService)
             .recordEvent(any(), any(), anyInt())
 
@@ -147,7 +147,7 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
 
     private fun buildCallbackQuery(): CallbackQuery {
         val user = mock(User::class.java)
-        `when`(user.id).thenReturn(userId)
+        `when`(user.id).thenReturn(externalUserId)
 
         val message = mock(Message::class.java)
         `when`(message.chatId).thenReturn(chatId)

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategyTest.kt
@@ -30,7 +30,7 @@ import java.time.ZoneOffset
 @DisplayName("SnoozeApplyReplyButtonStrategy Unit Test")
 class SnoozeApplyReplyButtonStrategyTest {
 
-    private val userId = 1L
+    private val externalUserId = 1L
     private val chatId = 2L
     private val messageId = 3
     private val fixedNow = LocalDateTime.of(2025, 1, 1, 14, 0, 0)
@@ -61,9 +61,9 @@ class SnoozeApplyReplyButtonStrategyTest {
     @EnumSource(SnoozeNotificationType::class)
     @DisplayName("reply(): deletes reply markup on original message")
     fun `reply deletes reply markup`(snoozeType: SnoozeNotificationType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(userId), any())).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         strategy.reply(callbackQuery)
@@ -75,25 +75,25 @@ class SnoozeApplyReplyButtonStrategyTest {
     @EnumSource(SnoozeNotificationType::class)
     @DisplayName("reply(): next notification fires exactly snoozeMinutes from now")
     fun `reply updates notification time`(snoozeType: SnoozeNotificationType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(userId), any())).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         strategy.reply(callbackQuery)
 
         val interval = notificationDto.notificationInterval.minutes
         val expectedTime = fixedNow.minusMinutes(interval).plusMinutes(snoozeType.minutes)
-        verify(notificationSettingsService).resetNotificationTimer(userId, expectedTime)
+        verify(notificationSettingsService).resetNotificationTimer(externalUserId, expectedTime)
     }
 
     @ParameterizedTest
     @EnumSource(SnoozeNotificationType::class)
     @DisplayName("reply(): sends confirmation message with snooze display name")
     fun `reply sends confirmation message`(snoozeType: SnoozeNotificationType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(userId), any())).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
@@ -112,25 +112,25 @@ class SnoozeApplyReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): falls back to TEN_MINS when queryData doesn't match any SnoozeNotificationType")
     fun `reply falls back to TEN_MINS for unknown queryData`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(userId), any())).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery("00000000-0000-0000-0000-000000000000")
         strategy.reply(callbackQuery)
 
         val interval = notificationDto.notificationInterval.minutes
         val expectedTime = fixedNow.minusMinutes(interval).plusMinutes(SnoozeNotificationType.TEN_MINS.minutes)
-        verify(notificationSettingsService).resetNotificationTimer(userId, expectedTime)
+        verify(notificationSettingsService).resetNotificationTimer(externalUserId, expectedTime)
     }
 
     @ParameterizedTest
     @EnumSource(SnoozeNotificationType::class)
     @DisplayName("reply(): records water statistic with SNOOZE event type")
     fun `reply records statistic any type`(snoozeType: SnoozeNotificationType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(userId), any())).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
 
@@ -164,8 +164,8 @@ class SnoozeApplyReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): sends snooze confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
         `when`(notificationSettingsService.resetNotificationTimer(any(), any())).thenReturn(notificationDto)
         doThrow(RuntimeException("statistic error")).`when`(waterStatisticService)
             .recordEvent(any(), any(), anyInt())
@@ -182,7 +182,7 @@ class SnoozeApplyReplyButtonStrategyTest {
 
     private fun buildCallbackQuery(queryData: String): CallbackQuery {
         val user = mock(User::class.java)
-        `when`(user.id).thenReturn(userId)
+        `when`(user.id).thenReturn(externalUserId)
 
         val message = mock(Message::class.java)
         `when`(message.chatId).thenReturn(chatId)

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
@@ -30,7 +30,7 @@ import java.time.ZoneOffset
 @DisplayName("WaterAmountApplyReplyButtonStrategy Unit Test")
 class WaterAmountApplyReplyButtonStrategyTest {
 
-    private val userId = 1L
+    private val externalUserId = 1L
     private val chatId = 2L
     private val messageId = 3
     private val fixedNow = LocalDateTime.of(2025, 1, 1, 14, 0, 0)
@@ -61,8 +61,8 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @EnumSource(WaterAmountType::class)
     @DisplayName("reply(): deletes reply markup on original message")
     fun `reply deletes reply markup`(waterAmountType: WaterAmountType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
@@ -73,20 +73,20 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @EnumSource(WaterAmountType::class)
     @DisplayName("reply(): updates last notification time to now()")
     fun `reply updates notification time`(waterAmountType: WaterAmountType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
-        verify(notificationSettingsService).resetNotificationTimer(userId, fixedNow)
+        verify(notificationSettingsService).resetNotificationTimer(externalUserId, fixedNow)
     }
 
     @ParameterizedTest
     @EnumSource(WaterAmountType::class)
     @DisplayName("reply(): sends YES confirmation message")
     fun `reply sends confirmation message`(waterAmountType: WaterAmountType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
@@ -101,8 +101,8 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @EnumSource(WaterAmountType::class)
     @DisplayName("reply(): records water statistic with correct water amount")
     fun `reply records statistic with correct water amount`(waterAmountType: WaterAmountType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
@@ -116,8 +116,8 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): falls back to ML_250 when queryData doesn't match any WaterAmountType")
     fun `reply falls back to ML_250 for unknown queryData`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery("00000000-0000-0000-0000-000000000000"))
 
@@ -131,14 +131,14 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): executes operations in correct order")
     fun `reply executes in correct order`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(WaterAmountType.ML_250.queryData.toString()))
 
         val inOrder = inOrder(messageEditorService, notificationSettingsService, waterStatisticService, sender)
         inOrder.verify(messageEditorService).deleteReplyMarkup(chatId, messageId)
-        inOrder.verify(notificationSettingsService).resetNotificationTimer(userId, fixedNow)
+        inOrder.verify(notificationSettingsService).resetNotificationTimer(externalUserId, fixedNow)
         inOrder.verify(waterStatisticService).recordEvent(
             notificationDto.telegramUser,
             AnswerNotificationType.YES,
@@ -172,8 +172,8 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): sends YES confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
         doThrow(RuntimeException("statistic error")).`when`(waterStatisticService)
             .recordEvent(any(), any(), anyInt())
 
@@ -188,7 +188,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
 
     private fun buildCallbackQuery(queryData: String): CallbackQuery {
         val user = mock(User::class.java)
-        `when`(user.id).thenReturn(userId)
+        `when`(user.id).thenReturn(externalUserId)
 
         val message = mock(Message::class.java)
         `when`(message.chatId).thenReturn(chatId)

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
@@ -29,7 +29,7 @@ import java.time.ZoneOffset
 @DisplayName("NotificationSenderService Unit Test")
 class NotificationSenderServiceTest {
 
-    private val userId = 1L
+    private val externalUserId = 1L
     private val chatId = 2L
 
     private val retryIntervalMinutes = 1L
@@ -81,7 +81,7 @@ class NotificationSenderServiceTest {
     @DisplayName("sendNotifications(): sends notification messages, increments attempts, updates settings")
     fun `sendNotifications sends and updates`() {
         val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
+            externalUserId = externalUserId,
             externalChatId = chatId,
             notificationAttempts = 0,
             previousNotificationMessageId = 10
@@ -107,14 +107,14 @@ class NotificationSenderServiceTest {
     @Test
     @DisplayName("sendNotifications(): 403 error - disables user and excludes from settings update")
     fun `sendNotifications on 403 disables notifications`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
         val exception = mock(TelegramApiRequestException::class.java)
         `when`(exception.errorCode).thenReturn(403)
         doThrow(exception).`when`(sender).execute(any<SendMessage>())
 
         service.sendNotifications(listOf(dto))
 
-        verify(notificationAccessService).disableNotifications(userId)
+        verify(notificationAccessService).disableNotifications(externalUserId)
         verify(notificationAccessService).updateNotificationSettings(anyCollection())
     }
 
@@ -132,7 +132,7 @@ class NotificationSenderServiceTest {
     @DisplayName("suspendNotifications(): sends suspend message, resets attempts and time, updates settings")
     fun `suspendNotifications sends and updates`() {
         val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
+            externalUserId = externalUserId,
             externalChatId = chatId,
             notificationAttempts = 3,
             previousNotificationMessageId = 10
@@ -150,7 +150,7 @@ class NotificationSenderServiceTest {
     @Test
     @DisplayName("suspendNotifications(): records water statistic events for each sent notification")
     fun `suspendNotifications records water statistics`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
 
         service.suspendNotifications(listOf(dto))
 
@@ -160,21 +160,21 @@ class NotificationSenderServiceTest {
     @Test
     @DisplayName("suspendNotifications(): 403 error - disables user and excludes from settings update")
     fun `suspendNotifications on 403 disables notifications`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
         val exception = mock(TelegramApiRequestException::class.java)
         `when`(exception.errorCode).thenReturn(403)
         doThrow(exception).`when`(sender).execute(any<SendMessage>())
 
         service.suspendNotifications(listOf(dto))
 
-        verify(notificationAccessService).disableNotifications(userId)
+        verify(notificationAccessService).disableNotifications(externalUserId)
         verify(notificationAccessService).updateNotificationSettings(anyCollection())
     }
 
     @Test
     @DisplayName("sendNotifications(): non-403 error - rethrows exception")
     fun `sendNotifications rethrows non-403 exception`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
         val exception = mock(TelegramApiRequestException::class.java)
         `when`(exception.errorCode).thenReturn(500)
         doThrow(exception).`when`(sender).execute(any<SendMessage>())
@@ -187,7 +187,7 @@ class NotificationSenderServiceTest {
     @Test
     @DisplayName("sendNotifications(): null errorCode - rethrows exception")
     fun `sendNotifications rethrows null errorCode exception`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
         val exception = mock(TelegramApiRequestException::class.java)
         doReturn(null).`when`(exception).errorCode
         doThrow(exception).`when`(sender).execute(any<SendMessage>())
@@ -200,7 +200,7 @@ class NotificationSenderServiceTest {
     @Test
     @DisplayName("suspendNotifications(): non-403 error - rethrows exception")
     fun `suspendNotifications rethrows non-403 exception`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
         val exception = mock(TelegramApiRequestException::class.java)
         `when`(exception.errorCode).thenReturn(500)
         doThrow(exception).`when`(sender).execute(any<SendMessage>())

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
@@ -19,7 +19,7 @@ import ru.illine.drinking.ponies.test.tag.UnitTest
 @DisplayName("NotificationService Unit Test")
 class NotificationServiceTest {
 
-    private val userId = 1L
+    private val externalUserId = 1L
     private val chatId = 2L
 
     private lateinit var sender: TelegramClient
@@ -39,34 +39,34 @@ class NotificationServiceTest {
     @Test
     @DisplayName("start(): existing user - sends greeting and default settings, finds existing settings")
     fun `start existing user`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        doReturn(true).`when`(notificationAccessService).existsByTelegramUserId(userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        doReturn(true).`when`(notificationAccessService).existsByExternalUserId(externalUserId)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         service.start(buildMessageContext())
 
         verify(sender, times(2)).execute(any<SendMessage>())
-        verify(notificationAccessService).findNotificationSettingByTelegramUserId(userId)
+        verify(notificationAccessService).findNotificationSettingByExternalUserId(externalUserId)
         verify(notificationAccessService, never()).save(any(), any(), any())
     }
 
     @Test
     @DisplayName("start(): new user - creates user, saves settings, sends default settings message")
     fun `start new user`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        doReturn(false).`when`(notificationAccessService).existsByTelegramUserId(userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        doReturn(false).`when`(notificationAccessService).existsByExternalUserId(externalUserId)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         service.start(buildMessageContext())
 
         verify(notificationAccessService).save(any(), any(), any())
-        verify(notificationAccessService).findNotificationSettingByTelegramUserId(userId)
+        verify(notificationAccessService).findNotificationSettingByExternalUserId(externalUserId)
         verify(sender, times(2)).execute(any<SendMessage>())
     }
 
     private fun buildMessageContext(): MessageContext {
         val user = mock(User::class.java)
-        `when`(user.id).thenReturn(userId)
+        `when`(user.id).thenReturn(externalUserId)
         `when`(user.userName).thenReturn("testUser")
 
         val context = mock(MessageContext::class.java)

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsServiceTest.kt
@@ -19,7 +19,7 @@ import java.time.*
 @DisplayName("NotificationSettingsService Unit Test")
 class NotificationSettingsServiceTest {
 
-    private val userId = 1L
+    private val externalUserId = 1L
 
     private lateinit var notificationAccessService: NotificationAccessService
     private lateinit var notificationTimeService: NotificationTimeService
@@ -40,9 +40,9 @@ class NotificationSettingsServiceTest {
         val start = LocalTime.of(22, 0)
         val end = LocalTime.of(8, 0)
 
-        service.changeQuietMode(userId, start, end)
+        service.changeQuietMode(externalUserId, start, end)
 
-        verify(notificationAccessService).changeQuietMode(userId, start, end)
+        verify(notificationAccessService).changeQuietMode(externalUserId, start, end)
     }
 
     @Test
@@ -51,28 +51,28 @@ class NotificationSettingsServiceTest {
         val time = LocalTime.of(10, 0)
 
         assertThrows(IllegalArgumentException::class.java) {
-            service.changeQuietMode(userId, time, time)
+            service.changeQuietMode(externalUserId, time, time)
         }
     }
 
     @Test
     @DisplayName("disableQuietMode(): disables quiet mode via access service")
     fun `disableQuietMode disables quiet mode`() {
-        service.disableQuietMode(userId)
+        service.disableQuietMode(externalUserId)
 
-        verify(notificationAccessService).disableQuietMode(userId)
+        verify(notificationAccessService).disableQuietMode(externalUserId)
     }
 
     @Test
     @DisplayName("getNotificationSettings(): delegates to access service")
     fun `getNotificationSettings delegates to access service`() {
-        val expected = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(expected)
+        val expected = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(expected)
 
-        val result = service.getNotificationSettings(userId)
+        val result = service.getNotificationSettings(externalUserId)
 
         assertEquals(expected, result)
-        verify(notificationAccessService).findNotificationSettingByTelegramUserId(userId)
+        verify(notificationAccessService).findNotificationSettingByExternalUserId(externalUserId)
     }
 
     @Test
@@ -91,48 +91,48 @@ class NotificationSettingsServiceTest {
     @DisplayName("resetNotificationTimer(): delegates to access service and returns DTO")
     fun `resetNotificationTimer delegates to access service`() {
         val time = LocalDateTime.of(2026, 4, 5, 12, 0)
-        val expected = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, time)).thenReturn(expected)
+        val expected = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationAccessService.updateTimeOfLastNotification(externalUserId, time)).thenReturn(expected)
 
-        val result = service.resetNotificationTimer(userId, time)
+        val result = service.resetNotificationTimer(externalUserId, time)
 
         assertEquals(expected, result)
-        verify(notificationAccessService).updateTimeOfLastNotification(userId, time)
+        verify(notificationAccessService).updateTimeOfLastNotification(externalUserId, time)
     }
 
     @Test
     @DisplayName("isEnabledNotifications(): delegates to access service")
     fun `isEnabledNotifications delegates to access service`() {
-        `when`(notificationAccessService.isEnabledNotifications(userId)).thenReturn(true)
+        `when`(notificationAccessService.isEnabledNotifications(externalUserId)).thenReturn(true)
 
-        val result = service.isEnabledNotifications(userId)
+        val result = service.isEnabledNotifications(externalUserId)
 
         assertEquals(true, result)
-        verify(notificationAccessService).isEnabledNotifications(userId)
+        verify(notificationAccessService).isEnabledNotifications(externalUserId)
     }
 
     @Test
     @DisplayName("isEnabledNotifications(): returns false when disabled")
     fun `isEnabledNotifications returns false when disabled`() {
-        `when`(notificationAccessService.isEnabledNotifications(userId)).thenReturn(false)
+        `when`(notificationAccessService.isEnabledNotifications(externalUserId)).thenReturn(false)
 
-        val result = service.isEnabledNotifications(userId)
+        val result = service.isEnabledNotifications(externalUserId)
 
         assertEquals(false, result)
-        verify(notificationAccessService).isEnabledNotifications(userId)
+        verify(notificationAccessService).isEnabledNotifications(externalUserId)
     }
 
     @Test
     @DisplayName("changeInterval(): delegates to access service and returns DTO")
     fun `changeInterval delegates to access service`() {
         val interval = IntervalNotificationType.TWO_HOURS
-        val expected = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateNotificationSettings(userId, interval)).thenReturn(expected)
+        val expected = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationAccessService.updateNotificationSettings(externalUserId, interval)).thenReturn(expected)
 
-        val result = service.changeInterval(userId, interval)
+        val result = service.changeInterval(externalUserId, interval)
 
         assertEquals(expected, result)
-        verify(notificationAccessService).updateNotificationSettings(userId, interval)
+        verify(notificationAccessService).updateNotificationSettings(externalUserId, interval)
     }
 
     @Test
@@ -141,13 +141,13 @@ class NotificationSettingsServiceTest {
         val expectedStart = LocalTime.of(23, 0)
         val expectedEnd = LocalTime.of(8, 0)
         val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
+            externalUserId = externalUserId,
             quietModeStart = expectedStart,
             quietModeEnd = expectedEnd
         )
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
-        val result = service.getQuietMode(userId)
+        val result = service.getQuietMode(externalUserId)
 
         assertEquals(expectedStart, result.first)
         assertEquals(expectedEnd, result.second)
@@ -157,14 +157,14 @@ class NotificationSettingsServiceTest {
     @DisplayName("getQuietMode(): throws IllegalStateException when start is null")
     fun `getQuietMode throws when start is null`() {
         val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
+            externalUserId = externalUserId,
             quietModeStart = null,
             quietModeEnd = LocalTime.of(8, 0)
         )
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         assertThrows(IllegalStateException::class.java) {
-            service.getQuietMode(userId)
+            service.getQuietMode(externalUserId)
         }
     }
 
@@ -172,32 +172,32 @@ class NotificationSettingsServiceTest {
     @DisplayName("getQuietMode(): throws IllegalStateException when end is null")
     fun `getQuietMode throws when end is null`() {
         val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
+            externalUserId = externalUserId,
             quietModeStart = LocalTime.of(23, 0),
             quietModeEnd = null
         )
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         assertThrows(IllegalStateException::class.java) {
-            service.getQuietMode(userId)
+            service.getQuietMode(externalUserId)
         }
     }
 
     @Test
     @DisplayName("changeNotificationStatus(): enables notifications when active is true")
     fun `changeNotificationStatus enables when active true`() {
-        service.changeNotificationStatus(userId, true)
+        service.changeNotificationStatus(externalUserId, true)
 
-        verify(notificationAccessService).enableNotifications(userId)
+        verify(notificationAccessService).enableNotifications(externalUserId)
         verify(notificationAccessService, never()).disableNotifications(anyLong())
     }
 
     @Test
     @DisplayName("changeNotificationStatus(): disables notifications when active is false")
     fun `changeNotificationStatus disables when active false`() {
-        service.changeNotificationStatus(userId, false)
+        service.changeNotificationStatus(externalUserId, false)
 
-        verify(notificationAccessService).disableNotifications(userId)
+        verify(notificationAccessService).disableNotifications(externalUserId)
         verify(notificationAccessService, never()).enableNotifications(anyLong())
     }
 
@@ -206,9 +206,9 @@ class NotificationSettingsServiceTest {
     fun `changeTimezone updates timezone`() {
         val timezone = "America/New_York"
 
-        service.changeTimezone(userId, timezone)
+        service.changeTimezone(externalUserId, timezone)
 
-        verify(notificationAccessService).changeTimezone(userId, timezone)
+        verify(notificationAccessService).changeTimezone(externalUserId, timezone)
     }
 
     @ParameterizedTest
@@ -216,7 +216,7 @@ class NotificationSettingsServiceTest {
     @DisplayName("changeTimezone(): throws IllegalArgumentException for invalid timezone")
     fun `changeTimezone throws when invalid timezone`(timezone: String) {
         assertThrows(IllegalArgumentException::class.java) {
-            service.changeTimezone(userId, timezone)
+            service.changeTimezone(externalUserId, timezone)
         }
 
         verify(notificationAccessService, never()).changeTimezone(anyLong(), anyString())
@@ -225,32 +225,32 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("getNextNotificationAt(): delegates to time service and returns instant")
     fun `getNextNotificationAt delegates to time service`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
         val expectedInstant = Instant.parse("2025-01-01T11:00:00Z")
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
         `when`(notificationTimeService.calculateNextNotificationAt(dto)).thenReturn(expectedInstant)
 
-        val result = service.getNextNotificationAt(userId)
+        val result = service.getNextNotificationAt(externalUserId)
 
         assertEquals(expectedInstant, result)
-        verify(notificationAccessService).findNotificationSettingByTelegramUserId(userId)
+        verify(notificationAccessService).findNotificationSettingByExternalUserId(externalUserId)
         verify(notificationTimeService).calculateNextNotificationAt(dto)
     }
 
     @Test
     @DisplayName("getAllSettings(): returns SettingDto with all fields when notifications are enabled")
     fun `getAllSettings returns full dto when enabled`() {
-        `when`(notificationAccessService.isEnabledNotifications(userId)).thenReturn(true)
+        `when`(notificationAccessService.isEnabledNotifications(externalUserId)).thenReturn(true)
         val notificationDto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
+            externalUserId = externalUserId,
             notificationInterval = IntervalNotificationType.HOUR,
             userTimeZone = "Europe/Moscow",
             quietModeStart = LocalTime.of(23, 0),
             quietModeEnd = LocalTime.of(8, 0),
         )
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(notificationDto)
 
-        val result = service.getAllSettings(userId)
+        val result = service.getAllSettings(externalUserId)
 
         assertEquals(true, result.notificationActive)
         assertEquals(IntervalNotificationType.HOUR.name, result.interval)
@@ -260,16 +260,16 @@ class NotificationSettingsServiceTest {
         assertEquals("08:00", result.quietModeEnd)
         assertEquals("Europe/Moscow", result.timezone)
         assertEquals(2000, result.dailyGoalMl)
-        verify(notificationAccessService).isEnabledNotifications(userId)
-        verify(notificationAccessService).findNotificationSettingByTelegramUserId(userId)
+        verify(notificationAccessService).isEnabledNotifications(externalUserId)
+        verify(notificationAccessService).findNotificationSettingByExternalUserId(externalUserId)
     }
 
     @Test
     @DisplayName("getAllSettings(): returns SettingDto with only notificationActive=false when notifications are disabled")
     fun `getAllSettings returns minimal dto when disabled`() {
-        `when`(notificationAccessService.isEnabledNotifications(userId)).thenReturn(false)
+        `when`(notificationAccessService.isEnabledNotifications(externalUserId)).thenReturn(false)
 
-        val result = service.getAllSettings(userId)
+        val result = service.getAllSettings(externalUserId)
 
         assertEquals(false, result.notificationActive)
         assertEquals(null, result.interval)
@@ -279,8 +279,8 @@ class NotificationSettingsServiceTest {
         assertEquals(null, result.quietModeEnd)
         assertEquals(null, result.timezone)
         assertEquals(null, result.dailyGoalMl)
-        verify(notificationAccessService).isEnabledNotifications(userId)
-        verify(notificationAccessService, never()).findNotificationSettingByTelegramUserId(anyLong())
+        verify(notificationAccessService).isEnabledNotifications(externalUserId)
+        verify(notificationAccessService, never()).findNotificationSettingByExternalUserId(anyLong())
     }
 
     @Test
@@ -289,9 +289,9 @@ class NotificationSettingsServiceTest {
         val minutes = 240L
         val expectedPauseUntil = LocalDateTime.of(2025, 1, 1, 16, 0)
 
-        service.pauseNotifications(userId, minutes)
+        service.pauseNotifications(externalUserId, minutes)
 
-        verify(notificationAccessService).setPause(userId, expectedPauseUntil)
+        verify(notificationAccessService).setPause(externalUserId, expectedPauseUntil)
     }
 
     @ParameterizedTest
@@ -299,7 +299,7 @@ class NotificationSettingsServiceTest {
     @DisplayName("pauseNotifications(): throws IllegalArgumentException when minutes is not positive")
     fun `pauseNotifications throws when minutes not positive`(minutes: Long) {
         assertThrows(IllegalArgumentException::class.java) {
-            service.pauseNotifications(userId, minutes)
+            service.pauseNotifications(externalUserId, minutes)
         }
 
         verify(notificationAccessService, never()).setPause(anyLong(), any())
@@ -308,19 +308,19 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("cancelPause(): delegates to access service with null pauseUntil")
     fun `cancelPause delegates with null`() {
-        service.cancelPause(userId)
+        service.cancelPause(externalUserId)
 
-        verify(notificationAccessService).setPause(userId, null)
+        verify(notificationAccessService).setPause(externalUserId, null)
     }
 
     @Test
     @DisplayName("getPauseState(): returns paused=true and ISO UTC pauseUntil when pause is active")
     fun `getPauseState returns paused true when active`() {
         val pauseUntil = LocalDateTime.of(2025, 1, 1, 13, 0)
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, pauseUntil = pauseUntil)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, pauseUntil = pauseUntil)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
-        val result = service.getPauseState(userId)
+        val result = service.getPauseState(externalUserId)
 
         assertEquals(true, result.paused)
         assertEquals(Instant.parse("2025-01-01T13:00:00Z"), result.pauseUntil)
@@ -330,10 +330,10 @@ class NotificationSettingsServiceTest {
     @DisplayName("getPauseState(): returns paused=false and null pauseUntil when pauseUntil is in the past")
     fun `getPauseState returns paused false when pauseUntil expired`() {
         val pauseUntil = LocalDateTime.of(2025, 1, 1, 11, 0)
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, pauseUntil = pauseUntil)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, pauseUntil = pauseUntil)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
-        val result = service.getPauseState(userId)
+        val result = service.getPauseState(externalUserId)
 
         assertEquals(false, result.paused)
         assertEquals(null, result.pauseUntil)
@@ -342,10 +342,10 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("getPauseState(): returns paused=false and null pauseUntil when pauseUntil is null")
     fun `getPauseState returns paused false when pauseUntil null`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, pauseUntil = null)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, pauseUntil = null)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
-        val result = service.getPauseState(userId)
+        val result = service.getPauseState(externalUserId)
 
         assertEquals(false, result.paused)
         assertEquals(null, result.pauseUntil)
@@ -355,10 +355,10 @@ class NotificationSettingsServiceTest {
     @DisplayName("getPauseState(): returns paused=false when pauseUntil equals now")
     fun `getPauseState returns paused false when pauseUntil equals now`() {
         val pauseUntil = LocalDateTime.of(2025, 1, 1, 12, 0)
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, pauseUntil = pauseUntil)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, pauseUntil = pauseUntil)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
-        val result = service.getPauseState(userId)
+        val result = service.getPauseState(externalUserId)
 
         assertEquals(false, result.paused)
         assertEquals(null, result.pauseUntil)
@@ -372,28 +372,28 @@ class NotificationSettingsServiceTest {
         val firstExpected = LocalDateTime.of(2025, 1, 1, 13, 0)
         val secondExpected = LocalDateTime.of(2025, 1, 1, 16, 0)
 
-        service.pauseNotifications(userId, firstMinutes)
-        service.pauseNotifications(userId, secondMinutes)
+        service.pauseNotifications(externalUserId, firstMinutes)
+        service.pauseNotifications(externalUserId, secondMinutes)
 
-        verify(notificationAccessService).setPause(userId, firstExpected)
-        verify(notificationAccessService).setPause(userId, secondExpected)
+        verify(notificationAccessService).setPause(externalUserId, firstExpected)
+        verify(notificationAccessService).setPause(externalUserId, secondExpected)
     }
 
     @Test
     @DisplayName("pauseNotifications(): does not call cancelPause path")
     fun `pauseNotifications does not cancel`() {
-        service.pauseNotifications(userId, 30L)
+        service.pauseNotifications(externalUserId, 30L)
 
-        verify(notificationAccessService, never()).setPause(userId, null)
+        verify(notificationAccessService, never()).setPause(externalUserId, null)
     }
 
     @ParameterizedTest
     @ValueSource(ints = [2000, 2250, 2500, 2750, 3000])
     @DisplayName("changeDailyGoal(): delegates to access service for any allowed value (incl. 2000 and 3000 boundaries)")
     fun `changeDailyGoal delegates for allowed value`(goalMl: Int) {
-        service.changeDailyGoal(userId, goalMl)
+        service.changeDailyGoal(externalUserId, goalMl)
 
-        verify(notificationAccessService).updateDailyGoal(userId, goalMl)
+        verify(notificationAccessService).updateDailyGoal(externalUserId, goalMl)
     }
 
     @ParameterizedTest
@@ -401,7 +401,7 @@ class NotificationSettingsServiceTest {
     @DisplayName("changeDailyGoal(): throws IllegalArgumentException for value outside ALLOWED_VALUES_ML")
     fun `changeDailyGoal throws when value not allowed`(goalMl: Int) {
         assertThrows(IllegalArgumentException::class.java) {
-            service.changeDailyGoal(userId, goalMl)
+            service.changeDailyGoal(externalUserId, goalMl)
         }
 
         verify(notificationAccessService, never()).updateDailyGoal(anyLong(), anyInt())
@@ -412,13 +412,13 @@ class NotificationSettingsServiceTest {
     fun `getPauseState returns paused true regardless of notificationAttempts`() {
         val pauseUntil = LocalDateTime.of(2025, 1, 1, 13, 0)
         val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
+            externalUserId = externalUserId,
             pauseUntil = pauseUntil,
             notificationAttempts = 3
         )
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
-        val result = service.getPauseState(userId)
+        val result = service.getPauseState(externalUserId)
 
         assertEquals(true, result.paused)
         assertEquals(Instant.parse("2025-01-01T13:00:00Z"), result.pauseUntil)

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsServiceTest.kt
@@ -31,7 +31,7 @@ import java.util.stream.Stream
 @DisplayName("StatisticsService Unit Test")
 class StatisticsServiceTest {
 
-    private val userId = 1L
+    private val externalUserId = 1L
 
     private lateinit var notificationAccessService: NotificationAccessService
     private lateinit var waterStatisticAccessService: WaterStatisticAccessService
@@ -51,9 +51,9 @@ class StatisticsServiceTest {
     }
 
     private fun stubSettings(zone: String = "UTC", dailyGoalMl: Int = 2000) {
-        whenever(notificationAccessService.findNotificationSettingByTelegramUserId(userId))
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId))
             .thenReturn(DtoGenerator.generateNotificationDto(
-                externalUserId = userId, userTimeZone = zone, dailyGoalMl = dailyGoalMl
+                externalUserId = externalUserId, userTimeZone = zone, dailyGoalMl = dailyGoalMl
             ))
     }
 
@@ -89,17 +89,17 @@ class StatisticsServiceTest {
         val expectedFromService = emptyList<WaterStatisticDto>()
         stubEvents(expectedFromService)
 
-        val result = service.getToday(userId)
+        val result = service.getToday(externalUserId)
 
         val startCaptor = argumentCaptor<LocalDateTime>()
         val endCaptor = argumentCaptor<LocalDateTime>()
         verify(waterStatisticAccessService).findByUserAndEventTimeBetween(
-            eq(userId), startCaptor.capture(), endCaptor.capture()
+            eq(externalUserId), startCaptor.capture(), endCaptor.capture()
         )
         assertEquals(expectedStart, startCaptor.firstValue)
         assertEquals(expectedEnd, endCaptor.firstValue)
         assertSame(expectedFromService, result)
-        verify(notificationAccessService).findNotificationSettingByTelegramUserId(userId)
+        verify(notificationAccessService).findNotificationSettingByExternalUserId(externalUserId)
     }
 
     @Test
@@ -109,14 +109,14 @@ class StatisticsServiceTest {
         stubSettings(zone = "Europe/Moscow")
         val expected = listOf(
             DtoGenerator.generateWaterStatisticDto(
-                externalUserId = userId,
+                externalUserId = externalUserId,
                 eventTime = LocalDateTime.of(2026, 5, 8, 8, 15),
                 waterAmountMl = 250,
             ),
         )
         stubEvents(expected)
 
-        val result = service.getToday(userId)
+        val result = service.getToday(externalUserId)
 
         assertEquals(expected, result)
     }
@@ -130,7 +130,7 @@ class StatisticsServiceTest {
         stubEvents(
             listOf(
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 12, 8, 15),
                     waterAmountMl = 250,
                 )
@@ -139,7 +139,7 @@ class StatisticsServiceTest {
         stubFirstEntry(LocalDateTime.of(2026, 5, 1, 9, 0))
         stubInsight("insight day")
 
-        val result = service.getStatistics(userId, today, today)
+        val result = service.getStatistics(externalUserId, today, today)
 
         assertEquals(24, result.points.size)
         assertEquals("08:00", result.points[8].label)
@@ -160,12 +160,12 @@ class StatisticsServiceTest {
         stubEvents(
             listOf(
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 4, 10, 0),
                     waterAmountMl = 2100,
                 ),
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 6, 10, 0),
                     waterAmountMl = 2400,
                 ),
@@ -174,7 +174,7 @@ class StatisticsServiceTest {
         stubFirstEntry(null)
         stubInsight("insight week")
 
-        val result = service.getStatistics(userId, LocalDate.of(2026, 5, 4), LocalDate.of(2026, 5, 10))
+        val result = service.getStatistics(externalUserId, LocalDate.of(2026, 5, 4), LocalDate.of(2026, 5, 10))
 
         assertEquals(7, result.points.size)
         assertEquals("2026-05-04", result.points[0].label)
@@ -199,7 +199,7 @@ class StatisticsServiceTest {
         stubEvents(
             listOf(
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 1, 9, 30),
                     waterAmountMl = 400,
                 )
@@ -208,7 +208,7 @@ class StatisticsServiceTest {
         stubFirstEntry(null)
         stubInsight()
 
-        val result = service.getStatistics(userId, past, past)
+        val result = service.getStatistics(externalUserId, past, past)
 
         assertEquals(24, result.points.size)
         assertEquals(400, result.points[9].valueMl)
@@ -226,19 +226,19 @@ class StatisticsServiceTest {
         stubEvents(
             listOf(
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 12, 8, 0),
                     eventType = AnswerNotificationType.YES,
                     waterAmountMl = 500,
                 ),
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 12, 10, 0),
                     eventType = AnswerNotificationType.SNOOZE,
                     waterAmountMl = 100,
                 ),
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 12, 14, 0),
                     eventType = AnswerNotificationType.CANCEL,
                     waterAmountMl = 200,
@@ -248,7 +248,7 @@ class StatisticsServiceTest {
         stubFirstEntry(null)
         stubInsight()
 
-        val result = service.getStatistics(userId, today, today)
+        val result = service.getStatistics(externalUserId, today, today)
 
         assertEquals(500, result.averageMlPerDay)
         assertEquals(500, result.points[8].valueMl)
@@ -267,7 +267,7 @@ class StatisticsServiceTest {
         stubSettings()
         val recentMet = (0L..6L).map { offset ->
             DtoGenerator.generateWaterStatisticDto(
-                externalUserId = userId,
+                externalUserId = externalUserId,
                 eventTime = today.minusDays(offset).atTime(10, 0),
                 waterAmountMl = 2200,
             )
@@ -276,7 +276,7 @@ class StatisticsServiceTest {
         stubFirstEntry(null)
         stubInsight()
 
-        val result = service.getStatistics(userId, LocalDate.of(2026, 4, 1), LocalDate.of(2026, 4, 30))
+        val result = service.getStatistics(externalUserId, LocalDate.of(2026, 4, 1), LocalDate.of(2026, 4, 30))
 
         assertEquals(7, result.currentStreakDays)
     }
@@ -291,7 +291,7 @@ class StatisticsServiceTest {
         stubSettings()
         val events = (0L..500L).map { offset ->
             DtoGenerator.generateWaterStatisticDto(
-                externalUserId = userId,
+                externalUserId = externalUserId,
                 eventTime = today.minusDays(offset).atTime(10, 0),
                 waterAmountMl = 2200,
             )
@@ -301,7 +301,7 @@ class StatisticsServiceTest {
         stubInsight()
 
         val result = service.getStatistics(
-            userId, today.minusDays(500), today
+            externalUserId, today.minusDays(500), today
         )
 
         assertEquals(367, result.currentStreakDays)
@@ -319,13 +319,13 @@ class StatisticsServiceTest {
             listOf(
                 // outside range, fetched only for streak
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 1, 10, 0),
                     waterAmountMl = 9999,
                 ),
                 // inside range
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 17, 10, 0),
                     waterAmountMl = 2500,
                 ),
@@ -335,7 +335,7 @@ class StatisticsServiceTest {
         stubInsight()
 
         val result = service.getStatistics(
-            userId, LocalDate.of(2026, 5, 15), today
+            externalUserId, LocalDate.of(2026, 5, 15), today
         )
 
         assertNotNull(result.bestDay)
@@ -351,7 +351,7 @@ class StatisticsServiceTest {
         stubSettings()
 
         val ex = assertThrows(IllegalArgumentException::class.java) {
-            service.getStatistics(userId, LocalDate.of(2026, 5, 10), LocalDate.of(2026, 5, 9))
+            service.getStatistics(externalUserId, LocalDate.of(2026, 5, 10), LocalDate.of(2026, 5, 9))
         }
         assertTrue(ex.message!!.contains("'from' must be before or equal to 'to'"))
     }
@@ -364,7 +364,7 @@ class StatisticsServiceTest {
         stubSettings()
 
         val ex = assertThrows(IllegalArgumentException::class.java) {
-            service.getStatistics(userId, today.plusDays(1), today.plusDays(2))
+            service.getStatistics(externalUserId, today.plusDays(1), today.plusDays(2))
         }
         assertTrue(ex.message!!.contains("'from' must not be in the future"))
     }
@@ -379,10 +379,10 @@ class StatisticsServiceTest {
         stubFirstEntry(null)
         stubInsight()
 
-        val result = service.getStatistics(userId, today, today)
+        val result = service.getStatistics(externalUserId, today, today)
 
         assertNull(result.firstEntryAt)
-        verify(waterStatisticAccessService).findEarliestEventTimeByUser(userId)
+        verify(waterStatisticAccessService).findEarliestEventTimeByUser(externalUserId)
     }
 
     @Test
@@ -395,7 +395,7 @@ class StatisticsServiceTest {
         stubFirstEntry(LocalDateTime.of(2026, 1, 15, 7, 45))
         stubInsight()
 
-        val result = service.getStatistics(userId, today, today)
+        val result = service.getStatistics(externalUserId, today, today)
 
         assertEquals(Instant.parse("2026-01-15T07:45:00Z"), result.firstEntryAt)
     }
@@ -409,7 +409,7 @@ class StatisticsServiceTest {
         stubEvents(
             listOf(
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 12, 10, 0),
                     waterAmountMl = 2200,
                 )
@@ -418,7 +418,7 @@ class StatisticsServiceTest {
         stubFirstEntry(null)
         stubInsight("text")
 
-        val result = service.getStatistics(userId, today, today)
+        val result = service.getStatistics(externalUserId, today, today)
 
         val ctxCaptor = argumentCaptor<InsightStatsContext>()
         verify(messageProvider).getMessage(eq(MessageSpec.InsightStats), ctxCaptor.capture())

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/telegram/TelegramValidatorServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/telegram/TelegramValidatorServiceTest.kt
@@ -82,7 +82,7 @@ class TelegramValidatorServiceTest {
 
         val result = service.map(initData)
 
-        assertEquals(1L, result.telegramId)
+        assertEquals(1L, result.externalUserId)
         assertEquals("First Name", result.firstName)
     }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
@@ -113,12 +113,12 @@ class DtoGenerator {
         )
 
         fun generateTelegramUserDto(
-            telegramId: Long = 1L,
+            externalUserId: Long = 1L,
             firstName: String? = "First Name",
             lastName: String? = null,
             username: String? = "username",
         ): TelegramUserDto = TelegramUserDto(
-            telegramId = telegramId,
+            externalUserId = externalUserId,
             firstName = firstName,
             lastName = lastName,
             username = username,


### PR DESCRIPTION
## Summary
- Unify the four names used for the Telegram external user id (`telegramId`, `telegramUserId`, `userId`, `externalUserId`) to a single `externalUserId` across the backend - properties, parameters, method names, locals, logs, tests, and test constants.
- Contract boundaries kept intentionally: the `GET /users/me` JSON key stays `telegramUserId` via `@JsonProperty` on `MeResponse.externalUserId` (MiniApp contract); the DB column `external_user_id` and the initData `@JsonProperty("id")` are untouched.
- Spring Data derived-query methods are NOT renamed (their names are bound to the entity property `externalUserId`); only the `@Query` repository method `isEnabledByExternalUserId` was renamed.

## Test plan
- [x] `./gradlew test` - all 558 tests green (integration tests boot the Spring context + DB, confirming derived-query resolution)
- [x] main + test compilation
- [x] Manual bot smoke test - OK
- [x] `GET /users/me` JSON key stays `telegramUserId` via `@JsonProperty` (frontend contract preserved)
