### PR TITLE
DPTB-165: replace builder facades with mapper companion delegates

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/SettingController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/SettingController.kt
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
-import ru.illine.drinking.ponies.builder.SettingResponseBuilder
+import ru.illine.drinking.ponies.mapper.SettingResponseMapper
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.dto.TelegramUserDto
 import ru.illine.drinking.ponies.model.dto.response.SettingResponse
@@ -29,7 +29,7 @@ class SettingController(
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
     ): SettingResponse {
         val settings = notificationSettingsService.getAllSettings(telegramUser.externalUserId)
-        return SettingResponseBuilder.toResponse(settings)
+        return SettingResponseMapper.toResponse(settings)
     }
 
     @PutMapping("/quiet-mode")

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/StatisticsController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/StatisticsController.kt
@@ -9,8 +9,8 @@ import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
-import ru.illine.drinking.ponies.builder.StatisticsBuilder
-import ru.illine.drinking.ponies.builder.WaterStatisticBuilder
+import ru.illine.drinking.ponies.mapper.StatisticsMapper
+import ru.illine.drinking.ponies.mapper.WaterStatisticMapper
 import ru.illine.drinking.ponies.model.dto.TelegramUserDto
 import ru.illine.drinking.ponies.model.dto.request.WaterEntryRequest
 import ru.illine.drinking.ponies.model.dto.response.StatisticsResponse
@@ -37,7 +37,7 @@ class StatisticsController(
     ): StatisticsTodayResponse {
         val entries = statisticsService.getToday(telegramUser.externalUserId)
         return StatisticsTodayResponse(
-            entries = entries.map(WaterStatisticBuilder::toWaterEntry),
+            entries = entries.map(WaterStatisticMapper::toWaterEntry),
         )
     }
 
@@ -59,7 +59,7 @@ class StatisticsController(
         )
         @RequestParam(name = "to", required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
     ): StatisticsResponse =
-        StatisticsBuilder.toResponse(statisticsService.getStatistics(telegramUser.externalUserId, from, to))
+        StatisticsMapper.toResponse(statisticsService.getStatistics(telegramUser.externalUserId, from, to))
 
     @PostMapping("/water")
     @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
@@ -3,14 +3,14 @@ package ru.illine.drinking.ponies.dao.access.impl
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import ru.illine.drinking.ponies.builder.NotificationSettingBuilder
-import ru.illine.drinking.ponies.builder.TelegramChatBuilder
-import ru.illine.drinking.ponies.builder.TelegramUserBuilder
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.dao.repository.NotificationSettingRepository
 import ru.illine.drinking.ponies.dao.repository.TelegramChatRepository
 import ru.illine.drinking.ponies.dao.repository.TelegramUserRepository
 import ru.illine.drinking.ponies.exception.NotificationSettingsNotFoundException
+import ru.illine.drinking.ponies.mapper.NotificationSettingMapper
+import ru.illine.drinking.ponies.mapper.TelegramChatMapper
+import ru.illine.drinking.ponies.mapper.TelegramUserMapper
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
@@ -36,9 +36,9 @@ class NotificationAccessServiceImpl(
 
         return settingRepository.findAll()
             .map {
-                val user = TelegramUserBuilder.toDto(it.telegramUser)
-                val chat = TelegramChatBuilder.toDto(it.telegramChat, user)
-                NotificationSettingBuilder.toDto(it, user, chat)
+                val user = TelegramUserMapper.toDto(it.telegramUser)
+                val chat = TelegramChatMapper.toDto(it.telegramChat, user)
+                NotificationSettingMapper.toDto(it, user, chat)
             }
             .toSet()
     }
@@ -48,9 +48,9 @@ class NotificationAccessServiceImpl(
         logger.debug("Finding a Notification by externalUserId [$externalUserId]")
 
         return requireSettings(externalUserId).let {
-            val user = TelegramUserBuilder.toDto(it.telegramUser)
-            val chat = TelegramChatBuilder.toDto(it.telegramChat, user)
-            NotificationSettingBuilder.toDto(it, user, chat)
+            val user = TelegramUserMapper.toDto(it.telegramUser)
+            val chat = TelegramChatMapper.toDto(it.telegramChat, user)
+            NotificationSettingMapper.toDto(it, user, chat)
         }
     }
 
