### PR TITLE
DPTB-180: slim down the fat jar and Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Send only the built artifact to the Docker daemon - nothing else is COPYed.
+*
+!build
+build/*
+!build/libs
+build/libs/*
+!build/libs/drinking-ponies.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,33 @@
-FROM azul/zulu-openjdk-alpine:17
+FROM azul/zulu-openjdk-alpine:17 AS builder
 
-ARG APP_HOME=/opt/drinking-ponies
-ARG APP_JAR=drinking-ponies.jar
+WORKDIR /builder
 
-ENV HOME=$APP_HOME \
-    JAR=$APP_JAR
+RUN apk add --no-cache binutils
+RUN jlink \
+      --add-modules java.base,java.compiler,java.desktop,java.instrument,java.management,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.security.jgss,java.security.sasl,java.sql,java.sql.rowset,java.transaction.xa,java.xml,jdk.crypto.ec,jdk.crypto.cryptoki,jdk.jfr,jdk.management,jdk.net,jdk.unsupported,jdk.zipfs \
+      --no-header-files \
+      --no-man-pages \
+      --strip-debug \
+      --compress=2 \
+      --output /javaruntime
 
-WORKDIR $HOME
-COPY build/libs/drinking-ponies.jar $HOME/$JAR
-ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar $JAR"]
+COPY build/libs/drinking-ponies.jar app.jar
+
+RUN java -Djarmode=tools -jar app.jar extract --layers --launcher --destination extracted
+
+FROM alpine:3.21
+
+RUN apk add --no-cache tzdata && \
+    addgroup -S app && adduser -S -G app -H -D app
+
+ENV JAVA_HOME=/opt/java PATH="/opt/java/bin:$PATH"
+COPY --from=builder /javaruntime $JAVA_HOME
+
+WORKDIR /app
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/application/ ./
+
+USER app
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS org.springframework.boot.loader.launch.JarLauncher"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,9 +34,15 @@ repositories {
 dependencies {
     implementation(libs.spring.boot.starter.actuator)
     implementation(libs.spring.boot.starter.cache)
-    implementation(libs.spring.boot.starter.data.jpa)
+    implementation(libs.spring.boot.starter.data.jpa) {
+        // Unused: caching/@Transactional are proxy-based, no AspectJ weaving needed.
+        exclude(group = "org.springframework", module = "spring-aspects")
+    }
     implementation(libs.spring.boot.starter.validation)
-    implementation(libs.spring.boot.starter.web)
+    implementation(libs.spring.boot.starter.web) {
+        // Unused: REST + long polling only, no websocket.
+        exclude(group = "org.apache.tomcat.embed", module = "tomcat-embed-websocket")
+    }
     implementation(libs.caffeine)
 
     implementation(libs.kotlin.reflect)
@@ -46,7 +52,12 @@ dependencies {
     implementation(libs.logbook.okhttp)
     implementation(libs.telegrambots.client)
     implementation(libs.telegrambots.longpolling)
-    implementation(libs.telegrambots.abilities)
+    implementation(libs.telegrambots.abilities) {
+        // Unused: webhook server, long polling only.
+        exclude(group = "org.telegram", module = "telegrambots-webhook")
+        // MapDB replaced by InMemoryDBContext.
+        exclude(group = "org.mapdb", module = "mapdb")
+    }
     implementation(libs.datasource.decorator.spring.boot)
     implementation(libs.p6spy)
     implementation(libs.micrometer.registry.prometheus)

--- a/src/main/kotlin/ru/illine/drinking/ponies/bot/DrinkingPoniesTelegramBot.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/bot/DrinkingPoniesTelegramBot.kt
@@ -2,7 +2,6 @@ package ru.illine.drinking.ponies.bot
 
 import org.telegram.telegrambots.abilitybots.api.bot.AbilityBot
 import org.telegram.telegrambots.abilitybots.api.bot.BaseAbilityBot
-import org.telegram.telegrambots.abilitybots.api.db.MapDBContext.offlineInstance
 import org.telegram.telegrambots.abilitybots.api.objects.Ability
 import org.telegram.telegrambots.abilitybots.api.objects.Flag
 import org.telegram.telegrambots.abilitybots.api.objects.Locality
@@ -27,7 +26,7 @@ class DrinkingPoniesTelegramBot(
 ) : AbilityBot(
         telegramClient,
         telegramBotProperties.username,
-        offlineInstance(telegramBotProperties.username),
+        InMemoryDBContext(),
         BareboneToggle(),
     ) {
     // Sentinel: Privacy.CREATOR is no longer used, but creatorId() is abstract in AbilityBot

--- a/src/main/kotlin/ru/illine/drinking/ponies/bot/InMemoryDBContext.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/bot/InMemoryDBContext.kt
@@ -1,0 +1,80 @@
+package ru.illine.drinking.ponies.bot
+
+import org.telegram.telegrambots.abilitybots.api.db.DBContext
+import org.telegram.telegrambots.abilitybots.api.db.Var
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Heap-backed [DBContext] for [AbilityBot]. The bot keeps its state in PostgreSQL and never reads the
+ * ability db, so this stub replaces the default MapDB-based context.
+ */
+@Suppress("TooManyFunctions")
+class InMemoryDBContext : DBContext {
+    private val structures = ConcurrentHashMap<String, Any>()
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> getList(name: String): MutableList<T> =
+        structures.computeIfAbsent(name) { Collections.synchronizedList(mutableListOf<T>()) } as MutableList<T>
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <K, V> getMap(name: String): MutableMap<K, V> =
+        structures.computeIfAbsent(name) { ConcurrentHashMap<K & Any, V & Any>() } as MutableMap<K, V>
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> getSet(name: String): MutableSet<T> =
+        structures.computeIfAbsent(name) { ConcurrentHashMap.newKeySet<T>() } as MutableSet<T>
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> getVar(name: String): Var<T> = structures.computeIfAbsent(name) { InMemoryVar<T>() } as Var<T>
+
+    override fun summary(): String = structures.keys.joinToString("\n", transform = ::info)
+
+    override fun backup(): Any = HashMap(structures)
+
+    override fun recover(backup: Any): Boolean {
+        if (backup !is Map<*, *>) return false
+        structures.clear()
+        backup.forEach { (key, value) -> if (key is String && value != null) structures[key] = value }
+        return true
+    }
+
+    override fun info(name: String): String {
+        val structure = structures[name] ?: error("DB structure with name [$name] does not exist")
+        val description =
+            when (structure) {
+                is Set<*> -> "Set - ${structure.size}"
+                is List<*> -> "List - ${structure.size}"
+                is Map<*, *> -> "Map - ${structure.size}"
+                else -> "Var"
+            }
+        return "$name - $description"
+    }
+
+    override fun commit() = Unit
+
+    override fun clear() {
+        structures.values.forEach { structure ->
+            when (structure) {
+                is MutableCollection<*> -> structure.clear()
+                is MutableMap<*, *> -> structure.clear()
+            }
+        }
+    }
+
+    override fun contains(name: String): Boolean = structures.containsKey(name)
+
+    override fun close() = Unit
+
+    private class InMemoryVar<T> : Var<T> {
+        @Volatile
+        private var value: Any? = null
+
+        @Suppress("UNCHECKED_CAST")
+        override fun get(): T = value as T
+
+        override fun set(value: T) {
+            this.value = value
+        }
+    }
+}

