### PR TITLE
DPTB-181: keep streak alive when today's goal not yet met (hanging streak)

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsAggregator.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsAggregator.kt
@@ -71,11 +71,11 @@ object StatisticsAggregator {
         today: LocalDate,
         dailyGoalMl: Int,
     ): Int {
-        // Active streak: if today's goal isn't met, the chain is broken right now, regardless of past days.
-        if ((byDate[today] ?: 0) < dailyGoalMl) return 0
-        var streak = 1
-        var cursor = today.minusDays(1)
+        // Hanging streak: an unfinished today does NOT break the chain - we start counting from
+        // yesterday in that case. The streak only resets to 0 on a real gap (yesterday below goal too).
+        var cursor = if ((byDate[today] ?: 0) >= dailyGoalMl) today else today.minusDays(1)
         val earliest = today.minusDays(STREAK_LIMIT_DAYS)
+        var streak = 0
         while (!cursor.isBefore(earliest)) {
             if ((byDate[cursor] ?: 0) < dailyGoalMl) break
             streak++

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsAggregatorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsAggregatorTest.kt
@@ -342,14 +342,25 @@ class StatisticsAggregatorTest {
                     ),
                     today,
                     2000,
-                    "today below goal -> streak=0 (chain broken now, prior days ignored)",
-                    0,
+                    "today below goal but yesterday met -> hanging streak ignores unfinished today -> 2",
+                    2,
                 ),
                 Arguments.of(
                     mapOf(today.minusDays(1) to 2000),
                     today,
                     2000,
-                    "today missing entirely -> streak=0",
+                    "today missing but yesterday met -> hanging streak -> 1",
+                    1,
+                ),
+                Arguments.of(
+                    mapOf(
+                        today to 500,
+                        today.minusDays(1) to 500,
+                        today.minusDays(2) to 2000,
+                    ),
+                    today,
+                    2000,
+                    "today below goal and yesterday below goal -> real gap -> 0",
                     0,
                 ),
                 Arguments.of(


### PR DESCRIPTION
## Summary
- `calculateStreak` no longer resets the streak to 0 when today's goal isn't met yet (hanging streak); it only resets on a real gap (yesterday also below goal).
- The count starts from today if today's goal is met, otherwise from yesterday; a single loop counts consecutive met days back to the STREAK_LIMIT_DAYS (366) bound.
- `today >= goal` behaviour is unchanged - no regression, the front-end renders the number as-is.

## Test plan
- [x] `provideCalculateStreakCases`: today < goal & yesterday >= goal -> hanging streak (2 / 1); added today < goal & yesterday < goal -> 0
- [x] 5 regression cases kept (today met -> 3, empty -> 0, gap-back -> 3, STREAK_LIMIT -> 367, only-today -> 1)
- [x] StatisticsAggregatorTest green (27/27), verified locally