@@ -74,20 +74,20 @@ class NotificationAccessServiceImpl(
         val userEntity =
             userRepository.findByExternalUserId(
                 externalUserId
-            ) ?: TelegramUserBuilder.toEntity(user)
+            ) ?: TelegramUserMapper.toEntity(user)
 
         val chatEntity =
-            chatRepository.findByExternalChatId(externalChatId) ?: TelegramChatBuilder.toEntity(chat, userEntity)
+            chatRepository.findByExternalChatId(externalChatId) ?: TelegramChatMapper.toEntity(chat, userEntity)
 
         val settingEntity =
             settingRepository.findByTelegramUser_ExternalUserId(
                 externalUserId
-            ) ?: NotificationSettingBuilder.toEntity(setting, userEntity, chatEntity)
+            ) ?: NotificationSettingMapper.toEntity(setting, userEntity, chatEntity)
 
         userEntity.addTelegramChat(chatEntity)
         userEntity.notificationSettings = settingEntity
 
-        return userRepository.save(userEntity).let { TelegramUserBuilder.toDto(it) }
+        return userRepository.save(userEntity).let { TelegramUserMapper.toDto(it) }
     }
 
     @Transactional
@@ -110,9 +110,9 @@ class NotificationAccessServiceImpl(
         }
 
         return settings.let {
-            val user = TelegramUserBuilder.toDto(it.telegramUser)
-            val chat = TelegramChatBuilder.toDto(it.telegramChat, user)
-            NotificationSettingBuilder.toDto(it, user, chat)
+            val user = TelegramUserMapper.toDto(it.telegramUser)
+            val chat = TelegramChatMapper.toDto(it.telegramChat, user)
+            NotificationSettingMapper.toDto(it, user, chat)
         }
     }
 
@@ -135,18 +135,18 @@ class NotificationAccessServiceImpl(
 
         return settings
             .map {
-                val user = TelegramUserBuilder.toEntity(it.telegramUser)
-                val chat = TelegramChatBuilder.toEntity(it.telegramChat, user)
-                NotificationSettingBuilder.toEntity(it, user, chat).also { setting ->
+                val user = TelegramUserMapper.toEntity(it.telegramUser)
+                val chat = TelegramChatMapper.toEntity(it.telegramChat, user)
+                NotificationSettingMapper.toEntity(it, user, chat).also { setting ->
                     user.notificationSettings = setting
                     user.telegramChats += chat
                 }
             }
             .apply { settingRepository.saveAll(this) }
             .map {
-                val user = TelegramUserBuilder.toDto(it.telegramUser)
-                val chat = TelegramChatBuilder.toDto(it.telegramChat, user)
-                NotificationSettingBuilder.toDto(it, user, chat)
+                val user = TelegramUserMapper.toDto(it.telegramUser)
+                val chat = TelegramChatMapper.toDto(it.telegramChat, user)
+                NotificationSettingMapper.toDto(it, user, chat)
             }
             .toSet()
     }
@@ -164,9 +164,9 @@ class NotificationAccessServiceImpl(
             }.let {
                 settingRepository.save(it)
             }.let {
-                val user = TelegramUserBuilder.toDto(it.telegramUser)
-                val chat = TelegramChatBuilder.toDto(it.telegramChat, user)
-                NotificationSettingBuilder.toDto(it, user, chat)
+                val user = TelegramUserMapper.toDto(it.telegramUser)
+                val chat = TelegramChatMapper.toDto(it.telegramChat, user)
+                NotificationSettingMapper.toDto(it, user, chat)
             }
     }
 