--- a/src/test/kotlin/ru/illine/drinking/ponies/bot/InMemoryDBContextTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/bot/InMemoryDBContextTest.kt
@@ -1,0 +1,105 @@
+package ru.illine.drinking.ponies.bot
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import ru.illine.drinking.ponies.test.tag.UnitTest
+
+@UnitTest
+@DisplayName("InMemoryDBContext Unit Test")
+class InMemoryDBContextTest {
+    private lateinit var db: InMemoryDBContext
+
+    @BeforeEach
+    fun setUp() {
+        db = InMemoryDBContext()
+    }
+
+    @Test
+    @DisplayName("getMap(): returns the same live map for the same name")
+    fun `getMap returns same instance`() {
+        val first = db.getMap<String, Int>("counters")
+        first["a"] = 1
+        val second = db.getMap<String, Int>("counters")
+
+        assertSame(first, second)
+        assertEquals(1, second["a"])
+    }
+
+    @Test
+    @DisplayName("getSet(): returns the same live set for the same name")
+    fun `getSet returns same instance`() {
+        val first = db.getSet<Long>("admins")
+        first.add(42L)
+        val second = db.getSet<Long>("admins")
+
+        assertSame(first, second)
+        assertTrue(second.contains(42L))
+    }
+
+    @Test
+    @DisplayName("getList(): returns the same live list for the same name")
+    fun `getList returns same instance`() {
+        val first = db.getList<String>("events")
+        first.add("started")
+        val second = db.getList<String>("events")
+
+        assertSame(first, second)
+        assertEquals(listOf("started"), second.toList())
+    }
+
+    @Test
+    @DisplayName("getVar(): persists the value across lookups")
+    fun `getVar persists value`() {
+        db.getVar<String>("token").set("secret")
+
+        assertEquals("secret", db.getVar<String>("token").get())
+    }
+
+    @Test
+    @DisplayName("contains(): true only after a structure is created")
+    fun `contains reflects created structures`() {
+        assertFalse(db.contains("users"))
+
+        db.getMap<Long, String>("users")
+
+        assertTrue(db.contains("users"))
+    }
+
+    @Test
+    @DisplayName("clear(): empties structures but keeps them registered")
+    fun `clear empties structures but keeps them registered`() {
+        db.getMap<String, Int>("counters")["a"] = 1
+        db.getSet<Long>("admins").add(42L)
+
+        db.clear()
+
+        assertTrue(db.getMap<String, Int>("counters").isEmpty())
+        assertTrue(db.getSet<Long>("admins").isEmpty())
+        assertTrue(db.contains("counters"))
+    }
+
+    @Test
+    @DisplayName("backup()/recover(): round-trips the stored structures")
+    fun `backup and recover round-trip`() {
+        db.getMap<String, Int>("counters")["a"] = 1
+
+        val restored = InMemoryDBContext()
+        val recovered = restored.recover(db.backup())
+
+        assertTrue(recovered)
+        assertEquals(1, restored.getMap<String, Int>("counters")["a"])
+    }
+
+    @Test
+    @DisplayName("info(): reports type and size of a structure")
+    fun `info reports structure type and size`() {
+        db.getSet<Long>("admins").add(42L)
+
+        assertEquals("admins - Set - 1", db.info("admins"))
+    }
+}


### PR DESCRIPTION
## Summary
- Trim unused transitive deps from the fat jar (108 → 74 MB): exclude the webhook server (Javalin + Jetty) and MapDB from `telegrambots-abilities`, replace MapDB's `DBContext` with an in-memory one, drop `aspectjweaver` and `tomcat-embed-websocket`.
- Rework the Dockerfile into a multi-stage build (374 → 144 MB): jlink minimal runtime, Spring Boot layered jar, non-root user, add `.dockerignore`.

## Test plan
- [x] `./gradlew build` green (unit + spring-integration)
- [x] New `InMemoryDBContext` unit test (8 cases)
- [x] Image verified locally: starts in 4s, TLS to Telegram OK, Postgres connected, `/actuator/health` + `/actuator/prometheus` OK
