### PR TITLE
DPTB-179: speed up bot CI with Gradle build cache and cache policy tuning

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,8 +25,9 @@ workflow:
     - when: never
 
 variables:
-  GRADLE_JVM_OPTS: "-Xmx4096m"
-  GRADLE_OPTS: "-Dorg.gradle.workers.max=4"
+  GRADLE_OPTS: "-Dorg.gradle.workers.max=4 -Dorg.gradle.caching=true"
+  FF_USE_FASTZIP: "true"
+  CACHE_COMPRESSION_LEVEL: "fast"
   SERVICE_NAME: "dptb"
   SERVICE_DISPLAY_NAME: "Bot"
   YOUTRACK_PROJECT: "DPTB"
@@ -60,9 +61,7 @@ test:
     - key: gradle-cache-${CI_PROJECT_ID}
       paths:
         - .gradle
-    - key: gradle-build-${CI_PROJECT_ID}-${CI_COMMIT_REF_NAME}
-      paths:
-        - build/
+      policy: pull
   before_script:
     - |
       curl -fsSL https://cli.codecov.io/latest/linux/codecov -o codecov
@@ -102,6 +101,7 @@ build-jar:
     - key: gradle-cache-${CI_PROJECT_ID}
       paths:
         - .gradle
+      policy: pull
   script:
     - gradle assemble
   artifacts:


### PR DESCRIPTION
## Summary
- Enable Gradle build cache (`org.gradle.caching` via `GRADLE_OPTS`) - `main` is compiled once per pipeline instead of 3x; `test`/`build-jar` now take `:compileKotlin`/`:kspKotlin`/`:kaptKotlin` FROM-CACHE
- Add `policy: pull` to the `.gradle` cache in `test` and `build-jar` - downstream jobs stop re-archiving the dependency cache (`lint` stays the sole writer)
- Drop the unused `build/` cache key from `test` (build-cache already restores compilation)
- Enable fastzip (`FF_USE_FASTZIP` + `CACHE_COMPRESSION_LEVEL: fast`) for faster cache pack/unpack
- Remove dead `GRADLE_JVM_OPTS` (Gradle never reads this var; daemon ran on default heap regardless)

## Test plan
- [x] Pipeline green on `feature/DPTB-179`
- [x] `:compileKotlin` / `:kspKotlin` / `:kaptKotlin` = FROM-CACHE in `test` and `build-jar`
- [x] Pipeline time ~8:23 -> ~3 min (-60%)
- [x] `archive_cache` gone from `test`/`build-jar` (only `lint` writes the cache)