@@ -225,9 +225,9 @@ class NotificationAccessServiceImpl(
             }.let {
                 settingRepository.save(it)
             }.let {
-                val user = TelegramUserBuilder.toDto(it.telegramUser)
-                val chat = TelegramChatBuilder.toDto(it.telegramChat, user)
-                NotificationSettingBuilder.toDto(it, user, chat)
+                val user = TelegramUserMapper.toDto(it.telegramUser)
+                val chat = TelegramChatMapper.toDto(it.telegramChat, user)
+                NotificationSettingMapper.toDto(it, user, chat)
             }
     }
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/WaterStatisticAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/WaterStatisticAccessServiceImpl.kt
@@ -5,12 +5,12 @@ import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import ru.illine.drinking.ponies.builder.TelegramUserBuilder
-import ru.illine.drinking.ponies.builder.WaterStatisticBuilder
 import ru.illine.drinking.ponies.config.cache.CacheConfig
 import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.dao.repository.TelegramUserRepository
 import ru.illine.drinking.ponies.dao.repository.WaterStatisticRepository
+import ru.illine.drinking.ponies.mapper.TelegramUserMapper
+import ru.illine.drinking.ponies.mapper.WaterStatisticMapper
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import java.time.LocalDateTime
 
@@ -33,7 +33,7 @@ class WaterStatisticAccessServiceImpl(
         )
         return waterStatisticRepository
             .findByUserAndEventTimeBetween(externalUserId, startInclusive, endExclusive)
-            .map { WaterStatisticBuilder.toDto(it, TelegramUserBuilder.toDto(it.telegramUser)) }
+            .map { WaterStatisticMapper.toDto(it, TelegramUserMapper.toDto(it.telegramUser)) }
     }
 
     @Transactional(readOnly = true)
@@ -53,8 +53,8 @@ class WaterStatisticAccessServiceImpl(
             { "Not found a Telegram User by externalUserId [${dto.telegramUser.externalUserId}]" }
         )
 
-        return waterStatisticRepository.save(WaterStatisticBuilder.toEntity(dto, userEntity))
-            .let { WaterStatisticBuilder.toDto(it, TelegramUserBuilder.toDto(it.telegramUser)) }
+        return waterStatisticRepository.save(WaterStatisticMapper.toEntity(dto, userEntity))
+            .let { WaterStatisticMapper.toDto(it, TelegramUserMapper.toDto(it.telegramUser)) }
     }
 
     @Transactional
@@ -71,9 +71,9 @@ class WaterStatisticAccessServiceImpl(
                 if (userEntity == null) {
                     logger.warn("Not found user by external id: [{}], skipping", statistic.telegramUser.externalUserId)
                 }
-                userEntity?.let { WaterStatisticBuilder.toEntity(statistic, userEntity) }
+                userEntity?.let { WaterStatisticMapper.toEntity(statistic, userEntity) }
             }
             .let { waterStatisticRepository.saveAll(it) }
-            .map { WaterStatisticBuilder.toDto(it, TelegramUserBuilder.toDto(it.telegramUser)) }
+            .map { WaterStatisticMapper.toDto(it, TelegramUserMapper.toDto(it.telegramUser)) }
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/NotificationSettingMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/NotificationSettingMapper.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.builder
+package ru.illine.drinking.ponies.mapper
 
 import io.mcarle.konvert.api.Konverter
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
@@ -21,22 +21,6 @@ interface NotificationSettingMapper {
         telegramUser: TelegramUserEntity,
         telegramChat: TelegramChatEntity,
     ): NotificationSettingEntity
-}
 
