### PR TITLE
DPTB-109: switch WebConfig to default-secure auth mapping

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/WebConfig.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/WebConfig.kt
@@ -21,13 +21,12 @@ class WebConfig(
 
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(telegramAuthInterceptor)
-            .addPathPatterns(
-                "/settings",
-                "/settings/**",
-                "/notifications/**",
-                "/users/**",
-                "/systems/**",
-                "/statistics/**"
+            .addPathPatterns("/**")
+            .excludePathPatterns(
+                "/docs/**",
+                "/swagger-ui/**",
+                "/v3/api-docs/**",
+                "/actuator/**"
             )
 
         registry.addInterceptor(adminAuthInterceptor)

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigAuthInterceptorIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigAuthInterceptorIntegrationTest.kt
@@ -1,0 +1,138 @@
+package ru.illine.drinking.ponies.config.web
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.context.jdbc.SqlConfig
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import ru.illine.drinking.ponies.config.web.WebConfigAuthInterceptorIntegrationTest.DefaultSecureTestConfig
+import ru.illine.drinking.ponies.config.web.security.AuthErrorType
+import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
+import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
+
+@SpringIntegrationTest
+@DisplayName("WebConfig default-secure interceptor Spring Integration Test")
+@Import(DefaultSecureTestConfig::class)
+@Sql(
+    scripts = ["classpath:sql/access/TelegramUserAccessService.sql"],
+    config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+)
+@Sql(
+    scripts = ["classpath:sql/clear.sql"],
+    config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD
+)
+class WebConfigAuthInterceptorIntegrationTest @Autowired constructor(
+    private val restTemplate: TestRestTemplate,
+) {
+
+    @MockitoBean
+    private lateinit var telegramValidatorService: TelegramValidatorService
+
+    private val telegramUser = TelegramUserDto(
+        externalUserId = 1L,
+        firstName = "First Name",
+        lastName = null,
+        username = "username"
+    )
+
+    @BeforeEach
+    fun setUp() {
+        `when`(telegramValidatorService.verifySignature(any())).thenReturn(true)
+        `when`(telegramValidatorService.map(any())).thenReturn(telegramUser)
+    }
+
+    private fun buildHeaders(): HttpHeaders {
+        return HttpHeaders().apply {
+            set("X-Authorization-Telegram-Data", "test-init-data")
+        }
+    }
+
+    @Nested
+    @DisplayName("default-secure: endpoint outside any exclude pattern is protected by default")
+    inner class DefaultSecureEndpoint {
+
+        private val url = "/test-default-secure"
+
+        @Test
+        @DisplayName("missing auth header - returns 401 with X-Auth-Error-Code invalid_auth_signature")
+        fun `missing auth header returns 401 with invalid_auth_signature header`() {
+            val response = restTemplate.exchange(
+                url, HttpMethod.GET, HttpEntity<Void>(HttpHeaders()), Void::class.java
+            )
+
+            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+            assertEquals(
+                AuthErrorType.INVALID_AUTH_SIGNATURE.value,
+                response.headers.getFirst(AuthErrorType.HEADER_NAME)
+            )
+            verify(telegramValidatorService, never()).verifySignature(any())
+            verify(telegramValidatorService, never()).map(any())
+        }
+
+        @Test
+        @DisplayName("valid auth header - returns 200")
+        fun `valid auth header returns 200`() {
+            val response = restTemplate.exchange(
+                url, HttpMethod.GET, HttpEntity<Void>(buildHeaders()), String::class.java
+            )
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            verify(telegramValidatorService).verifySignature("test-init-data")
+            verify(telegramValidatorService).map("test-init-data")
+        }
+    }
+
+    @Nested
+    @DisplayName("excluded public path: /v3/api-docs is reachable without auth header")
+    inner class ExcludedPublicPath {
+
+        @Test
+        @DisplayName("GET /v3/api-docs without auth header - returns 200 and is not blocked by auth")
+        fun `api docs without auth header returns 200`() {
+            val response = restTemplate.exchange(
+                "/v3/api-docs", HttpMethod.GET, HttpEntity<Void>(HttpHeaders()), String::class.java
+            )
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertNotEquals(
+                AuthErrorType.INVALID_AUTH_SIGNATURE.value,
+                response.headers.getFirst(AuthErrorType.HEADER_NAME)
+            )
+            verify(telegramValidatorService, never()).verifySignature(any())
+        }
+    }
+
+    @TestConfiguration
+    class DefaultSecureTestConfig {
+
+        @RestController
+        @RequestMapping("/test-default-secure")
+        class DefaultSecureTestController {
+
+            @GetMapping
+            fun defaultSecure(): String = "ok"
+        }
+    }
+}

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/message/LocalMessageProviderTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/message/LocalMessageProviderTest.kt
@@ -111,6 +111,34 @@ class LocalMessageProviderTest {
     }
 
     @Test
+    @DisplayName("getMessage(): avg >= goal but goal <= 0 does NOT trigger AVG_GOOD (guards against bogus daily goal)")
+    fun `avg above non-positive goal does not trigger specific bucket`() {
+        // Predicate is `avgMlPerDay >= dailyGoalMl && dailyGoalMl > 0`.
+        // With dailyGoalMl=0 the first part is true (0 >= 0) but the guard `> 0` must veto the AVG_GOOD rule,
+        // so only the fallback bucket may surface - never the "выше цели"/"перебирает" phrasing.
+        val outcomes = (0L until 100L).map { seed ->
+            LocalMessageProvider(Random(seed))
+                .getMessage(
+                    MessageSpec.InsightStats,
+                    DtoGenerator.generateInsightStatsContext(
+                        currentStreakDays = 0,
+                        avgMlPerDay = 0,
+                        dailyGoalMl = 0,
+                        bestDay = null,
+                    )
+                ).text
+        }
+
+        outcomes.forEach { text ->
+            assertFalse(
+                text.contains("выше цели") || text.contains("перебирает"),
+                "AVG_GOOD must not trigger when dailyGoalMl <= 0, got: $text"
+            )
+            assertTrue(text.isNotBlank(), "fallback must produce non-empty text")
+        }
+    }
+
+    @Test
     @DisplayName("getMessage(): bestDay set with valueMl > 0 renders BEST_DAY phrasing reachably")
     fun `bestDay rule surfaces value`() {
         val outcomes = (0L until 100L).map { seed ->

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/message/TemplateRuleTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/message/TemplateRuleTest.kt
@@ -1,0 +1,39 @@
+package ru.illine.drinking.ponies.util.message
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import ru.illine.drinking.ponies.model.dto.message.InsightStatsContext
+import ru.illine.drinking.ponies.test.tag.UnitTest
+
+@UnitTest
+@DisplayName("TemplateRule Unit Test")
+class TemplateRuleTest {
+
+    @Test
+    @DisplayName("init: empty templates list is rejected (rule must carry at least one template)")
+    fun `empty templates rejected`() {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            TemplateRule<InsightStatsContext>(
+                predicate = { true },
+                templates = emptyList()
+            )
+        }
+
+        assertEquals("TemplateRule must have at least one template", exception.message)
+    }
+
+    @Test
+    @DisplayName("init: non-empty templates list is accepted")
+    fun `non-empty templates accepted`() {
+        val rule = TemplateRule<InsightStatsContext>(
+            predicate = { true },
+            templates = listOf({ "phrase" })
+        )
+
+        assertTrue(rule.predicate(InsightStatsContext(avgMlPerDay = 0, bestDay = null, currentStreakDays = 0, dailyGoalMl = 0)))
+        assertEquals(1, rule.templates.size)
+    }
+}

--- a/src/test/resources/application-integration-test.yaml
+++ b/src/test/resources/application-integration-test.yaml
@@ -49,6 +49,12 @@ telegram-bot:
     notification:
       cron: "*/15 * * * * *"
 
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+
 logbook:
   strategy: body-only-if-status-at-least
   minimum-status: 200


### PR DESCRIPTION
## Summary
- Invert `WebConfig` auth from an explicit whitelist to default-secure: `telegramAuthInterceptor` now maps `/**` with `excludePathPatterns` for public paths (`/docs/**`, `/swagger-ui/**`, `/v3/api-docs/**`, `/actuator/**`).
- A new endpoint is protected by default - forgetting to register it can no longer leave it open (closes the DPTB-60 class of bug).
- Enable springdoc in the integration-test profile so `/v3/api-docs` is reachable without auth in tests.
- Add `WebConfigAuthInterceptorIntegrationTest`: default-secure 401 without header / 200 with valid header, and excluded `/v3/api-docs` 200 without auth.
- Drive-by coverage: `LocalInsightStats` goal guard + new `TemplateRuleTest` (empty-templates invariant).

## Test plan
- [x] `./gradlew test` green locally (full suite)
- [x] New endpoint without auth -> 401; with valid header -> 200
- [x] `/v3/api-docs` reachable without auth -> 200
- [x] Verified on stand
