### PR TITLE
DPTB-164: opt in to Kotlin param-property annotation default target (KT-73255)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -125,6 +125,17 @@ tasks {
     compileKotlin {
         compilerOptions {
             freeCompilerArgs.add("-Xjsr305=strict")
+            // KT-73255: opt in to the upcoming Kotlin default where a constructor-parameter
+            // annotation without an explicit use-site target is applied to both the parameter
+            // and the property/field. See https://youtrack.jetbrains.com/issue/KT-73255
+            freeCompilerArgs.add("-Xannotation-default-target=param-property")
+        }
+    }
+
+    compileTestKotlin {
+        compilerOptions {
+            // Keep the annotation default target consistent with main (KT-73255).
+            freeCompilerArgs.add("-Xannotation-default-target=param-property")
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `-Xannotation-default-target=param-property` to `compileKotlin`/`compileTestKotlin`, adopting the upcoming Kotlin default where a constructor-parameter annotation without an explicit use-site target applies to both the parameter and the property/field (KT-73255).
- Clears 62 KT-73255 deprecation warnings across 18 DTO/Properties files without suppressing them (`@param:`/`@Suppress`) or editing each file.

## Test plan
- [x] Clean recompile: 0 KT-73255 warnings (was 62), flag accepted, build green
- [x] Full suite: 564 passed, 0 failed (unit + spring-integration), incl. `/v3/api-docs` -> 200
- [x] Bytecode: `@Schema`/`@JsonProperty` now on field+param; `@field:` validation only on field (no double-apply)