-object NotificationSettingBuilder {
-    private val mapper: NotificationSettingMapper = Konverter.get<NotificationSettingMapper>()
-
-    fun toDto(
-        setting: NotificationSettingEntity,
-        user: TelegramUserDto,
-        chat: TelegramChatDto
-    ): NotificationSettingDto =
-        mapper.toDto(setting, user, chat)
-
-    fun toEntity(
-        setting: NotificationSettingDto,
-        user: TelegramUserEntity,
-        chat: TelegramChatEntity
-    ): NotificationSettingEntity =
-        mapper.toEntity(setting, user, chat)
+    companion object : NotificationSettingMapper by Konverter.get<NotificationSettingMapper>()
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/SettingMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/SettingMapper.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.builder
+package ru.illine.drinking.ponies.mapper
 
 import ru.illine.drinking.ponies.model.dto.SettingDto
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
@@ -10,7 +10,7 @@ import ru.illine.drinking.ponies.util.TimeHelper
 // express all of this as @Mapping(expression=...), which it does not verify, giving no real
 // safety over this named-constructor form. Correctness is guarded by
 // NotificationSettingsServiceTest."getAllSettings returns full dto when enabled", which asserts every field.
-object SettingBuilder {
+object SettingMapper {
     fun toDto(settings: NotificationSettingDto): SettingDto = SettingDto(
         interval = settings.notificationInterval.name,
         intervalDisplayName = settings.notificationInterval.displayName,

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/SettingResponseMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/SettingResponseMapper.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.builder
+package ru.illine.drinking.ponies.mapper
 
 import io.mcarle.konvert.api.Konverter
 import ru.illine.drinking.ponies.model.dto.SettingDto
@@ -7,10 +7,6 @@ import ru.illine.drinking.ponies.model.dto.response.SettingResponse
 @Konverter
 interface SettingResponseMapper {
     fun toResponse(dto: SettingDto): SettingResponse
-}
 
-object SettingResponseBuilder {
-    private val mapper: SettingResponseMapper = Konverter.get<SettingResponseMapper>()
-
-    fun toResponse(dto: SettingDto): SettingResponse = mapper.toResponse(dto)
+    companion object : SettingResponseMapper by Konverter.get<SettingResponseMapper>()
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/StatisticsMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/StatisticsMapper.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.builder
+package ru.illine.drinking.ponies.mapper
 
 import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Konverter
@@ -25,10 +25,6 @@ interface StatisticsMapper {
     fun toPoint(dto: StatisticsPointDto): StatisticsPoint
 
     fun toBestDay(dto: BestDayDto): BestDayInfo
-}
 
-object StatisticsBuilder {
-    private val mapper: StatisticsMapper = Konverter.get<StatisticsMapper>()
-
-    fun toResponse(dto: StatisticsDto): StatisticsResponse = mapper.toResponse(dto)
+    companion object : StatisticsMapper by Konverter.get<StatisticsMapper>()
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/TelegramChatMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/TelegramChatMapper.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.builder
+package ru.illine.drinking.ponies.mapper
 
 import io.mcarle.konvert.api.Konverter
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
@@ -17,14 +17,6 @@ interface TelegramChatMapper {
         @Konverter.Source chat: TelegramChatDto,
         telegramUser: TelegramUserEntity,
     ): TelegramChatEntity
-}
 
-object TelegramChatBuilder {
-    private val mapper: TelegramChatMapper = Konverter.get<TelegramChatMapper>()
-
-    fun toDto(chat: TelegramChatEntity, user: TelegramUserDto): TelegramChatDto =
-        mapper.toDto(chat, user)
-
-    fun toEntity(chat: TelegramChatDto, user: TelegramUserEntity): TelegramChatEntity =
-        mapper.toEntity(chat, user)
+    companion object : TelegramChatMapper by Konverter.get<TelegramChatMapper>()
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/TelegramUserMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/TelegramUserMapper.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.builder
+package ru.illine.drinking.ponies.mapper
 
 import io.mcarle.konvert.api.Konverter
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
@@ -8,12 +8,6 @@ import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 interface TelegramUserMapper {
     fun toDto(entity: TelegramUserEntity): TelegramUserDto
     fun toEntity(dto: TelegramUserDto): TelegramUserEntity
-}
 
-object TelegramUserBuilder {
-    private val mapper: TelegramUserMapper = Konverter.get<TelegramUserMapper>()
-
-    fun toDto(entity: TelegramUserEntity): TelegramUserDto = mapper.toDto(entity)
-
-    fun toEntity(dto: TelegramUserDto): TelegramUserEntity = mapper.toEntity(dto)
+    companion object : TelegramUserMapper by Konverter.get<TelegramUserMapper>()
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/WaterStatisticMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/WaterStatisticMapper.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.builder
+package ru.illine.drinking.ponies.mapper
 
 import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Konverter
@@ -28,17 +28,6 @@ interface WaterStatisticMapper {
         ]
     )
     fun toWaterEntry(dto: WaterStatisticDto): WaterEntry
-}
 
-object WaterStatisticBuilder {
-    private val mapper: WaterStatisticMapper = Konverter.get<WaterStatisticMapper>()
-
-    fun toDto(entity: WaterStatisticEntity, user: TelegramUserDto): WaterStatisticDto =
-        mapper.toDto(entity, user)
-
-    fun toEntity(dto: WaterStatisticDto, user: TelegramUserEntity): WaterStatisticEntity =
-        mapper.toEntity(dto, user)
-
-    fun toWaterEntry(dto: WaterStatisticDto): WaterEntry =
-        mapper.toWaterEntry(dto)
+    companion object : WaterStatisticMapper by Konverter.get<WaterStatisticMapper>()
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSettingsServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSettingsServiceImpl.kt
@@ -2,8 +2,8 @@ package ru.illine.drinking.ponies.service.notification.impl
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import ru.illine.drinking.ponies.builder.SettingBuilder
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.mapper.SettingMapper
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.dto.SettingDto
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
@@ -39,7 +39,7 @@ class NotificationSettingsServiceImpl(
         }
 
         logger.debug("Settings for externalUserId [$externalUserId] has been enabled")
-        return getNotificationSettings(externalUserId).let { SettingBuilder.toDto(it) }
+        return getNotificationSettings(externalUserId).let { SettingMapper.toDto(it) }
     }
 
     override fun getNotificationSettings(externalUserId: Long): NotificationSettingDto {

--- a/src/test/kotlin/ru/illine/drinking/ponies/mapper/StatisticsMapperTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/mapper/StatisticsMapperTest.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.builder
+package ru.illine.drinking.ponies.mapper
 
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
@@ -14,8 +14,8 @@ import java.time.LocalDate
 import kotlin.reflect.full.memberProperties
 
 @UnitTest
-@DisplayName("StatisticsBuilder Unit Test")
-class StatisticsBuilderTest {
+@DisplayName("StatisticsMapper Unit Test")
+class StatisticsMapperTest {
 
     @Test
     @DisplayName("toResponse(): maps every field from StatisticsDto to StatisticsResponse")
@@ -33,7 +33,7 @@ class StatisticsBuilderTest {
             firstEntryAt = Instant.parse("2026-04-15T10:30:00Z"),
         )
 
-        val response = StatisticsBuilder.toResponse(dto)
+        val response = StatisticsMapper.toResponse(dto)
 
         assertEquals(2, response.points.size)
         assertEquals("2026-05-04", response.points[0].label)
@@ -65,7 +65,7 @@ class StatisticsBuilderTest {
             firstEntryAt = null,
         )
 
-        val response = StatisticsBuilder.toResponse(dto)
+        val response = StatisticsMapper.toResponse(dto)
 
         assertNull(response.firstEntryAt)
     }
@@ -98,7 +98,7 @@ class StatisticsBuilderTest {
             firstEntryAt = null,
         )
 
-        val response = StatisticsBuilder.toResponse(dto)
+        val response = StatisticsMapper.toResponse(dto)
 
         assertNull(response.bestDay)
         assertEquals(0, response.points.size)


### PR DESCRIPTION
## Summary
- Collapse each `@Konverter interface XxxMapper` + `object XxxBuilder` facade pair into one declaration: the access point moves to `companion object : XxxMapper by Konverter.get<XxxMapper>()` on the interface
- Rename `Builder` → `Mapper` and move package `builder/` → `mapper/` (6 Konvert mappers + all callsites)
- `SettingMapper` stays a hand-written `object` (presentation transform, not Konvert) - documented exception, no companion
- Preserve method reference `WaterStatisticMapper::toWaterEntry` and multi-arg `@Konverter.Source` signatures
- Rename `StatisticsBuilderTest` → `StatisticsMapperTest` (logic unchanged)
- Net −49 lines; no public HTTP contract change

## Test plan
- [x] `./gradlew clean build` green (unit + Spring integration on testcontainers)
- [x] `./gradlew clean kspKotlin compileKotlin` green - Konvert regenerates Impl under new package, companion delegates resolve
- [x] grep clean: no refs to `ponies.builder` or `*Builder` symbols
- [x] `build.gradle.kts` ksp block unchanged
- [x] Code review: no blocker/important findings
