### PR TITLE
DPTB-136: migrate builders to Konvert compile-time mappers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.kotlin.jpa)
     alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
 }
 
 group = "ru.illine"
@@ -50,6 +51,7 @@ dependencies {
     implementation(libs.commons.codec)
     implementation(libs.commons.lang3)
     implementation(libs.springdoc.openapi.starter.webmvc.ui)
+    implementation(libs.konvert.api)
 
     liquibaseRuntime(libs.liquibase.core)
     liquibaseRuntime(libs.liquibase.groovy.dsl)
@@ -62,6 +64,7 @@ dependencies {
     runtimeOnly(libs.micrometer.exposition.formats)
 
     kapt(libs.spring.boot.configuration.processor)
+    ksp(libs.konvert)
 
     testImplementation(libs.spring.boot.starter.test) {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
@@ -79,6 +82,13 @@ allOpen {
     annotation("jakarta.persistence.Entity")
     annotation("jakarta.persistence.MappedSuperclass")
     annotation("jakarta.persistence.Embeddable")
+}
+
+ksp {
+    // Konvert: make the build fail on incomplete or invalid mappings - the core goal of DPTB-136.
+    arg("konvert.invalid-mapping-strategy", "fail")
+    arg("konvert.non-constructor-properties-mapping", "all")
+    arg("konvert.enforce-not-null", "true")
 }
 
 liquibase {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,9 @@
 spring-boot-plugin = "3.5.9"
 spring-dependency-management-plugin = "1.1.7"
 liquibase-plugin = "2.2.1"
-kotlin-plugin = "2.1.21"
+kotlin-plugin = "2.3.10"
+ksp-plugin = "2.3.5"
+konvert = "4.5.0"
 
 validation-api = "2.0.1.Final"
 logbook = "3.9.0"
@@ -67,6 +69,8 @@ commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "co
 springdoc-openapi-starter-webmvc-ui = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc" }
 xmlunit = { module = "org.xmlunit:xmlunit-core", version.ref = "xmlunit" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
+konvert = { module = "io.mcarle:konvert", version.ref = "konvert" }
+konvert-api = { module = "io.mcarle:konvert-api", version.ref = "konvert" }
 
 [plugins]
 springframework-boot = { id = "org.springframework.boot", version.ref = "spring-boot-plugin" }
@@ -76,3 +80,4 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin-plugin" }
 kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin-plugin" }
 kotlin-jpa = { id = "org.jetbrains.kotlin.plugin.jpa", version.ref = "kotlin-plugin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin-plugin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp-plugin" }

--- a/src/main/kotlin/ru/illine/drinking/ponies/builder/NotificationSettingBuilder.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/builder/NotificationSettingBuilder.kt
@@ -1,5 +1,6 @@
 package ru.illine.drinking.ponies.builder
 
+import io.mcarle.konvert.api.Konverter
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
@@ -7,49 +8,35 @@ import ru.illine.drinking.ponies.model.entity.NotificationSettingEntity
 import ru.illine.drinking.ponies.model.entity.TelegramChatEntity
 import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 
+@Konverter
+interface NotificationSettingMapper {
+    fun toDto(
+        @Konverter.Source setting: NotificationSettingEntity,
+        telegramUser: TelegramUserDto,
+        telegramChat: TelegramChatDto,
+    ): NotificationSettingDto
+
+    fun toEntity(
+        @Konverter.Source setting: NotificationSettingDto,
+        telegramUser: TelegramUserEntity,
+        telegramChat: TelegramChatEntity,
+    ): NotificationSettingEntity
+}
+
 object NotificationSettingBuilder {
+    private val mapper: NotificationSettingMapper = Konverter.get<NotificationSettingMapper>()
+
     fun toDto(
         setting: NotificationSettingEntity,
         user: TelegramUserDto,
         chat: TelegramChatDto
     ): NotificationSettingDto =
-        NotificationSettingDto(
-            id = setting.id,
-            telegramUser = user,
-            telegramChat = chat,
-            notificationInterval = setting.notificationInterval,
-            timeOfLastNotification = setting.timeOfLastNotification,
-            notificationAttempts = setting.notificationAttempts,
-            quietModeStart = setting.quietModeStart,
-            quietModeEnd = setting.quietModeEnd,
-            pauseUntil = setting.pauseUntil,
-            dailyGoalMl = setting.dailyGoalMl,
-            enabled = setting.enabled,
-        )
+        mapper.toDto(setting, user, chat)
 
     fun toEntity(
         setting: NotificationSettingDto,
         user: TelegramUserEntity,
         chat: TelegramChatEntity
-    ): NotificationSettingEntity {
-
-        val setting = NotificationSettingEntity(
-            id = setting.id,
-            telegramUser = user,
-            telegramChat = chat,
-            notificationInterval = setting.notificationInterval,
-            timeOfLastNotification = setting.timeOfLastNotification,
-            notificationAttempts = setting.notificationAttempts,
-            quietModeStart = setting.quietModeStart,
-            quietModeEnd = setting.quietModeEnd,
-            pauseUntil = setting.pauseUntil,
-            dailyGoalMl = setting.dailyGoalMl,
-            enabled = setting.enabled,
-        )
-
-        user.notificationSettings = setting
-        user.telegramChats += chat
-
-        return setting
-    }
+    ): NotificationSettingEntity =
+        mapper.toEntity(setting, user, chat)
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/builder/SettingBuilder.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/builder/SettingBuilder.kt
@@ -4,6 +4,12 @@ import ru.illine.drinking.ponies.model.dto.SettingDto
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.util.TimeHelper
 
+// Intentionally hand-written, not migrated to Konvert (DPTB-136): this is a presentation
+// transformation, not a structural mapping - the interval enum is expanded into three fields,
+// LocalTime is formatted to String, and timezone is read from a nested object. Konvert would
+// express all of this as @Mapping(expression=...), which it does not verify, giving no real
+// safety over this named-constructor form. Correctness is guarded by
+// NotificationSettingsServiceTest."getAllSettings returns full dto when enabled", which asserts every field.
 object SettingBuilder {
     fun toDto(settings: NotificationSettingDto): SettingDto = SettingDto(
         interval = settings.notificationInterval.name,

--- a/src/main/kotlin/ru/illine/drinking/ponies/builder/SettingResponseBuilder.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/builder/SettingResponseBuilder.kt
@@ -1,0 +1,16 @@
+package ru.illine.drinking.ponies.builder
+
+import io.mcarle.konvert.api.Konverter
+import ru.illine.drinking.ponies.model.dto.SettingDto
+import ru.illine.drinking.ponies.model.dto.response.SettingResponse
+
+@Konverter
+interface SettingResponseMapper {
+    fun toResponse(dto: SettingDto): SettingResponse
+}
+
+object SettingResponseBuilder {
+    private val mapper: SettingResponseMapper = Konverter.get<SettingResponseMapper>()
+
+    fun toResponse(dto: SettingDto): SettingResponse = mapper.toResponse(dto)
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/builder/StatisticsBuilder.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/builder/StatisticsBuilder.kt
@@ -1,30 +1,34 @@
 package ru.illine.drinking.ponies.builder
 
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Mapping
 import ru.illine.drinking.ponies.model.dto.BestDayDto
 import ru.illine.drinking.ponies.model.dto.StatisticsDto
 import ru.illine.drinking.ponies.model.dto.StatisticsPointDto
 import ru.illine.drinking.ponies.model.dto.response.BestDayInfo
-import ru.illine.drinking.ponies.model.dto.response.InsightInfo
 import ru.illine.drinking.ponies.model.dto.response.StatisticsPoint
 import ru.illine.drinking.ponies.model.dto.response.StatisticsResponse
 
+@Konverter
+interface StatisticsMapper {
+    @Konvert(
+        mappings = [
+            Mapping(
+                target = "insight",
+                expression = "ru.illine.drinking.ponies.model.dto.response.InsightInfo(it.insightText)",
+            ),
+        ]
+    )
+    fun toResponse(dto: StatisticsDto): StatisticsResponse
+
+    fun toPoint(dto: StatisticsPointDto): StatisticsPoint
+
+    fun toBestDay(dto: BestDayDto): BestDayInfo
+}
+
 object StatisticsBuilder {
+    private val mapper: StatisticsMapper = Konverter.get<StatisticsMapper>()
 
-    fun toResponse(dto: StatisticsDto): StatisticsResponse =
-        StatisticsResponse(
-            points = dto.points.map(::toPoint),
-            dailyGoalMl = dto.dailyGoalMl,
-            averageMlPerDay = dto.averageMlPerDay,
-            bestDay = dto.bestDay?.let(::toBestDay),
-            currentStreakDays = dto.currentStreakDays,
-            insight = InsightInfo(text = dto.insightText),
-            firstEntryAt = dto.firstEntryAt,
-        )
-
-    private fun toPoint(point: StatisticsPointDto): StatisticsPoint =
-        StatisticsPoint(label = point.label, valueMl = point.valueMl)
-
-    private fun toBestDay(bestDay: BestDayDto): BestDayInfo =
-        BestDayInfo(date = bestDay.date, valueMl = bestDay.valueMl, weekday = bestDay.weekday)
-
+    fun toResponse(dto: StatisticsDto): StatisticsResponse = mapper.toResponse(dto)
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/builder/TelegramChatBuilder.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/builder/TelegramChatBuilder.kt
@@ -1,25 +1,30 @@
 package ru.illine.drinking.ponies.builder
 
+import io.mcarle.konvert.api.Konverter
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
 import ru.illine.drinking.ponies.model.entity.TelegramChatEntity
 import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 
+@Konverter
+interface TelegramChatMapper {
+    fun toDto(
+        @Konverter.Source chat: TelegramChatEntity,
+        telegramUser: TelegramUserDto,
+    ): TelegramChatDto
+
+    fun toEntity(
+        @Konverter.Source chat: TelegramChatDto,
+        telegramUser: TelegramUserEntity,
+    ): TelegramChatEntity
+}
+
 object TelegramChatBuilder {
+    private val mapper: TelegramChatMapper = Konverter.get<TelegramChatMapper>()
 
     fun toDto(chat: TelegramChatEntity, user: TelegramUserDto): TelegramChatDto =
-        TelegramChatDto(
-            id = chat.id,
-            telegramUser = user,
-            externalChatId = chat.externalChatId,
-            previousNotificationMessageId = chat.previousNotificationMessageId,
-        )
+        mapper.toDto(chat, user)
 
     fun toEntity(chat: TelegramChatDto, user: TelegramUserEntity): TelegramChatEntity =
-        TelegramChatEntity(
-            id = chat.id,
-            externalChatId = chat.externalChatId,
-            previousNotificationMessageId = chat.previousNotificationMessageId,
-            telegramUser = user,
-        )
+        mapper.toEntity(chat, user)
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/builder/TelegramUserBuilder.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/builder/TelegramUserBuilder.kt
@@ -1,26 +1,19 @@
 package ru.illine.drinking.ponies.builder
 
+import io.mcarle.konvert.api.Konverter
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
 import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 
-object TelegramUserBuilder {
-    fun toDto(entity: TelegramUserEntity): TelegramUserDto =
-        TelegramUserDto(
-            id = entity.id,
-            externalUserId = entity.externalUserId,
-            userTimeZone = entity.userTimeZone,
-            isAdmin = entity.isAdmin,
-            created = entity.created,
-            deleted = entity.deleted,
-        )
+@Konverter
+interface TelegramUserMapper {
+    fun toDto(entity: TelegramUserEntity): TelegramUserDto
+    fun toEntity(dto: TelegramUserDto): TelegramUserEntity
+}
 
-    fun toEntity(dto: TelegramUserDto): TelegramUserEntity =
-        TelegramUserEntity(
-            id = dto.id,
-            externalUserId = dto.externalUserId,
-            userTimeZone = dto.userTimeZone,
-            isAdmin = dto.isAdmin,
-            created = dto.created,
-            deleted = dto.deleted,
-        )
+object TelegramUserBuilder {
+    private val mapper: TelegramUserMapper = Konverter.get<TelegramUserMapper>()
+
+    fun toDto(entity: TelegramUserEntity): TelegramUserDto = mapper.toDto(entity)
+
+    fun toEntity(dto: TelegramUserDto): TelegramUserEntity = mapper.toEntity(dto)
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/builder/WaterStatisticBuilder.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/builder/WaterStatisticBuilder.kt
@@ -1,38 +1,44 @@
 package ru.illine.drinking.ponies.builder
 
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Mapping
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.model.dto.response.WaterEntry
 import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 import ru.illine.drinking.ponies.model.entity.WaterStatisticEntity
-import ru.illine.drinking.ponies.util.statistics.toUtcInstant
+
+@Konverter
+interface WaterStatisticMapper {
+    fun toDto(
+        @Konverter.Source entity: WaterStatisticEntity,
+        telegramUser: TelegramUserDto,
+    ): WaterStatisticDto
+
+    fun toEntity(
+        @Konverter.Source dto: WaterStatisticDto,
+        telegramUser: TelegramUserEntity,
+    ): WaterStatisticEntity
+
+    @Konvert(
+        mappings = [
+            Mapping(source = "waterAmountMl", target = "amountMl"),
+            Mapping(target = "eventTime", expression = "it.eventTime.toInstant(java.time.ZoneOffset.UTC)"),
+        ]
+    )
+    fun toWaterEntry(dto: WaterStatisticDto): WaterEntry
+}
 
 object WaterStatisticBuilder {
+    private val mapper: WaterStatisticMapper = Konverter.get<WaterStatisticMapper>()
 
     fun toDto(entity: WaterStatisticEntity, user: TelegramUserDto): WaterStatisticDto =
-        WaterStatisticDto(
-            id = entity.id,
-            telegramUser = user,
-            eventTime = entity.eventTime,
-            eventType = entity.eventType,
-            waterAmountMl = entity.waterAmountMl,
-            source = entity.source
-        )
+        mapper.toDto(entity, user)
 
     fun toEntity(dto: WaterStatisticDto, user: TelegramUserEntity): WaterStatisticEntity =
-        WaterStatisticEntity(
-            id = dto.id,
-            telegramUser = user,
-            eventTime = dto.eventTime,
-            eventType = dto.eventType,
-            waterAmountMl = dto.waterAmountMl,
-            source = dto.source
-        )
+        mapper.toEntity(dto, user)
 
     fun toWaterEntry(dto: WaterStatisticDto): WaterEntry =
-        WaterEntry(
-            eventTime = dto.eventTime.toUtcInstant(),
-            amountMl = dto.waterAmountMl,
-        )
-
+        mapper.toWaterEntry(dto)
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/SettingController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/SettingController.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
+import ru.illine.drinking.ponies.builder.SettingResponseBuilder
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.dto.TelegramUserDto
 import ru.illine.drinking.ponies.model.dto.response.SettingResponse
@@ -28,16 +29,7 @@ class SettingController(
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
     ): SettingResponse {
         val settings = notificationSettingsService.getAllSettings(telegramUser.externalUserId)
-        return SettingResponse(
-            interval = settings.interval,
-            intervalDisplayName = settings.intervalDisplayName,
-            intervalMinutes = settings.intervalMinutes,
-            quietModeStart = settings.quietModeStart,
-            quietModeEnd = settings.quietModeEnd,
-            timezone = settings.timezone,
-            dailyGoalMl = settings.dailyGoalMl,
-            notificationActive = settings.notificationActive,
-        )
+        return SettingResponseBuilder.toResponse(settings)
     }
 
     @PutMapping("/quiet-mode")

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
@@ -137,7 +137,10 @@ class NotificationAccessServiceImpl(
             .map {
                 val user = TelegramUserBuilder.toEntity(it.telegramUser)
                 val chat = TelegramChatBuilder.toEntity(it.telegramChat, user)
-                NotificationSettingBuilder.toEntity(it, user, chat)
+                NotificationSettingBuilder.toEntity(it, user, chat).also { setting ->
+                    user.notificationSettings = setting
+                    user.telegramChats += chat
+                }
             }
             .apply { settingRepository.saveAll(this) }
             .map {

--- a/src/test/kotlin/ru/illine/drinking/ponies/builder/StatisticsBuilderTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/builder/StatisticsBuilderTest.kt
@@ -43,9 +43,10 @@ class StatisticsBuilderTest {
         assertEquals(2000, response.dailyGoalMl)
         assertEquals(1950, response.averageMlPerDay)
         assertNotNull(response.bestDay)
-        assertEquals(LocalDate.of(2026, 5, 5), response.bestDay!!.date)
-        assertEquals(2100, response.bestDay!!.valueMl)
-        assertEquals(DayOfWeek.TUESDAY, response.bestDay!!.weekday)
+        val bestDay = response.bestDay!!
+        assertEquals(LocalDate.of(2026, 5, 5), bestDay.date)
+        assertEquals(2100, bestDay.valueMl)
+        assertEquals(DayOfWeek.TUESDAY, bestDay.weekday)
         assertEquals(3, response.currentStreakDays)
         assertEquals("Котик, ты пьёшь водицу 3 дней подряд - так держать!", response.insight.text)
         assertEquals(Instant.parse("2026-04-15T10:30:00Z"), response.firstEntryAt)

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
@@ -164,9 +164,10 @@ class StatisticsControllerTest @Autowired constructor(
             assertEquals(dto.averageMlPerDay, body.averageMlPerDay)
             assertEquals(dto.currentStreakDays, body.currentStreakDays)
             assertEquals(dto.insightText, body.insight.text)
-            assertEquals(LocalDate.of(2026, 5, 6), body.bestDay!!.date)
-            assertEquals(2400, body.bestDay!!.valueMl)
-            assertEquals(DayOfWeek.WEDNESDAY, body.bestDay!!.weekday)
+            val bestDay = body.bestDay!!
+            assertEquals(LocalDate.of(2026, 5, 6), bestDay.date)
+            assertEquals(2400, bestDay.valueMl)
+            assertEquals(DayOfWeek.WEDNESDAY, bestDay.weekday)
             assertEquals(Instant.parse("2026-04-15T10:30:00Z"), body.firstEntryAt)
             val fromCaptor = argumentCaptor<LocalDate>()
             val toCaptor = argumentCaptor<LocalDate>()

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsServiceTest.kt
@@ -182,9 +182,10 @@ class StatisticsServiceTest {
         assertEquals("2026-05-06", result.points[2].label)
         assertEquals(2400, result.points[2].valueMl)
         assertNotNull(result.bestDay)
-        assertEquals(LocalDate.of(2026, 5, 6), result.bestDay!!.date)
-        assertEquals(2400, result.bestDay!!.valueMl)
-        assertEquals(DayOfWeek.WEDNESDAY, result.bestDay!!.weekday)
+        val bestDay = result.bestDay!!
+        assertEquals(LocalDate.of(2026, 5, 6), bestDay.date)
+        assertEquals(2400, bestDay.valueMl)
+        assertEquals(DayOfWeek.WEDNESDAY, bestDay.weekday)
         assertEquals((2100 + 2400) / 7, result.averageMlPerDay)
         assertNull(result.firstEntryAt)
     }
@@ -339,8 +340,9 @@ class StatisticsServiceTest {
         )
 
         assertNotNull(result.bestDay)
-        assertEquals(LocalDate.of(2026, 5, 17), result.bestDay!!.date)
-        assertEquals(2500, result.bestDay!!.valueMl)
+        val bestDay = result.bestDay!!
+        assertEquals(LocalDate.of(2026, 5, 17), bestDay.date)
+        assertEquals(2500, bestDay.valueMl)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Replace 5 of 6 hand-written object-builders in `builder/` with Konvert KSP compile-time mappers (`@Konverter` interface + thin `object` facade keeping old signatures); the build now fails on any unmapped field.
- Add `SettingResponseBuilder` to replace the manual `SettingDto -> SettingResponse` copy in `SettingController.getSettings()`.
- Make `NotificationSettingBuilder.toEntity` a pure mapper; hoist the back-reference mutation (`user.notificationSettings`/`telegramChats`) into `NotificationAccessServiceImpl`.
- Keep `SettingBuilder` hand-written by design (presentation transformation: enum expansion, time formatting, nested field) - documented in code, correctness guarded by an existing service test.
- Upgrade Kotlin 2.1.21 -> 2.3.10 and KSP to 2.3.5 (required by konvert 4.5.0 metadata).
- Drop redundant `!!` in 3 statistics tests surfaced by the Kotlin upgrade.

KT-73255 deprecation warnings on Response DTOs are tracked separately in DPTB-164.

## Test plan
- [x] `./gradlew clean test` (unit + spring-integration) green locally on a clean build
- [x] KSP fail-policy (`invalid-mapping-strategy=fail`) makes the build red on any unmapped mapper field
