### PR TITLE
DPTB-170: make tests idiomatic mockito-kotlin (remove Java-style Mockito)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,125 @@
+# Testing guide
+
+Backend tests for the Drinking Ponies bot. This document describes the single,
+shared style every test under `src/test/kotlin/**` follows so the suite stays
+readable and consistent. The mocking idioms are the canonical reference for
+[mockito-kotlin](https://github.com/mockito/mockito-kotlin); do not mix in raw
+`org.mockito.Mockito` / `org.mockito.ArgumentMatchers` calls.
+
+## Stack
+
+- **JUnit 5** (Jupiter) - test framework. `@Test`, `@ParameterizedTest`,
+  `@DisplayName`, `@Nested`.
+- **mockito-kotlin** - the only mocking API used in unit tests (`mock<T>()`,
+  `whenever`, `verify`, `argumentCaptor<T>()`, ...). Never the raw Mockito API.
+- **Spring Boot Test** - `@SpringBootTest` with `RANDOM_PORT` and
+  `TestRestTemplate` for integration tests.
+- **Testcontainers (PostgreSQL)** - real database for integration tests, wired
+  through `TestDatabaseConfig`.
+- **JaCoCo** - coverage, emitted to `build/jacoco/coverage.xml`.
+
+## Test tags
+
+Every test class carries exactly one tag, applied through a meta-annotation:
+
+- `@UnitTest` -> `@Tag("unit")` - pure unit tests, collaborators mocked with
+  mockito-kotlin, no Spring context.
+- `@SpringIntegrationTest` -> `@Tag("spring-integration")` - full
+  `@SpringBootTest` with the real context, Testcontainers DB, and beans replaced
+  via `@MockitoBean`. Bundles `TestDatabaseConfig` + `TestTimeConfig` and the
+  `integration-test` profile.
+
+Both tags run together:
+
+```bash
+./gradlew test                                              # whole suite
+./gradlew test --tests "ru.illine.drinking.ponies.service.*" # one package
+```
+
+## File layout
+
+- **Co-located by package**: a test mirrors the package of its subject and is
+  named `<Subject>Test.kt` (e.g. `service/notification/NotificationServiceTest`).
+- Test the public surface, not the `Impl`: the file is named after the
+  interface/subject and lives in the interface package, even when it exercises
+  the `*Impl`.
+- One class per subject, `@DisplayName` on the class. Use `@Nested` inner
+  classes to group cases by endpoint/method (see the controller tests).
+- Follow **Arrange / Act / Assert** - three visually separated blocks. Short
+  tests may collapse them, but keep the order.
+- Use `@ParameterizedTest` (`@EnumSource` / `@ValueSource` / `@MethodSource`)
+  for table-driven cases instead of copy-pasting near-identical `@Test`s.
+
+## Naming
+
+- Class: `@DisplayName("NotificationService Unit Test")`.
+- Method: a backtick function name describing the behavior, plus a `@DisplayName`
+  spelling out the contract:
+
+```kotlin
+@Test
+@DisplayName("reply(): records water statistic with CANCEL event type")
+fun `reply records statistic`() { ... }
+```
+
+## Mocking (mockito-kotlin)
+
+One import style per file: everything comes from `org.mockito.kotlin.*`. A file
+must never mix `org.mockito.Mockito.*` / `org.mockito.ArgumentMatchers.*` with
+mockito-kotlin.
+
+- **Create**: `mock<TelegramClient>()` (reified) - never `mock(T::class.java)`.
+- **Stub**: `whenever(mock.call()).thenReturn(x)` - never the backtick `` `when` ``.
+  For void/throwing stubs use the prefix form: `doThrow(ex).whenever(mock).call()`,
+  `doReturn(x).whenever(mock).prop`.
+- **Verify**: `verify(mock).call(...)`, `verify(mock, never())`,
+  `verify(mock, times(2))`, `verifyNoInteractions(mock)`,
+  `verifyNoMoreInteractions(mock)`. For ordering use
+  `inOrder(a, b).verify(a)...`.
+- **Capture**: `argumentCaptor<SendMessage>()`, read via `captor.firstValue`
+  (or `lastValue` / `allValues`) - not `.value`. For a nullable argument use
+  `nullableArgumentCaptor<Instant>()`.
+- **Matchers**: `any()` / `any<T>()` for non-null arguments, `anyOrNull()` for
+  nullable arguments, `eq(value)` when mixing a literal with other matchers.
+  Pick `any<T>()` vs `anyOrNull()` by the parameter's nullability - the wrong
+  one yields an NPE or a stub that never matches.
+
+## Integration tests
+
+- Annotate the class with `@SpringIntegrationTest` and inject `TestRestTemplate`
+  (plus `ObjectMapper`, `CacheManager`, etc.) via `@Autowired constructor`.
+- Replace service/collaborator beans with `@MockitoBean` (Spring-native bean
+  override). This is the **only** sanctioned non-mockito-kotlin construct -
+  there is no mockito-kotlin equivalent, and it is not a style violation.
+- Seed and clean the database with `@Sql` (BEFORE/AFTER each method, isolated
+  transaction mode), pointing at `classpath:sql/...` scripts.
+- Time is deterministic: a fixed `Clock` comes from `TestTimeConfig`; in unit
+  tests build one explicitly (`Clock.fixed(...)`). Assert against UTC.
+- Assert on the observable contract: HTTP status, response body, error headers
+  (`X-Auth-Error-Code`), and the captured arguments forwarded to mocked beans.
+
+## Fixtures
+
+- Build DTOs through `DtoGenerator` (e.g. `generateNotificationDto(...)`,
+  `generateWaterStatisticDto(...)`). Add new factory methods there with sensible
+  defaults rather than hand-constructing DTOs in each test.
+
+## What we do NOT test
+
+We do not test third-party library behavior (the `no-tests-for-third-party-libs`
+rule). A test that only asserts what Spring, Hibernate, Jackson, Liquibase, or
+mockito already guarantee gives false confidence. Test **our** logic: branch
+selection, computed values, delegated calls, dispatched side effects, and the
+HTTP contract.
+
+## Intentional exceptions
+
+These deviate from the rules above on purpose - do not "fix" them:
+
+- **`@MockitoBean`** in integration tests - Spring bean override, kept as-is.
+- **`eq()` + `capture()`** and **`any<T>()` for non-null** - inherent
+  mockito-kotlin friction (Kotlin null-safety vs Mockito matchers); tolerated,
+  not worth a mock-engine migration.
+- **`CustomP6SpyLoggerTest`** uses the raw Mockito static-mocking API
+  (`mockStatic` + `MockedStatic.`when``): mockito-kotlin 5.2.1 ships no
+  `mockStatic` wrapper, so the Java API is the only option here.

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/DefaultExceptionHandlerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/DefaultExceptionHandlerTest.kt
@@ -4,8 +4,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.converter.HttpMessageNotReadableException
@@ -43,11 +43,11 @@ class DefaultExceptionHandlerTest {
     @Test
     @DisplayName("handleValidationException(): MethodArgumentNotValidException - returns 400 with 'validation failed'")
     fun `handleValidationException with MethodArgumentNotValidException returns 400`() {
-        val bindingResult = mock(BindingResult::class.java)
+        val bindingResult = mock<BindingResult>()
         val fieldError = FieldError("obj", "field", "must not be null")
-        `when`(bindingResult.fieldErrors).thenReturn(listOf(fieldError))
-        val exception = mock(MethodArgumentNotValidException::class.java)
-        `when`(exception.bindingResult).thenReturn(bindingResult)
+        whenever(bindingResult.fieldErrors).thenReturn(listOf(fieldError))
+        val exception = mock<MethodArgumentNotValidException>()
+        whenever(exception.bindingResult).thenReturn(bindingResult)
 
         val response = handler.handleValidationException(exception)
 
@@ -69,7 +69,7 @@ class DefaultExceptionHandlerTest {
     @Test
     @DisplayName("handleValidationException(): HttpMessageNotReadableException - returns 400 with 'validation failed'")
     fun `handleValidationException with HttpMessageNotReadableException returns 400`() {
-        val exception = mock(HttpMessageNotReadableException::class.java)
+        val exception = mock<HttpMessageNotReadableException>()
 
         val response = handler.handleValidationException(exception)
 
@@ -80,7 +80,7 @@ class DefaultExceptionHandlerTest {
     @Test
     @DisplayName("handleValidationException(): MethodArgumentTypeMismatchException - returns 400 with 'validation failed'")
     fun `handleValidationException with MethodArgumentTypeMismatchException returns 400`() {
-        val exception = mock(MethodArgumentTypeMismatchException::class.java)
+        val exception = mock<MethodArgumentTypeMismatchException>()
 
         val response = handler.handleValidationException(exception)
 
@@ -91,8 +91,8 @@ class DefaultExceptionHandlerTest {
     @Test
     @DisplayName("handleNoResourceFound(): returns 404 with 'resource not found'")
     fun `handleNoResourceFound returns 404`() {
-        val exception = mock(NoResourceFoundException::class.java)
-        `when`(exception.resourcePath).thenReturn("/unknown/path")
+        val exception = mock<NoResourceFoundException>()
+        whenever(exception.resourcePath).thenReturn("/unknown/path")
 
         val response = handler.handleNoResourceFound(exception)
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigAuthInterceptorIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigAuthInterceptorIntegrationTest.kt
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.never
-import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.web.client.TestRestTemplate
@@ -59,8 +59,8 @@ class WebConfigAuthInterceptorIntegrationTest @Autowired constructor(
 
     @BeforeEach
     fun setUp() {
-        `when`(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        `when`(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
     }
 
     private fun buildHeaders(): HttpHeaders {

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorIntegrationTest.kt
@@ -5,8 +5,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.web.client.TestRestTemplate
@@ -64,8 +66,8 @@ class AdminAuthInterceptorIntegrationTest @Autowired constructor(
     @BeforeEach
     fun setUp() {
         cacheManager.getCache(CacheConfig.USER_IS_ADMIN)?.clear()
-        `when`(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        `when`(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
     }
 
     private fun buildHeaders(): HttpHeaders {
@@ -91,7 +93,7 @@ class AdminAuthInterceptorIntegrationTest @Autowired constructor(
         @Test
         @DisplayName("non-admin user - returns 403 with X-Auth-Error-Code forbidden_admin")
         fun `non-admin user returns 403 with forbidden_admin header`() {
-            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
+            whenever(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
 
             val response = restTemplate.exchange(
                 "/systems/admin-test", HttpMethod.GET, HttpEntity<Void>(buildHeaders()), Void::class.java
@@ -107,7 +109,7 @@ class AdminAuthInterceptorIntegrationTest @Autowired constructor(
         @Test
         @DisplayName("expired auth_date - returns 403 with X-Auth-Error-Code session_expired (auth runs first)")
         fun `expired auth_date returns 403 with session_expired header`() {
-            `when`(telegramValidatorService.verifySignature(any())).thenReturn(false)
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
 
             val response = restTemplate.exchange(
                 "/systems/admin-test", HttpMethod.GET, HttpEntity<Void>(buildHeaders()), Void::class.java

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorTest.kt
@@ -8,7 +8,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.Mockito.*
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.springframework.web.method.HandlerMethod
 import ru.illine.drinking.ponies.config.web.security.AdminOnly
 import ru.illine.drinking.ponies.config.web.security.AuthErrorType
@@ -43,9 +46,9 @@ class AdminAuthInterceptorTest {
 
     @BeforeEach
     fun setUp() {
-        request = mock(HttpServletRequest::class.java)
-        response = mock(HttpServletResponse::class.java)
-        handlerMethod = mock(HandlerMethod::class.java)
+        request = mock<HttpServletRequest>()
+        response = mock<HttpServletResponse>()
+        handlerMethod = mock<HandlerMethod>()
         interceptor = AdminAuthInterceptor()
     }
 
@@ -62,7 +65,7 @@ class AdminAuthInterceptorTest {
     @Test
     @DisplayName("preHandle(): handler without @AdminOnly - returns true")
     fun `handler without AdminOnly returns true`() {
-        `when`(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(null)
+        whenever(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(null)
 
         val result = interceptor.preHandle(request, response, handlerMethod)
 
@@ -73,8 +76,8 @@ class AdminAuthInterceptorTest {
     @Test
     @DisplayName("preHandle(): @AdminOnly + admin user - returns true")
     fun `admin user returns true`() {
-        `when`(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(AdminOnly())
-        `when`(request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)).thenReturn(adminUser)
+        whenever(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(AdminOnly())
+        whenever(request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)).thenReturn(adminUser)
 
         val result = interceptor.preHandle(request, response, handlerMethod)
 
@@ -85,8 +88,8 @@ class AdminAuthInterceptorTest {
     @Test
     @DisplayName("preHandle(): @AdminOnly + non-admin user - returns false, 403, X-Auth-Error-Code forbidden_admin")
     fun `non-admin user returns false with 403 and forbidden_admin header`() {
-        `when`(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(AdminOnly())
-        `when`(request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)).thenReturn(nonAdminUser)
+        whenever(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(AdminOnly())
+        whenever(request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)).thenReturn(nonAdminUser)
 
         val result = interceptor.preHandle(request, response, handlerMethod)
 
@@ -98,8 +101,8 @@ class AdminAuthInterceptorTest {
     @Test
     @DisplayName("preHandle(): @AdminOnly + missing telegramUser attribute - throws IllegalStateException")
     fun `missing telegramUser attribute fails fast`() {
-        `when`(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(AdminOnly())
-        `when`(request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)).thenReturn(null)
+        whenever(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(AdminOnly())
+        whenever(request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)).thenReturn(null)
 
         assertThrows<IllegalStateException> {
             interceptor.preHandle(request, response, handlerMethod)

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptorTest.kt
@@ -10,8 +10,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
 import java.util.stream.Stream
 import ru.illine.drinking.ponies.config.web.security.AuthErrorType
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
@@ -35,17 +39,17 @@ class TelegramAuthInterceptorTest {
 
     @BeforeEach
     fun setUp() {
-        validatorService = mock(TelegramValidatorService::class.java)
-        telegramUserAccessService = mock(TelegramUserAccessService::class.java)
-        request = mock(HttpServletRequest::class.java)
-        response = mock(HttpServletResponse::class.java)
+        validatorService = mock<TelegramValidatorService>()
+        telegramUserAccessService = mock<TelegramUserAccessService>()
+        request = mock<HttpServletRequest>()
+        response = mock<HttpServletResponse>()
         interceptor = TelegramAuthInterceptor(validatorService, telegramUserAccessService)
     }
 
     @Test
     @DisplayName("preHandle(): OPTIONS request - returns true without validation")
     fun `preHandle OPTIONS request returns true`() {
-        `when`(request.method).thenReturn("OPTIONS")
+        whenever(request.method).thenReturn("OPTIONS")
 
         val result = interceptor.preHandle(request, response, Any())
 
@@ -60,8 +64,8 @@ class TelegramAuthInterceptorTest {
     fun `preHandle missing or blank header returns false with 401 and invalid_auth_signature header`(
         headerValue: String?,
     ) {
-        `when`(request.method).thenReturn("POST")
-        `when`(request.getHeader(headerName)).thenReturn(headerValue)
+        whenever(request.method).thenReturn("POST")
+        whenever(request.getHeader(headerName)).thenReturn(headerValue)
 
         val result = interceptor.preHandle(request, response, Any())
 
@@ -75,9 +79,9 @@ class TelegramAuthInterceptorTest {
     @Test
     @DisplayName("preHandle(): malformed initData (verifySignature throws) - 401, X-Auth-Error-Code invalid_auth_signature")
     fun `preHandle malformed initData returns false with 401 and invalid_auth_signature header`() {
-        `when`(request.method).thenReturn("POST")
-        `when`(request.getHeader(headerName)).thenReturn("malformed")
-        `when`(validatorService.verifySignature(any()))
+        whenever(request.method).thenReturn("POST")
+        whenever(request.getHeader(headerName)).thenReturn("malformed")
+        whenever(validatorService.verifySignature(any()))
             .thenThrow(InvalidAuthSignatureException("Failed to decode 'initData'"))
 
         val result = interceptor.preHandle(request, response, Any())
@@ -91,9 +95,9 @@ class TelegramAuthInterceptorTest {
     @Test
     @DisplayName("preHandle(): unexpected exception during verify - 401, X-Auth-Error-Code unknown")
     fun `preHandle unexpected exception returns false with 401 and unknown header`() {
-        `when`(request.method).thenReturn("POST")
-        `when`(request.getHeader(headerName)).thenReturn("data")
-        `when`(validatorService.verifySignature(any()))
+        whenever(request.method).thenReturn("POST")
+        whenever(request.getHeader(headerName)).thenReturn("data")
+        whenever(validatorService.verifySignature(any()))
             .thenThrow(RuntimeException("boom"))
 
         val result = interceptor.preHandle(request, response, Any())
@@ -109,11 +113,11 @@ class TelegramAuthInterceptorTest {
     fun `preHandle valid signature enriches isAdmin true`() {
         val initData = "valid-init-data"
         val telegramUser = TelegramUserDto(externalUserId = 1L, firstName = "Test", lastName = null, username = null)
-        `when`(request.method).thenReturn("POST")
-        `when`(request.getHeader(headerName)).thenReturn(initData)
-        `when`(validatorService.verifySignature(any())).thenReturn(true)
-        `when`(validatorService.map(initData)).thenReturn(telegramUser)
-        `when`(telegramUserAccessService.findIsAdminByExternalUserId(1L)).thenReturn(true)
+        whenever(request.method).thenReturn("POST")
+        whenever(request.getHeader(headerName)).thenReturn(initData)
+        whenever(validatorService.verifySignature(any())).thenReturn(true)
+        whenever(validatorService.map(initData)).thenReturn(telegramUser)
+        whenever(telegramUserAccessService.findIsAdminByExternalUserId(1L)).thenReturn(true)
 
         val result = interceptor.preHandle(request, response, Any())
 
@@ -130,11 +134,11 @@ class TelegramAuthInterceptorTest {
     fun `preHandle valid signature enriches isAdmin false`() {
         val initData = "valid-init-data"
         val telegramUser = TelegramUserDto(externalUserId = 2L, firstName = "Test", lastName = null, username = null)
-        `when`(request.method).thenReturn("POST")
-        `when`(request.getHeader(headerName)).thenReturn(initData)
-        `when`(validatorService.verifySignature(any())).thenReturn(true)
-        `when`(validatorService.map(initData)).thenReturn(telegramUser)
-        `when`(telegramUserAccessService.findIsAdminByExternalUserId(2L)).thenReturn(false)
+        whenever(request.method).thenReturn("POST")
+        whenever(request.getHeader(headerName)).thenReturn(initData)
+        whenever(validatorService.verifySignature(any())).thenReturn(true)
+        whenever(validatorService.map(initData)).thenReturn(telegramUser)
+        whenever(telegramUserAccessService.findIsAdminByExternalUserId(2L)).thenReturn(false)
 
         val result = interceptor.preHandle(request, response, Any())
 
@@ -149,9 +153,9 @@ class TelegramAuthInterceptorTest {
     @Test
     @DisplayName("preHandle(): expired auth_date (verifySignature returns false) - 403, X-Auth-Error-Code session_expired")
     fun `preHandle expired auth_date returns false with 403 and session_expired header`() {
-        `when`(request.method).thenReturn("POST")
-        `when`(request.getHeader(headerName)).thenReturn("expired-data")
-        `when`(validatorService.verifySignature(any())).thenReturn(false)
+        whenever(request.method).thenReturn("POST")
+        whenever(request.getHeader(headerName)).thenReturn("expired-data")
+        whenever(validatorService.verifySignature(any())).thenReturn(false)
 
         val result = interceptor.preHandle(request, response, Any())
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/NotificationControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/NotificationControllerTest.kt
@@ -8,8 +8,12 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.http.HttpEntity
@@ -42,8 +46,8 @@ class NotificationControllerTest @Autowired constructor(
 
     @BeforeEach
     fun setUp() {
-        `when`(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        `when`(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
     }
 
     private fun buildHeaders(): HttpHeaders {
@@ -60,7 +64,7 @@ class NotificationControllerTest @Autowired constructor(
         @DisplayName("valid request - returns 200 with next notification time")
         fun `returns 200 with next notification time`() {
             val expectedInstant = Instant.parse("2025-01-01T14:00:00Z")
-            `when`(notificationSettingsService.getNextNotificationAt(any())).thenReturn(expectedInstant)
+            whenever(notificationSettingsService.getNextNotificationAt(any())).thenReturn(expectedInstant)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -77,7 +81,7 @@ class NotificationControllerTest @Autowired constructor(
         @DisplayName("service throws IllegalArgumentException - returns 400")
         fun `returns 400 when service throws`() {
             doThrow(IllegalArgumentException("User not found"))
-                .`when`(notificationSettingsService).getNextNotificationAt(any())
+                .whenever(notificationSettingsService).getNextNotificationAt(any())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -102,7 +106,7 @@ class NotificationControllerTest @Autowired constructor(
         @DisplayName("settings not found (e.g. disabled user) - returns 404")
         fun `returns 404 when settings not found`() {
             doThrow(NotificationSettingsNotFoundException("Not found"))
-                .`when`(notificationSettingsService).getNextNotificationAt(any())
+                .whenever(notificationSettingsService).getNextNotificationAt(any())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -123,7 +127,7 @@ class NotificationControllerTest @Autowired constructor(
         fun `returns 200 with paused true`() {
             val expectedPauseUntil = Instant.parse("2025-01-01T18:00:00Z")
             val expected = PauseStateResponse(paused = true, pauseUntil = expectedPauseUntil)
-            `when`(notificationSettingsService.getPauseState(any())).thenReturn(expected)
+            whenever(notificationSettingsService.getPauseState(any())).thenReturn(expected)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -141,7 +145,7 @@ class NotificationControllerTest @Autowired constructor(
         @DisplayName("not paused - returns 200 with paused=false and null pauseUntil")
         fun `returns 200 with paused false`() {
             val expected = PauseStateResponse(paused = false, pauseUntil = null)
-            `when`(notificationSettingsService.getPauseState(any())).thenReturn(expected)
+            whenever(notificationSettingsService.getPauseState(any())).thenReturn(expected)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -169,7 +173,7 @@ class NotificationControllerTest @Autowired constructor(
         @DisplayName("settings not found (e.g. disabled user) - returns 404")
         fun `returns 404 when settings not found`() {
             doThrow(NotificationSettingsNotFoundException("Not found"))
-                .`when`(notificationSettingsService).getPauseState(any())
+                .whenever(notificationSettingsService).getPauseState(any())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -195,7 +199,7 @@ class NotificationControllerTest @Autowired constructor(
 
             assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
             verify(notificationSettingsService).pauseNotifications(telegramUser.externalUserId, 60)
-            verify(notificationSettingsService, never()).cancelPause(anyLong())
+            verify(notificationSettingsService, never()).cancelPause(any<Long>())
         }
 
         @Test
@@ -209,7 +213,7 @@ class NotificationControllerTest @Autowired constructor(
 
             assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
             verify(notificationSettingsService).cancelPause(telegramUser.externalUserId)
-            verify(notificationSettingsService, never()).pauseNotifications(anyLong(), anyLong())
+            verify(notificationSettingsService, never()).pauseNotifications(any<Long>(), any<Long>())
         }
 
         @ParameterizedTest(name = "[{index}] minutes={0} - returns 400 from @Min/@Max validation")
@@ -267,7 +271,7 @@ class NotificationControllerTest @Autowired constructor(
         @DisplayName("settings not found (e.g. disabled user) - returns 404")
         fun `returns 404 when settings not found`() {
             doThrow(NotificationSettingsNotFoundException("Not found"))
-                .`when`(notificationSettingsService).pauseNotifications(anyLong(), anyLong())
+                .whenever(notificationSettingsService).pauseNotifications(any<Long>(), any<Long>())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/SettingControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/SettingControllerTest.kt
@@ -7,8 +7,11 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.http.HttpEntity
@@ -40,8 +43,8 @@ class SettingControllerTest @Autowired constructor(
 
     @BeforeEach
     fun setUp() {
-        `when`(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        `when`(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
     }
 
     private fun buildHeaders(): HttpHeaders {
@@ -59,7 +62,7 @@ class SettingControllerTest @Autowired constructor(
         fun `returns 200 with all settings`() {
             val expectedInterval = IntervalNotificationType.HOUR_AND_HALF
             val settingDto = DtoGenerator.generateSettingDto()
-            `when`(notificationSettingsService.getAllSettings(any())).thenReturn(settingDto)
+            whenever(notificationSettingsService.getAllSettings(any())).thenReturn(settingDto)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -81,7 +84,7 @@ class SettingControllerTest @Autowired constructor(
         @DisplayName("notifications disabled - returns 200 with notificationActive=false")
         fun `returns 200 with only notificationActive when disabled`() {
             val settingDto = SettingDto(notificationActive = false)
-            `when`(notificationSettingsService.getAllSettings(any())).thenReturn(settingDto)
+            whenever(notificationSettingsService.getAllSettings(any())).thenReturn(settingDto)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -250,7 +253,7 @@ class SettingControllerTest @Autowired constructor(
         @DisplayName("invalid timezone value - returns 400")
         fun `returns 400 when invalid timezone value`() {
             doThrow(IllegalArgumentException("Invalid timezone"))
-                .`when`(notificationSettingsService).changeTimezone(any(), any())
+                .whenever(notificationSettingsService).changeTimezone(any(), any())
             val headers = buildHeaders()
             val url = "/settings/timezone?timezone=Invalid/Zone"
 
@@ -368,7 +371,7 @@ class SettingControllerTest @Autowired constructor(
         @DisplayName("service rejects out-of-range / non-allowed goalMl - returns 400")
         fun `returns 400 when service rejects goalMl`(goalMl: Int) {
             doThrow(IllegalArgumentException("Daily goal must be one of [2000, 2250, 2500, 2750, 3000] ml, got: $goalMl"))
-                .`when`(notificationSettingsService).changeDailyGoal(any(), any())
+                .whenever(notificationSettingsService).changeDailyGoal(any(), any())
             val headers = buildHeaders()
             val url = "/settings/goal?goalMl=$goalMl"
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
@@ -9,11 +9,14 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.nullableArgumentCaptor
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.http.*
@@ -50,8 +53,8 @@ class StatisticsControllerTest @Autowired constructor(
 
     @BeforeEach
     fun setUp() {
-        `when`(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        `when`(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
     }
 
     private fun buildHeaders(): HttpHeaders {
@@ -81,7 +84,7 @@ class StatisticsControllerTest @Autowired constructor(
                     waterAmountMl = 500,
                 ),
             )
-            `when`(statisticsService.getToday(telegramUser.externalUserId)).thenReturn(entries)
+            whenever(statisticsService.getToday(telegramUser.externalUserId)).thenReturn(entries)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -102,7 +105,7 @@ class StatisticsControllerTest @Autowired constructor(
         @Test
         @DisplayName("empty list - returns 200 with empty entries")
         fun `returns 200 with empty entries`() {
-            `when`(statisticsService.getToday(telegramUser.externalUserId)).thenReturn(emptyList())
+            whenever(statisticsService.getToday(telegramUser.externalUserId)).thenReturn(emptyList())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -148,7 +151,7 @@ class StatisticsControllerTest @Autowired constructor(
         @DisplayName("valid range - returns 200 with full body and forwards from/to to service")
         fun `valid range returns 200`() {
             val dto = dailyDto()
-            `when`(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(from), eq(to))).thenReturn(dto)
+            whenever(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(from), eq(to))).thenReturn(dto)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -180,7 +183,7 @@ class StatisticsControllerTest @Autowired constructor(
         @DisplayName("from == to - returns 200 with 24 hourly buckets")
         fun `from equals to returns hourly`() {
             val day = LocalDate.of(2026, 5, 12)
-            `when`(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(day), eq(day))).thenReturn(hourlyDto())
+            whenever(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(day), eq(day))).thenReturn(hourlyDto())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -197,7 +200,7 @@ class StatisticsControllerTest @Autowired constructor(
         @Test
         @DisplayName("firstEntryAt = null is rendered as null in response")
         fun `null firstEntryAt rendered as null`() {
-            `when`(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(from), eq(to)))
+            whenever(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(from), eq(to)))
                 .thenReturn(dailyDto(firstEntryAt = null))
             val headers = buildHeaders()
 
@@ -213,7 +216,7 @@ class StatisticsControllerTest @Autowired constructor(
         @Test
         @DisplayName("service throws IllegalArgumentException (e.g. from > to in user TZ) - returns 400")
         fun `service IllegalArgumentException returns 400`() {
-            `when`(statisticsService.getStatistics(any(), any(), any()))
+            whenever(statisticsService.getStatistics(any(), any(), any()))
                 .thenThrow(IllegalArgumentException("Invalid parameter: 'from' must be before or equal to 'to'"))
             val headers = buildHeaders()
 
@@ -295,7 +298,7 @@ class StatisticsControllerTest @Autowired constructor(
         @DisplayName("notifications disabled (NotificationSettingsNotFoundException) - returns 404")
         fun `returns 404 when settings not found`() {
             doThrow(NotificationSettingsNotFoundException("not found"))
-                .`when`(statisticsService).getStatistics(any(), any(), any())
+                .whenever(statisticsService).getStatistics(any(), any(), any())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -366,7 +369,7 @@ class StatisticsControllerTest @Autowired constructor(
         @DisplayName("service throws IllegalArgumentException - returns 400 (handler maps to BAD_REQUEST)")
         fun `returns 400 on service IllegalArgumentException`() {
             doThrow(IllegalArgumentException("invalid"))
-                .`when`(waterStatisticService).manualRecordEvent(any(), any(), any())
+                .whenever(waterStatisticService).manualRecordEvent(any(), any(), any())
             val body = objectMapper.writeValueAsString(DtoGenerator.generateWaterEntryRequest(pastInstant(), 250))
 
             val response = restTemplate.exchange(
@@ -439,7 +442,7 @@ class StatisticsControllerTest @Autowired constructor(
         @Test
         @DisplayName("invalid signature - returns 403")
         fun `returns 403 on invalid signature`() {
-            `when`(telegramValidatorService.verifySignature(any())).thenReturn(false)
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
             val body = objectMapper.writeValueAsString(DtoGenerator.generateWaterEntryRequest(pastInstant(), 250))
 
             val response = restTemplate.exchange(

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/SystemControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/SystemControllerTest.kt
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.http.HttpEntity
@@ -34,8 +34,8 @@ class SystemControllerTest @Autowired constructor(
 
     @BeforeEach
     fun setUp() {
-        `when`(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        `when`(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
     }
 
     private fun buildHeaders(): HttpHeaders {
@@ -79,7 +79,7 @@ class SystemControllerTest @Autowired constructor(
         @Test
         @DisplayName("expired auth_date - returns 403 with X-Auth-Error-Code session_expired")
         fun `returns 403 with session_expired header`() {
-            `when`(telegramValidatorService.verifySignature(any())).thenReturn(false)
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/UserControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/UserControllerTest.kt
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.cache.CacheManager
@@ -54,8 +54,8 @@ class UserControllerTest @Autowired constructor(
     @BeforeEach
     fun setUp() {
         cacheManager.getCache(CacheConfig.USER_IS_ADMIN)?.clear()
-        `when`(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        `when`(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
     }
 
     private fun buildHeaders(): HttpHeaders {
@@ -86,7 +86,7 @@ class UserControllerTest @Autowired constructor(
         @Test
         @DisplayName("non-admin user - returns 200 with isAdmin=false")
         fun `returns 200 with isAdmin false for non-admin`() {
-            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
+            whenever(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -102,7 +102,7 @@ class UserControllerTest @Autowired constructor(
         @Test
         @DisplayName("user not in DB - returns 200 with isAdmin=false")
         fun `returns 200 with isAdmin false for user not in db`() {
-            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = MISSING_USER_ID))
+            whenever(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = MISSING_USER_ID))
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -132,7 +132,7 @@ class UserControllerTest @Autowired constructor(
         @Test
         @DisplayName("expired auth_date - returns 403 with X-Auth-Error-Code session_expired")
         fun `returns 403 with session_expired header`() {
-            `when`(telegramValidatorService.verifySignature(any())).thenReturn(false)
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(

--- a/src/test/kotlin/ru/illine/drinking/ponies/scheduler/NotificationSchedulerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/scheduler/NotificationSchedulerTest.kt
@@ -3,7 +3,12 @@ package ru.illine.drinking.ponies.scheduler
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import ru.illine.drinking.ponies.service.notification.NotificationSenderService
 import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.notification.NotificationTimeService
@@ -21,88 +26,88 @@ class NotificationSchedulerTest {
 
     @BeforeEach
     fun setUp() {
-        notificationSettingsService = mock(NotificationSettingsService::class.java)
-        notificationSenderService = mock(NotificationSenderService::class.java)
-        notificationTimeService = mock(NotificationTimeService::class.java)
+        notificationSettingsService = mock<NotificationSettingsService>()
+        notificationSenderService = mock<NotificationSenderService>()
+        notificationTimeService = mock<NotificationTimeService>()
         scheduler = NotificationScheduler(notificationSettingsService, notificationSenderService, notificationTimeService)
     }
 
     @Test
     @DisplayName("sendDrinkingReminders(): no interactions when no notifications exist")
     fun `sendDrinkingReminders does nothing when no notifications`() {
-        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(emptySet())
+        whenever(notificationSettingsService.getAllNotificationSettings()).thenReturn(emptySet())
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationSenderService, never()).sendNotifications(anyCollection())
-        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(any())
+        verify(notificationSenderService, never()).suspendNotifications(any())
     }
 
     @Test
     @DisplayName("sendDrinkingReminders(): skips disabled notifications")
     fun `sendDrinkingReminders filters out disabled notifications`() {
         val disabled = DtoGenerator.generateNotificationDto().copy(enabled = false)
-        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(disabled))
+        whenever(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(disabled))
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationSenderService, never()).sendNotifications(anyCollection())
-        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(any())
+        verify(notificationSenderService, never()).suspendNotifications(any())
     }
 
     @Test
     @DisplayName("sendDrinkingReminders(): skips notifications inside quiet time")
     fun `sendDrinkingReminders filters out quiet time notifications`() {
         val dto = DtoGenerator.generateNotificationDto()
-        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
-        doReturn(false).`when`(notificationTimeService).isOutsideQuietTime(dto)
+        whenever(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
+        doReturn(false).whenever(notificationTimeService).isOutsideQuietTime(dto)
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationSenderService, never()).sendNotifications(anyCollection())
-        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(any())
+        verify(notificationSenderService, never()).suspendNotifications(any())
     }
 
     @Test
     @DisplayName("sendDrinkingReminders(): skips notifications not yet due")
     fun `sendDrinkingReminders filters out not due notifications`() {
         val dto = DtoGenerator.generateNotificationDto()
-        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
-        doReturn(true).`when`(notificationTimeService).isOutsideQuietTime(dto)
-        doReturn(false).`when`(notificationTimeService).isNotificationDue(dto)
+        whenever(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
+        doReturn(true).whenever(notificationTimeService).isOutsideQuietTime(dto)
+        doReturn(false).whenever(notificationTimeService).isNotificationDue(dto)
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationSenderService, never()).sendNotifications(anyCollection())
-        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(any())
+        verify(notificationSenderService, never()).suspendNotifications(any())
     }
 
     @Test
     @DisplayName("sendDrinkingReminders(): sends active notification (attempts < 3)")
     fun `sendDrinkingReminders sends active notification`() {
         val dto = DtoGenerator.generateNotificationDto(notificationAttempts = 0)
-        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
-        doReturn(true).`when`(notificationTimeService).isOutsideQuietTime(dto)
-        doReturn(true).`when`(notificationTimeService).isNotificationDue(dto)
+        whenever(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
+        doReturn(true).whenever(notificationTimeService).isOutsideQuietTime(dto)
+        doReturn(true).whenever(notificationTimeService).isNotificationDue(dto)
 
         scheduler.sendDrinkingReminders()
 
         verify(notificationSenderService).sendNotifications(listOf(dto))
-        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).suspendNotifications(any())
     }
 
     @Test
     @DisplayName("sendDrinkingReminders(): suspends exhausted notification (attempts == 3)")
     fun `sendDrinkingReminders suspends exhausted notification`() {
         val dto = DtoGenerator.generateNotificationDto(notificationAttempts = 3)
-        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
-        doReturn(true).`when`(notificationTimeService).isOutsideQuietTime(dto)
-        doReturn(true).`when`(notificationTimeService).isNotificationDue(dto)
+        whenever(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
+        doReturn(true).whenever(notificationTimeService).isOutsideQuietTime(dto)
+        doReturn(true).whenever(notificationTimeService).isNotificationDue(dto)
 
         scheduler.sendDrinkingReminders()
 
         verify(notificationSenderService).suspendNotifications(listOf(dto))
-        verify(notificationSenderService, never()).sendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(any())
     }
 
     @Test
@@ -110,11 +115,11 @@ class NotificationSchedulerTest {
     fun `sendDrinkingReminders partitions exhausted and active`() {
         val active = DtoGenerator.generateNotificationDto(notificationAttempts = 1)
         val exhausted = DtoGenerator.generateNotificationDto(notificationAttempts = 3)
-        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(active, exhausted))
-        doReturn(true).`when`(notificationTimeService).isOutsideQuietTime(active)
-        doReturn(true).`when`(notificationTimeService).isOutsideQuietTime(exhausted)
-        doReturn(true).`when`(notificationTimeService).isNotificationDue(active)
-        doReturn(true).`when`(notificationTimeService).isNotificationDue(exhausted)
+        whenever(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(active, exhausted))
+        doReturn(true).whenever(notificationTimeService).isOutsideQuietTime(active)
+        doReturn(true).whenever(notificationTimeService).isOutsideQuietTime(exhausted)
+        doReturn(true).whenever(notificationTimeService).isNotificationDue(active)
+        doReturn(true).whenever(notificationTimeService).isNotificationDue(exhausted)
 
         scheduler.sendDrinkingReminders()
 
@@ -125,11 +130,11 @@ class NotificationSchedulerTest {
     @Test
     @DisplayName("sendDrinkingReminders(): throws an error")
     fun `scheduler failed`() {
-        `when`(notificationSettingsService.getAllNotificationSettings()).thenThrow(RuntimeException("Scheduler Failed"))
+        whenever(notificationSettingsService.getAllNotificationSettings()).thenThrow(RuntimeException("Scheduler Failed"))
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationSenderService, never()).sendNotifications(anyCollection())
-        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(any())
+        verify(notificationSenderService, never()).suspendNotifications(any())
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactoryTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactoryTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.mockito.Mockito.mock
+import org.mockito.kotlin.mock
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
@@ -29,17 +29,17 @@ class ReplyButtonFactoryTest {
     @BeforeEach
     fun setUp() {
         val snoozeStrategy = SnoozeApplyReplyButtonStrategy(
-            mock(TelegramClient::class.java),
-            mock(NotificationSettingsService::class.java),
-            mock(WaterStatisticService::class.java),
-            mock(MessageEditorService::class.java),
+            mock<TelegramClient>(),
+            mock<NotificationSettingsService>(),
+            mock<WaterStatisticService>(),
+            mock<MessageEditorService>(),
             Clock.systemUTC()
         )
         val waterAmountStrategy = WaterAmountApplyReplyButtonStrategy(
-            mock(TelegramClient::class.java),
-            mock(NotificationSettingsService::class.java),
-            mock(WaterStatisticService::class.java),
-            mock(MessageEditorService::class.java),
+            mock<TelegramClient>(),
+            mock<NotificationSettingsService>(),
+            mock<WaterStatisticService>(),
+            mock<MessageEditorService>(),
             Clock.systemUTC()
         )
         factory = ReplyButtonFactoryImpl(listOf(snoozeStrategy, waterAmountStrategy))

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategyTest.kt
@@ -6,9 +6,12 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
@@ -43,10 +46,10 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
-        messageEditorService = mock(MessageEditorService::class.java)
-        notificationSettingsService = mock(NotificationSettingsService::class.java)
-        waterStatisticService = mock(WaterStatisticService::class.java)
+        sender = mock<TelegramClient>()
+        messageEditorService = mock<MessageEditorService>()
+        notificationSettingsService = mock<NotificationSettingsService>()
+        waterStatisticService = mock<WaterStatisticService>()
         strategy = CancelAnswerNotificationReplyButtonStrategy(
             sender,
             messageEditorService,
@@ -60,7 +63,7 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): edits original message with CANCEL display name")
     fun `reply edits original message`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
@@ -73,7 +76,7 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): updates last notification time to now(clock)")
     fun `reply updates notification time`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
@@ -84,7 +87,7 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): records water statistic with CANCEL event type")
     fun `reply records statistic`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
@@ -95,13 +98,13 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): sends CANCEL confirmation message")
     fun `reply sends confirmation message`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
-        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        val captor = argumentCaptor<SendMessage>()
         strategy.reply(buildCallbackQuery())
 
         verify(sender).execute(captor.capture())
-        val sent = captor.value
+        val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(TelegramMessageConstants.NOTIFICATION_ANSWER_CANCEL_MESSAGE, sent.text)
     }
@@ -132,30 +135,30 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): sends CANCEL confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
-        doThrow(RuntimeException("statistic error")).`when`(waterStatisticService)
-            .recordEvent(any(), any(), anyInt())
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        doThrow(RuntimeException("statistic error")).whenever(waterStatisticService)
+            .recordEvent(any(), any(), any<Int>())
 
-        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        val captor = argumentCaptor<SendMessage>()
         strategy.reply(buildCallbackQuery())
 
         verify(sender).execute(captor.capture())
-        val sent = captor.value
+        val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(TelegramMessageConstants.NOTIFICATION_ANSWER_CANCEL_MESSAGE, sent.text)
     }
 
     private fun buildCallbackQuery(): CallbackQuery {
-        val user = mock(User::class.java)
-        `when`(user.id).thenReturn(externalUserId)
+        val user = mock<User>()
+        whenever(user.id).thenReturn(externalUserId)
 
-        val message = mock(Message::class.java)
-        `when`(message.chatId).thenReturn(chatId)
-        `when`(message.messageId).thenReturn(messageId)
+        val message = mock<Message>()
+        whenever(message.chatId).thenReturn(chatId)
+        whenever(message.messageId).thenReturn(messageId)
 
-        val callbackQuery = mock(CallbackQuery::class.java)
-        `when`(callbackQuery.from).thenReturn(user)
-        `when`(callbackQuery.message).thenReturn(message)
+        val callbackQuery = mock<CallbackQuery>()
+        whenever(callbackQuery.from).thenReturn(user)
+        whenever(callbackQuery.message).thenReturn(message)
         return callbackQuery
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategyTest.kt
@@ -6,10 +6,13 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.message.Message
@@ -34,8 +37,8 @@ class YesAnswerNotificationReplyButtonStrategyTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
-        messageEditorService = mock(MessageEditorService::class.java)
+        sender = mock<TelegramClient>()
+        messageEditorService = mock<MessageEditorService>()
         strategy = YesAnswerNotificationReplyButtonStrategy(sender, messageEditorService)
     }
 
@@ -52,12 +55,12 @@ class YesAnswerNotificationReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): sends water amount menu message with buttons")
     fun `reply sends water amount menu message`() {
-        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        val captor = argumentCaptor<SendMessage>()
 
         strategy.reply(buildCallbackQuery())
 
         verify(sender).execute(captor.capture())
-        val sent = captor.value
+        val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(TelegramMessageConstants.NOTIFICATION_WATER_AMOUNT_MENU_MESSAGE, sent.text)
         val buttons = (sent.replyMarkup as InlineKeyboardMarkup).keyboard
@@ -98,12 +101,12 @@ class YesAnswerNotificationReplyButtonStrategyTest {
     }
 
     private fun buildCallbackQuery(): CallbackQuery {
-        val message = mock(Message::class.java)
-        `when`(message.chatId).thenReturn(chatId)
-        `when`(message.messageId).thenReturn(messageId)
+        val message = mock<Message>()
+        whenever(message.chatId).thenReturn(chatId)
+        whenever(message.messageId).thenReturn(messageId)
 
-        val callbackQuery = mock(CallbackQuery::class.java)
-        `when`(callbackQuery.message).thenReturn(message)
+        val callbackQuery = mock<CallbackQuery>()
+        whenever(callbackQuery.message).thenReturn(message)
         return callbackQuery
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategyTest.kt
@@ -6,9 +6,13 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
@@ -44,10 +48,10 @@ class SnoozeApplyReplyButtonStrategyTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
-        notificationSettingsService = mock(NotificationSettingsService::class.java)
-        messageEditorService = mock(MessageEditorService::class.java)
-        waterStatisticService = mock(WaterStatisticService::class.java)
+        sender = mock<TelegramClient>()
+        notificationSettingsService = mock<NotificationSettingsService>()
+        messageEditorService = mock<MessageEditorService>()
+        waterStatisticService = mock<WaterStatisticService>()
         strategy = SnoozeApplyReplyButtonStrategy(
             sender,
             notificationSettingsService,
@@ -62,8 +66,8 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): deletes reply markup on original message")
     fun `reply deletes reply markup`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
+        whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         strategy.reply(callbackQuery)
@@ -76,8 +80,8 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): next notification fires exactly snoozeMinutes from now")
     fun `reply updates notification time`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
+        whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         strategy.reply(callbackQuery)
@@ -92,16 +96,16 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): sends confirmation message with snooze display name")
     fun `reply sends confirmation message`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
+        whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
-        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        val captor = argumentCaptor<SendMessage>()
 
         strategy.reply(callbackQuery)
 
         verify(sender).execute(captor.capture())
-        val sent = captor.value
+        val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(
             TelegramMessageConstants.NOTIFICATION_SUSPEND_MESSAGE.format(snoozeType.displayName),
@@ -113,8 +117,8 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): falls back to TEN_MINS when queryData doesn't match any SnoozeNotificationType")
     fun `reply falls back to TEN_MINS for unknown queryData`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
+        whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery("00000000-0000-0000-0000-000000000000")
         strategy.reply(callbackQuery)
@@ -129,8 +133,8 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): records water statistic with SNOOZE event type")
     fun `reply records statistic any type`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
+        whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
 
@@ -165,33 +169,33 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): sends snooze confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(any(), any())).thenReturn(notificationDto)
-        doThrow(RuntimeException("statistic error")).`when`(waterStatisticService)
-            .recordEvent(any(), any(), anyInt())
+        whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(any(), any())).thenReturn(notificationDto)
+        doThrow(RuntimeException("statistic error")).whenever(waterStatisticService)
+            .recordEvent(any(), any(), any<Int>())
 
         val snoozeType = SnoozeNotificationType.TEN_MINS
-        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        val captor = argumentCaptor<SendMessage>()
         strategy.reply(buildCallbackQuery(snoozeType.queryData.toString()))
 
         verify(sender).execute(captor.capture())
-        val sent = captor.value
+        val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(TelegramMessageConstants.NOTIFICATION_SUSPEND_MESSAGE.format(snoozeType.displayName), sent.text)
     }
 
     private fun buildCallbackQuery(queryData: String): CallbackQuery {
-        val user = mock(User::class.java)
-        `when`(user.id).thenReturn(externalUserId)
+        val user = mock<User>()
+        whenever(user.id).thenReturn(externalUserId)
 
-        val message = mock(Message::class.java)
-        `when`(message.chatId).thenReturn(chatId)
-        `when`(message.messageId).thenReturn(messageId)
+        val message = mock<Message>()
+        whenever(message.chatId).thenReturn(chatId)
+        whenever(message.messageId).thenReturn(messageId)
 
-        val callbackQuery = mock(CallbackQuery::class.java)
-        `when`(callbackQuery.from).thenReturn(user)
-        `when`(callbackQuery.message).thenReturn(message)
-        `when`(callbackQuery.data).thenReturn(queryData)
+        val callbackQuery = mock<CallbackQuery>()
+        whenever(callbackQuery.from).thenReturn(user)
+        whenever(callbackQuery.message).thenReturn(message)
+        whenever(callbackQuery.data).thenReturn(queryData)
         return callbackQuery
     }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeMenuReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeMenuReplyButtonStrategyTest.kt
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.*
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.message.Message
@@ -31,8 +33,8 @@ class SnoozeMenuReplyButtonStrategyTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
-        messageEditorService = mock(MessageEditorService::class.java)
+        sender = mock<TelegramClient>()
+        messageEditorService = mock<MessageEditorService>()
         strategy = SnoozeMenuReplyButtonStrategy(sender, messageEditorService)
     }
 
@@ -52,12 +54,12 @@ class SnoozeMenuReplyButtonStrategyTest {
     @DisplayName("reply(): sends snooze menu message with buttons")
     fun `reply sends snooze menu message`() {
         val callbackQuery = buildCallbackQuery()
-        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        val captor = argumentCaptor<SendMessage>()
 
         strategy.reply(callbackQuery)
 
         verify(sender).execute(captor.capture())
-        val sent = captor.value
+        val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(TelegramMessageConstants.NOTIFICATION_SNOOZE_MENU_MESSAGE, sent.text)
         val buttons = (sent.replyMarkup as org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup).keyboard
@@ -87,12 +89,12 @@ class SnoozeMenuReplyButtonStrategyTest {
     }
 
     private fun buildCallbackQuery(): CallbackQuery {
-        val message = mock(Message::class.java)
-        `when`(message.chatId).thenReturn(chatId)
-        `when`(message.messageId).thenReturn(messageId)
+        val message = mock<Message>()
+        whenever(message.chatId).thenReturn(chatId)
+        whenever(message.messageId).thenReturn(messageId)
 
-        val callbackQuery = mock(CallbackQuery::class.java)
-        `when`(callbackQuery.message).thenReturn(message)
+        val callbackQuery = mock<CallbackQuery>()
+        whenever(callbackQuery.message).thenReturn(message)
         return callbackQuery
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
@@ -6,9 +6,13 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
@@ -44,10 +48,10 @@ class WaterAmountApplyReplyButtonStrategyTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
-        notificationSettingsService = mock(NotificationSettingsService::class.java)
-        waterStatisticService = mock(WaterStatisticService::class.java)
-        messageEditorService = mock(MessageEditorService::class.java)
+        sender = mock<TelegramClient>()
+        notificationSettingsService = mock<NotificationSettingsService>()
+        waterStatisticService = mock<WaterStatisticService>()
+        messageEditorService = mock<MessageEditorService>()
         strategy = WaterAmountApplyReplyButtonStrategy(
             sender,
             notificationSettingsService,
@@ -62,7 +66,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): deletes reply markup on original message")
     fun `reply deletes reply markup`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
@@ -74,7 +78,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): updates last notification time to now()")
     fun `reply updates notification time`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
@@ -86,13 +90,13 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): sends YES confirmation message")
     fun `reply sends confirmation message`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
-        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        val captor = argumentCaptor<SendMessage>()
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
         verify(sender).execute(captor.capture())
-        val sent = captor.value
+        val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(TelegramMessageConstants.NOTIFICATION_ANSWER_YES_MESSAGE, sent.text)
     }
@@ -102,7 +106,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): records water statistic with correct water amount")
     fun `reply records statistic with correct water amount`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
@@ -117,7 +121,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): falls back to ML_250 when queryData doesn't match any WaterAmountType")
     fun `reply falls back to ML_250 for unknown queryData`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery("00000000-0000-0000-0000-000000000000"))
 
@@ -132,7 +136,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): executes operations in correct order")
     fun `reply executes in correct order`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(WaterAmountType.ML_250.queryData.toString()))
 
@@ -173,31 +177,31 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): sends YES confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
-        doThrow(RuntimeException("statistic error")).`when`(waterStatisticService)
-            .recordEvent(any(), any(), anyInt())
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        doThrow(RuntimeException("statistic error")).whenever(waterStatisticService)
+            .recordEvent(any(), any(), any<Int>())
 
-        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        val captor = argumentCaptor<SendMessage>()
         strategy.reply(buildCallbackQuery(WaterAmountType.ML_250.queryData.toString()))
 
         verify(sender).execute(captor.capture())
-        val sent = captor.value
+        val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(TelegramMessageConstants.NOTIFICATION_ANSWER_YES_MESSAGE, sent.text)
     }
 
     private fun buildCallbackQuery(queryData: String): CallbackQuery {
-        val user = mock(User::class.java)
-        `when`(user.id).thenReturn(externalUserId)
+        val user = mock<User>()
+        whenever(user.id).thenReturn(externalUserId)
 
-        val message = mock(Message::class.java)
-        `when`(message.chatId).thenReturn(chatId)
-        `when`(message.messageId).thenReturn(messageId)
+        val message = mock<Message>()
+        whenever(message.chatId).thenReturn(chatId)
+        whenever(message.messageId).thenReturn(messageId)
 
-        val callbackQuery = mock(CallbackQuery::class.java)
-        `when`(callbackQuery.from).thenReturn(user)
-        `when`(callbackQuery.message).thenReturn(message)
-        `when`(callbackQuery.data).thenReturn(queryData)
+        val callbackQuery = mock<CallbackQuery>()
+        whenever(callbackQuery.from).thenReturn(user)
+        whenever(callbackQuery.message).thenReturn(message)
+        whenever(callbackQuery.data).thenReturn(queryData)
         return callbackQuery
     }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/command/CommandServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/command/CommandServiceTest.kt
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.telegram.telegrambots.meta.api.methods.menubutton.SetChatMenuButton
 import org.telegram.telegrambots.meta.api.objects.menubutton.MenuButtonWebApp
 import org.telegram.telegrambots.meta.generics.TelegramClient
@@ -24,7 +24,7 @@ class CommandServiceTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
+        sender = mock<TelegramClient>()
     }
 
     @Test
@@ -34,10 +34,10 @@ class CommandServiceTest {
 
         service.register()
 
-        val menuCaptor = ArgumentCaptor.forClass(SetChatMenuButton::class.java)
+        val menuCaptor = argumentCaptor<SetChatMenuButton>()
         verify(sender).execute(menuCaptor.capture())
 
-        val menuButton = menuCaptor.value.menuButton as MenuButtonWebApp
+        val menuButton = menuCaptor.firstValue.menuButton as MenuButtonWebApp
         assertEquals(TelegramMenuConstants.MENU_BUTTON_TEXT, menuButton.text)
         assertEquals(MINI_APP_URL, menuButton.webAppInfo.url)
     }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
@@ -4,9 +4,14 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException
@@ -51,11 +56,10 @@ class NotificationSenderServiceTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
-        messageEditorService = mock(MessageEditorService::class.java)
-        notificationAccessService = mock(NotificationAccessService::class.java)
-        @Suppress("UNCHECKED_CAST")
-        waterStatisticService = mock(WaterStatisticService::class.java)
+        sender = mock<TelegramClient>()
+        messageEditorService = mock<MessageEditorService>()
+        notificationAccessService = mock<NotificationAccessService>()
+        waterStatisticService = mock<WaterStatisticService>()
         clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)
         service = NotificationSenderServiceImpl(
             sender,
@@ -86,9 +90,9 @@ class NotificationSenderServiceTest {
             notificationAttempts = 0,
             previousNotificationMessageId = 10
         )
-        val returnedMessage = mock(Message::class.java)
-        `when`(returnedMessage.messageId).thenReturn(2)
-        doReturn(returnedMessage).`when`(sender).execute(any<SendMessage>())
+        val returnedMessage = mock<Message>()
+        whenever(returnedMessage.messageId).thenReturn(2)
+        doReturn(returnedMessage).whenever(sender).execute(any<SendMessage>())
 
         service.sendNotifications(listOf(dto))
 
@@ -96,9 +100,9 @@ class NotificationSenderServiceTest {
             .minusMinutes(IntervalNotificationType.HOUR.minutes)
             .plusMinutes(retryIntervalMinutes)
 
-        verify(messageEditorService).deleteMessages(anyCollection())
+        verify(messageEditorService).deleteMessages(any())
         verify(sender).execute(any<SendMessage>())
-        verify(notificationAccessService).updateNotificationSettings(anyCollection())
+        verify(notificationAccessService).updateNotificationSettings(any())
         assertEquals(1, dto.notificationAttempts)
         assertEquals(2, dto.telegramChat.previousNotificationMessageId)
         assertEquals(expectedTimeOfLastNotification, dto.timeOfLastNotification)
@@ -108,14 +112,14 @@ class NotificationSenderServiceTest {
     @DisplayName("sendNotifications(): 403 error - disables user and excludes from settings update")
     fun `sendNotifications on 403 disables notifications`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
-        val exception = mock(TelegramApiRequestException::class.java)
-        `when`(exception.errorCode).thenReturn(403)
-        doThrow(exception).`when`(sender).execute(any<SendMessage>())
+        val exception = mock<TelegramApiRequestException>()
+        whenever(exception.errorCode).thenReturn(403)
+        doThrow(exception).whenever(sender).execute(any<SendMessage>())
 
         service.sendNotifications(listOf(dto))
 
         verify(notificationAccessService).updateNotificationsDisabled(externalUserId)
-        verify(notificationAccessService).updateNotificationSettings(anyCollection())
+        verify(notificationAccessService).updateNotificationSettings(any())
     }
 
     @Test
@@ -140,9 +144,9 @@ class NotificationSenderServiceTest {
 
         service.suspendNotifications(listOf(dto))
 
-        verify(messageEditorService).deleteMessages(anyCollection())
+        verify(messageEditorService).deleteMessages(any())
         verify(sender).execute(any<SendMessage>())
-        verify(notificationAccessService).updateNotificationSettings(anyCollection())
+        verify(notificationAccessService).updateNotificationSettings(any())
         assertEquals(0, dto.notificationAttempts)
         assertNull(dto.telegramChat.previousNotificationMessageId)
     }
@@ -161,23 +165,23 @@ class NotificationSenderServiceTest {
     @DisplayName("suspendNotifications(): 403 error - disables user and excludes from settings update")
     fun `suspendNotifications on 403 disables notifications`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
-        val exception = mock(TelegramApiRequestException::class.java)
-        `when`(exception.errorCode).thenReturn(403)
-        doThrow(exception).`when`(sender).execute(any<SendMessage>())
+        val exception = mock<TelegramApiRequestException>()
+        whenever(exception.errorCode).thenReturn(403)
+        doThrow(exception).whenever(sender).execute(any<SendMessage>())
 
         service.suspendNotifications(listOf(dto))
 
         verify(notificationAccessService).updateNotificationsDisabled(externalUserId)
-        verify(notificationAccessService).updateNotificationSettings(anyCollection())
+        verify(notificationAccessService).updateNotificationSettings(any())
     }
 
     @Test
     @DisplayName("sendNotifications(): non-403 error - rethrows exception")
     fun `sendNotifications rethrows non-403 exception`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
-        val exception = mock(TelegramApiRequestException::class.java)
-        `when`(exception.errorCode).thenReturn(500)
-        doThrow(exception).`when`(sender).execute(any<SendMessage>())
+        val exception = mock<TelegramApiRequestException>()
+        whenever(exception.errorCode).thenReturn(500)
+        doThrow(exception).whenever(sender).execute(any<SendMessage>())
 
         assertThrows(TelegramApiRequestException::class.java) {
             service.sendNotifications(listOf(dto))
@@ -188,9 +192,9 @@ class NotificationSenderServiceTest {
     @DisplayName("sendNotifications(): null errorCode - rethrows exception")
     fun `sendNotifications rethrows null errorCode exception`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
-        val exception = mock(TelegramApiRequestException::class.java)
-        doReturn(null).`when`(exception).errorCode
-        doThrow(exception).`when`(sender).execute(any<SendMessage>())
+        val exception = mock<TelegramApiRequestException>()
+        doReturn(null).whenever(exception).errorCode
+        doThrow(exception).whenever(sender).execute(any<SendMessage>())
 
         assertThrows(TelegramApiRequestException::class.java) {
             service.sendNotifications(listOf(dto))
@@ -201,9 +205,9 @@ class NotificationSenderServiceTest {
     @DisplayName("suspendNotifications(): non-403 error - rethrows exception")
     fun `suspendNotifications rethrows non-403 exception`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
-        val exception = mock(TelegramApiRequestException::class.java)
-        `when`(exception.errorCode).thenReturn(500)
-        doThrow(exception).`when`(sender).execute(any<SendMessage>())
+        val exception = mock<TelegramApiRequestException>()
+        whenever(exception.errorCode).thenReturn(500)
+        doThrow(exception).whenever(sender).execute(any<SendMessage>())
 
         assertThrows(TelegramApiRequestException::class.java) {
             service.suspendNotifications(listOf(dto))

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
@@ -3,9 +3,13 @@ package ru.illine.drinking.ponies.service.notification
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.abilitybots.api.objects.MessageContext
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.User
@@ -28,8 +32,8 @@ class NotificationServiceTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
-        notificationAccessService = mock(NotificationAccessService::class.java)
+        sender = mock<TelegramClient>()
+        notificationAccessService = mock<NotificationAccessService>()
         service = NotificationServiceImpl(
             sender,
             notificationAccessService
@@ -40,8 +44,8 @@ class NotificationServiceTest {
     @DisplayName("start(): existing user - sends greeting and default settings, finds existing settings")
     fun `start existing user`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        doReturn(true).`when`(notificationAccessService).existsByExternalUserId(externalUserId)
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        doReturn(true).whenever(notificationAccessService).existsByExternalUserId(externalUserId)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         service.start(buildMessageContext())
 
@@ -54,8 +58,8 @@ class NotificationServiceTest {
     @DisplayName("start(): new user - creates user, saves settings, sends default settings message")
     fun `start new user`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        doReturn(false).`when`(notificationAccessService).existsByExternalUserId(externalUserId)
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        doReturn(false).whenever(notificationAccessService).existsByExternalUserId(externalUserId)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         service.start(buildMessageContext())
 
@@ -65,13 +69,13 @@ class NotificationServiceTest {
     }
 
     private fun buildMessageContext(): MessageContext {
-        val user = mock(User::class.java)
-        `when`(user.id).thenReturn(externalUserId)
-        `when`(user.userName).thenReturn("testUser")
+        val user = mock<User>()
+        whenever(user.id).thenReturn(externalUserId)
+        whenever(user.userName).thenReturn("testUser")
 
-        val context = mock(MessageContext::class.java)
-        `when`(context.user()).thenReturn(user)
-        `when`(context.chatId()).thenReturn(chatId)
+        val context = mock<MessageContext>()
+        whenever(context.user()).thenReturn(user)
+        whenever(context.chatId()).thenReturn(chatId)
         return context
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsServiceTest.kt
@@ -7,7 +7,12 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import org.mockito.Mockito.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.service.notification.impl.NotificationSettingsServiceImpl
@@ -28,8 +33,8 @@ class NotificationSettingsServiceTest {
 
     @BeforeEach
     fun setUp() {
-        notificationAccessService = mock(NotificationAccessService::class.java)
-        notificationTimeService = mock(NotificationTimeService::class.java)
+        notificationAccessService = mock<NotificationAccessService>()
+        notificationTimeService = mock<NotificationTimeService>()
         clock = Clock.fixed(Instant.parse("2025-01-01T12:00:00Z"), ZoneOffset.UTC)
         service = NotificationSettingsServiceImpl(notificationAccessService, notificationTimeService, clock)
     }
@@ -67,7 +72,7 @@ class NotificationSettingsServiceTest {
     @DisplayName("getNotificationSettings(): delegates to access service")
     fun `getNotificationSettings delegates to access service`() {
         val expected = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(expected)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(expected)
 
         val result = service.getNotificationSettings(externalUserId)
 
@@ -79,7 +84,7 @@ class NotificationSettingsServiceTest {
     @DisplayName("getAllNotificationSettings(): delegates to access service")
     fun `getAllNotificationSettings delegates to access service`() {
         val expected = setOf(DtoGenerator.generateNotificationDto())
-        `when`(notificationAccessService.findAllNotificationSettings()).thenReturn(expected)
+        whenever(notificationAccessService.findAllNotificationSettings()).thenReturn(expected)
 
         val result = service.getAllNotificationSettings()
 
@@ -92,7 +97,7 @@ class NotificationSettingsServiceTest {
     fun `resetNotificationTimer delegates to access service`() {
         val time = LocalDateTime.of(2026, 4, 5, 12, 0)
         val expected = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(externalUserId, time)).thenReturn(expected)
+        whenever(notificationAccessService.updateTimeOfLastNotification(externalUserId, time)).thenReturn(expected)
 
         val result = service.resetNotificationTimer(externalUserId, time)
 
@@ -103,7 +108,7 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("isEnabledNotifications(): delegates to access service")
     fun `isEnabledNotifications delegates to access service`() {
-        `when`(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(true)
+        whenever(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(true)
 
         val result = service.isEnabledNotifications(externalUserId)
 
@@ -114,7 +119,7 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("isEnabledNotifications(): returns false when disabled")
     fun `isEnabledNotifications returns false when disabled`() {
-        `when`(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(false)
+        whenever(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(false)
 
         val result = service.isEnabledNotifications(externalUserId)
 
@@ -127,7 +132,7 @@ class NotificationSettingsServiceTest {
     fun `changeInterval delegates to access service`() {
         val interval = IntervalNotificationType.TWO_HOURS
         val expected = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationAccessService.updateNotificationSettings(externalUserId, interval)).thenReturn(expected)
+        whenever(notificationAccessService.updateNotificationSettings(externalUserId, interval)).thenReturn(expected)
 
         val result = service.changeInterval(externalUserId, interval)
 
@@ -145,7 +150,7 @@ class NotificationSettingsServiceTest {
             quietModeStart = expectedStart,
             quietModeEnd = expectedEnd
         )
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         val result = service.getQuietMode(externalUserId)
 
@@ -161,7 +166,7 @@ class NotificationSettingsServiceTest {
             quietModeStart = null,
             quietModeEnd = LocalTime.of(8, 0)
         )
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         assertThrows(IllegalStateException::class.java) {
             service.getQuietMode(externalUserId)
@@ -176,7 +181,7 @@ class NotificationSettingsServiceTest {
             quietModeStart = LocalTime.of(23, 0),
             quietModeEnd = null
         )
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         assertThrows(IllegalStateException::class.java) {
             service.getQuietMode(externalUserId)
@@ -189,7 +194,7 @@ class NotificationSettingsServiceTest {
         service.changeNotificationStatus(externalUserId, true)
 
         verify(notificationAccessService).updateNotificationsEnabled(externalUserId)
-        verify(notificationAccessService, never()).updateNotificationsDisabled(anyLong())
+        verify(notificationAccessService, never()).updateNotificationsDisabled(any<Long>())
     }
 
     @Test
@@ -198,7 +203,7 @@ class NotificationSettingsServiceTest {
         service.changeNotificationStatus(externalUserId, false)
 
         verify(notificationAccessService).updateNotificationsDisabled(externalUserId)
-        verify(notificationAccessService, never()).updateNotificationsEnabled(anyLong())
+        verify(notificationAccessService, never()).updateNotificationsEnabled(any<Long>())
     }
 
     @Test
@@ -219,7 +224,7 @@ class NotificationSettingsServiceTest {
             service.changeTimezone(externalUserId, timezone)
         }
 
-        verify(notificationAccessService, never()).updateTimezone(anyLong(), anyString())
+        verify(notificationAccessService, never()).updateTimezone(any<Long>(), any<String>())
     }
 
     @Test
@@ -227,8 +232,8 @@ class NotificationSettingsServiceTest {
     fun `getNextNotificationAt delegates to time service`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
         val expectedInstant = Instant.parse("2025-01-01T11:00:00Z")
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
-        `when`(notificationTimeService.calculateNextNotificationAt(dto)).thenReturn(expectedInstant)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationTimeService.calculateNextNotificationAt(dto)).thenReturn(expectedInstant)
 
         val result = service.getNextNotificationAt(externalUserId)
 
@@ -240,7 +245,7 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("getAllSettings(): returns SettingDto with all fields when notifications are enabled")
     fun `getAllSettings returns full dto when enabled`() {
-        `when`(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(true)
+        whenever(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(true)
         val notificationDto = DtoGenerator.generateNotificationDto(
             externalUserId = externalUserId,
             notificationInterval = IntervalNotificationType.HOUR,
@@ -248,7 +253,7 @@ class NotificationSettingsServiceTest {
             quietModeStart = LocalTime.of(23, 0),
             quietModeEnd = LocalTime.of(8, 0),
         )
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(notificationDto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(notificationDto)
 
         val result = service.getAllSettings(externalUserId)
 
@@ -267,7 +272,7 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("getAllSettings(): returns SettingDto with only notificationActive=false when notifications are disabled")
     fun `getAllSettings returns minimal dto when disabled`() {
-        `when`(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(false)
+        whenever(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(false)
 
         val result = service.getAllSettings(externalUserId)
 
@@ -280,7 +285,7 @@ class NotificationSettingsServiceTest {
         assertEquals(null, result.timezone)
         assertEquals(null, result.dailyGoalMl)
         verify(notificationAccessService).findIsEnabledNotificationsByExternalUserId(externalUserId)
-        verify(notificationAccessService, never()).findNotificationSettingByExternalUserId(anyLong())
+        verify(notificationAccessService, never()).findNotificationSettingByExternalUserId(any<Long>())
     }
 
     @Test
@@ -302,7 +307,7 @@ class NotificationSettingsServiceTest {
             service.pauseNotifications(externalUserId, minutes)
         }
 
-        verify(notificationAccessService, never()).updatePause(anyLong(), any())
+        verify(notificationAccessService, never()).updatePause(any<Long>(), anyOrNull())
     }
 
     @Test
@@ -318,7 +323,7 @@ class NotificationSettingsServiceTest {
     fun `getPauseState returns paused true when active`() {
         val pauseUntil = LocalDateTime.of(2025, 1, 1, 13, 0)
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, pauseUntil = pauseUntil)
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         val result = service.getPauseState(externalUserId)
 
@@ -331,7 +336,7 @@ class NotificationSettingsServiceTest {
     fun `getPauseState returns paused false when pauseUntil expired`() {
         val pauseUntil = LocalDateTime.of(2025, 1, 1, 11, 0)
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, pauseUntil = pauseUntil)
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         val result = service.getPauseState(externalUserId)
 
@@ -343,7 +348,7 @@ class NotificationSettingsServiceTest {
     @DisplayName("getPauseState(): returns paused=false and null pauseUntil when pauseUntil is null")
     fun `getPauseState returns paused false when pauseUntil null`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, pauseUntil = null)
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         val result = service.getPauseState(externalUserId)
 
@@ -356,7 +361,7 @@ class NotificationSettingsServiceTest {
     fun `getPauseState returns paused false when pauseUntil equals now`() {
         val pauseUntil = LocalDateTime.of(2025, 1, 1, 12, 0)
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, pauseUntil = pauseUntil)
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         val result = service.getPauseState(externalUserId)
 
@@ -404,7 +409,7 @@ class NotificationSettingsServiceTest {
             service.changeDailyGoal(externalUserId, goalMl)
         }
 
-        verify(notificationAccessService, never()).updateDailyGoal(anyLong(), anyInt())
+        verify(notificationAccessService, never()).updateDailyGoal(any<Long>(), any<Int>())
     }
 
     @Test
@@ -416,7 +421,7 @@ class NotificationSettingsServiceTest {
             pauseUntil = pauseUntil,
             notificationAttempts = 3
         )
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         val result = service.getPauseState(externalUserId)
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsServiceTest.kt
@@ -7,11 +7,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
@@ -40,9 +40,9 @@ class StatisticsServiceTest {
 
     @BeforeEach
     fun setUp() {
-        notificationAccessService = mock(NotificationAccessService::class.java)
-        waterStatisticAccessService = mock(WaterStatisticAccessService::class.java)
-        messageProvider = mock(MessageProvider::class.java)
+        notificationAccessService = mock<NotificationAccessService>()
+        waterStatisticAccessService = mock<WaterStatisticAccessService>()
+        messageProvider = mock<MessageProvider>()
     }
 
     private fun stubInsight(text: String = "insight") {

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
@@ -7,11 +7,11 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.never
-import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
@@ -37,7 +37,7 @@ class WaterStatisticServiceTest {
 
     @BeforeEach
     fun setUp() {
-        waterStatisticAccessService = mock(WaterStatisticAccessService::class.java)
+        waterStatisticAccessService = mock<WaterStatisticAccessService>()
         service = WaterStatisticServiceImpl(waterStatisticAccessService, fixedClock)
     }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/telegram/MessageEditorServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/telegram/MessageEditorServiceTest.kt
@@ -3,8 +3,13 @@ package ru.illine.drinking.ponies.service.telegram
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.DeleteMessage
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageReplyMarkup
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText
@@ -25,7 +30,7 @@ class MessageEditorServiceTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
+        sender = mock<TelegramClient>()
         service = MessageEditorServiceImpl(sender)
     }
 
@@ -49,7 +54,7 @@ class MessageEditorServiceTest {
     @Test
     @DisplayName("editReplyMarkup(): deletes old markup and sends new text with keyboard")
     fun `editReplyMarkup with keyboard`() {
-        val keyboard = mock(InlineKeyboardMarkup::class.java)
+        val keyboard = mock<InlineKeyboardMarkup>()
 
         service.editReplyMarkup("new text", chatId, messageId, replyKeyboard = keyboard)
 
@@ -97,7 +102,7 @@ class MessageEditorServiceTest {
     @Test
     @DisplayName("deleteMessage(): catches exception and does not rethrow")
     fun `deleteMessage catches exception`() {
-        doThrow(RuntimeException("Telegram error")).`when`(sender).execute(any<DeleteMessage>())
+        doThrow(RuntimeException("Telegram error")).whenever(sender).execute(any<DeleteMessage>())
 
         service.deleteMessage(chatId, messageId)
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/sql/CustomP6SpyLoggerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/sql/CustomP6SpyLoggerTest.kt
@@ -22,6 +22,8 @@ class CustomP6SpyLoggerTest {
     @Test
     @DisplayName("init(): does nothing when field is not found")
     fun `init skips when field not found`() {
+        // Exception to the mockito-kotlin style: mockito-kotlin 5.2.1 has no mockStatic wrapper,
+        // so static mocking uses the raw Mockito API (mockStatic + MockedStatic.`when`).
         mockStatic(ReflectionUtils::class.java).use { mocked: MockedStatic<ReflectionUtils> ->
             mocked.`when`<Any?> { ReflectionUtils.findField(any(), anyString()) }.thenReturn(null)
 


### PR DESCRIPTION
## Summary
- Migrate unit + integration tests to idiomatic mockito-kotlin, no mock-library change
- `mock<T>()`, `whenever`, `argumentCaptor<T>().firstValue`; pinpoint `org.mockito.kotlin.*` imports replacing wildcard `Mockito.*`/`ArgumentMatchers.*`
- Java matchers -> `any<T>()` / `anyOrNull()` chosen by parameter nullability
- Add `TESTING.md` documenting the backend test style
- Intentional exceptions kept: `@MockitoBean`, `eq()`+capture, raw `mockStatic` in `CustomP6SpyLoggerTest` (no mockito-kotlin wrapper in 5.2.1)

## Test plan
- [x] `./gradlew clean test` green - 564 tests, 0 failures
- [x] Coverage unchanged (99.69% instruction) - test logic untouched
- [x] No raw Mockito left except documented `mockStatic` exception
- [x] Code-Reviewer: no blockers
