### PR TITLE
[next:minor] Release 8.5.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Send only the built artifact to the Docker daemon - nothing else is COPYed.
+*
+!build
+build/*
+!build/libs
+build/libs/*
+!build/libs/drinking-ponies.jar

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{kt,kts}]
+# Single source of style for IDEA, ktlint and detekt.
+ktlint_code_style = ktlint_official
+max_line_length = 120
+# Never collapse imports into wildcards - keeps IDEA "Optimize Imports" in sync with ktlint's no-wildcard-imports.
+ij_kotlin_name_count_to_use_star_import = 2147483647
+ij_kotlin_name_count_to_use_star_import_for_members = 2147483647
+
+[*.{yml,yaml,json}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 include:
   - project: dptb/drinking-ponies-ci-templates
-    ref: develop
+    ref: v1.0.0
     file: dptb-ci.gitlab-ci.yml
   - local: .ansible.gitlab-ci.yml
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,8 +25,9 @@ workflow:
     - when: never
 
 variables:
-  GRADLE_JVM_OPTS: "-Xmx4096m"
-  GRADLE_OPTS: "-Dorg.gradle.workers.max=4"
+  GRADLE_OPTS: "-Dorg.gradle.workers.max=4 -Dorg.gradle.caching=true"
+  FF_USE_FASTZIP: "true"
+  CACHE_COMPRESSION_LEVEL: "fast"
   SERVICE_NAME: "dptb"
   SERVICE_DISPLAY_NAME: "Bot"
   YOUTRACK_PROJECT: "DPTB"
@@ -60,9 +61,7 @@ test:
     - key: gradle-cache-${CI_PROJECT_ID}
       paths:
         - .gradle
-    - key: gradle-build-${CI_PROJECT_ID}-${CI_COMMIT_REF_NAME}
-      paths:
-        - build/
+      policy: pull
   before_script:
     - |
       curl -fsSL https://cli.codecov.io/latest/linux/codecov -o codecov
@@ -102,6 +101,7 @@ build-jar:
     - key: gradle-cache-${CI_PROJECT_ID}
       paths:
         - .gradle
+      policy: pull
   script:
     - gradle assemble
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,9 +34,24 @@ variables:
 default:
   interruptible: true
 
+lint:
+  extends: .default-tags
+  stage: test
+  image: gradle:8.4-jdk17
+  variables:
+    GRADLE_USER_HOME: ".gradle"
+  cache:
+    - key: gradle-cache-${CI_PROJECT_ID}
+      paths:
+        - .gradle
+  script:
+    - gradle lintKotlin detekt
+
 test:
   extends: .default-tags
   stage: test
+  needs:
+    - lint
   image: gradle:8.4-jdk17
   variables:
     GRADLE_USER_HOME: ".gradle"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,50 @@
+# Development
+
+## Code quality
+
+The backend uses two complementary Kotlin tools:
+
+- **ktlint** (via the [kotlinter](https://github.com/jeremymailen/kotlinter-gradle) Gradle plugin) - **formatting**: indentation, import ordering, wrapping, trailing commas. Auto-fixable.
+- **detekt** - **static analysis**: code smells, complexity, potential bugs, naming. Not auto-fixable; it points, you fix.
+
+Formatting is owned exclusively by ktlint; detekt runs with its formatting ruleset disabled so the two never fight.
+
+### Single source of style
+
+[`.editorconfig`](.editorconfig) is the single source of truth for code style. It is read by ktlint, detekt **and** IntelliJ IDEA, so the editor, local checks and CI all agree.
+
+### Commands
+
+```bash
+./gradlew formatKotlin        # auto-fix formatting (run this before committing)
+./gradlew lintKotlin detekt   # the exact checks CI runs (formatting + static analysis)
+./gradlew check               # full local verify: lint + detekt + tests + coverage
+```
+
+CI runs `gradle lintKotlin detekt` as the `lint` job, which the `test` job depends on (`needs`), so formatting/smell regressions fail fast before tests.
+
+### detekt baseline
+
+[`config/detekt/baseline.xml`](config/detekt/baseline.xml) freezes the pre-existing findings on legacy code so CI does not fail on them. New code is checked cleanly. To review what is currently baselined, see [`config/detekt/detekt.yml`](config/detekt/detekt.yml) for the active rules and regenerate the baseline with `./gradlew detektBaseline` after intentionally clearing findings.
+
+### IntelliJ IDEA setup
+
+`.editorconfig` is the only setup the editor needs. Make sure `Settings → Editor → Code Style → Enable EditorConfig support` is on (it is by default) - a *"Settings may be overridden by EditorConfig"* banner on the Code Style page confirms IDEA is reading it.
+
+With that, the native `Reformat Code` (Cmd/Ctrl+Alt+L) picks up `ktlint_official` and the `ij_kotlin_*` rules from `.editorconfig`, so it is already close to ktlint and fine for quick touch-ups. It does **not** match ktlint exactly (trailing commas and some wrapping rules diverge), so the source of truth stays `./gradlew formatKotlin` before pushing - CI runs the same check and fails on any mismatch.
+
+**Optional plugins** (inline feedback, not required):
+
+- **[Ktlint plugin](https://plugins.jetbrains.com/plugin/15057-ktlint)** (by Nikolay Badal) - formats exactly like CI. Caveat: its format-on-save reacts to *explicit* saves only; IDEA's autosave (timer / focus loss) does not trigger it, so on an autosave workflow run `formatKotlin` manually or bind the plugin's format action to a shortcut. Its mode is stored per project - enable it here, leave it `Disabled` elsewhere; global IDE settings are untouched.
+- **detekt plugin** - surfaces static-analysis findings inline; point it at `config/detekt/detekt.yml` and `config/detekt/baseline.xml`.
+
+### Caveats
+
+- **Kotlin 2.3.21.** detekt 2.0 (alpha) is compiled against an exact Kotlin compiler version and refuses to run on a mismatch. The project is pinned to the Kotlin version detekt's alpha targets. A Kotlin bump may require a matching detekt alpha (and vice versa) until detekt 2.0 reaches stable.
+- **No type resolution (yet).** CI runs the flat `detekt` task, which analyses sources without type resolution. The type-aware variants (`detektMain`/`detektTest`) are intentionally left out for now - they are the most fragile path on the detekt alpha. Rules that require type resolution therefore do not run yet; enabling them is a follow-up once detekt 2.0 stabilises.
+- **detekt baseline** currently freezes the existing legacy findings (`config/detekt/baseline.xml`). `MaxLineLength` overlaps with ktlint's line-length rule and is a planned follow-up to disable in detekt (ktlint owns line length).
+- Generated KSP/Konvert sources under `build/generated/**` are excluded from ktlint and are not picked up by detekt.
+
+## Tests
+
+Test layout, tags and coverage live in [`TESTING.md`](TESTING.md).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,33 @@
-FROM azul/zulu-openjdk-alpine:17
+FROM azul/zulu-openjdk-alpine:17 AS builder
 
-ARG APP_HOME=/opt/drinking-ponies
-ARG APP_JAR=drinking-ponies.jar
+WORKDIR /builder
 
-ENV HOME=$APP_HOME \
-    JAR=$APP_JAR
+RUN apk add --no-cache binutils
+RUN jlink \
+      --add-modules java.base,java.compiler,java.desktop,java.instrument,java.management,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.security.jgss,java.security.sasl,java.sql,java.sql.rowset,java.transaction.xa,java.xml,jdk.crypto.ec,jdk.crypto.cryptoki,jdk.jfr,jdk.management,jdk.net,jdk.unsupported,jdk.zipfs \
+      --no-header-files \
+      --no-man-pages \
+      --strip-debug \
+      --compress=2 \
+      --output /javaruntime
 
-WORKDIR $HOME
-COPY build/libs/drinking-ponies.jar $HOME/$JAR
-ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar $JAR"]
+COPY build/libs/drinking-ponies.jar app.jar
+
+RUN java -Djarmode=tools -jar app.jar extract --layers --launcher --destination extracted
+
+FROM alpine:3.21
+
+RUN apk add --no-cache tzdata && \
+    addgroup -S app && adduser -S -G app -H -D app
+
+ENV JAVA_HOME=/opt/java PATH="/opt/java/bin:$PATH"
+COPY --from=builder /javaruntime $JAVA_HOME
+
+WORKDIR /app
+COPY --from=builder /builder/extracted/dependencies/ ./
+COPY --from=builder /builder/extracted/spring-boot-loader/ ./
+COPY --from=builder /builder/extracted/snapshot-dependencies/ ./
+COPY --from=builder /builder/extracted/application/ ./
+
+USER app
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS org.springframework.boot.loader.launch.JarLauncher"]

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,125 @@
+# Testing guide
+
+Backend tests for the Drinking Ponies bot. This document describes the single,
+shared style every test under `src/test/kotlin/**` follows so the suite stays
+readable and consistent. The mocking idioms are the canonical reference for
+[mockito-kotlin](https://github.com/mockito/mockito-kotlin); do not mix in raw
+`org.mockito.Mockito` / `org.mockito.ArgumentMatchers` calls.
+
+## Stack
+
+- **JUnit 5** (Jupiter) - test framework. `@Test`, `@ParameterizedTest`,
+  `@DisplayName`, `@Nested`.
+- **mockito-kotlin** - the only mocking API used in unit tests (`mock<T>()`,
+  `whenever`, `verify`, `argumentCaptor<T>()`, ...). Never the raw Mockito API.
+- **Spring Boot Test** - `@SpringBootTest` with `RANDOM_PORT` and
+  `TestRestTemplate` for integration tests.
+- **Testcontainers (PostgreSQL)** - real database for integration tests, wired
+  through `TestDatabaseConfig`.
+- **JaCoCo** - coverage, emitted to `build/jacoco/coverage.xml`.
+
+## Test tags
+
+Every test class carries exactly one tag, applied through a meta-annotation:
+
+- `@UnitTest` -> `@Tag("unit")` - pure unit tests, collaborators mocked with
+  mockito-kotlin, no Spring context.
+- `@SpringIntegrationTest` -> `@Tag("spring-integration")` - full
+  `@SpringBootTest` with the real context, Testcontainers DB, and beans replaced
+  via `@MockitoBean`. Bundles `TestDatabaseConfig` + `TestTimeConfig` and the
+  `integration-test` profile.
+
+Both tags run together:
+
+```bash
+./gradlew test                                              # whole suite
+./gradlew test --tests "ru.illine.drinking.ponies.service.*" # one package
+```
+
+## File layout
+
+- **Co-located by package**: a test mirrors the package of its subject and is
+  named `<Subject>Test.kt` (e.g. `service/notification/NotificationServiceTest`).
+- Test the public surface, not the `Impl`: the file is named after the
+  interface/subject and lives in the interface package, even when it exercises
+  the `*Impl`.
+- One class per subject, `@DisplayName` on the class. Use `@Nested` inner
+  classes to group cases by endpoint/method (see the controller tests).
+- Follow **Arrange / Act / Assert** - three visually separated blocks. Short
+  tests may collapse them, but keep the order.
+- Use `@ParameterizedTest` (`@EnumSource` / `@ValueSource` / `@MethodSource`)
+  for table-driven cases instead of copy-pasting near-identical `@Test`s.
+
+## Naming
+
+- Class: `@DisplayName("NotificationService Unit Test")`.
+- Method: a backtick function name describing the behavior, plus a `@DisplayName`
+  spelling out the contract:
+
+```kotlin
+@Test
+@DisplayName("reply(): records water statistic with CANCEL event type")
+fun `reply records statistic`() { ... }
+```
+
+## Mocking (mockito-kotlin)
+
+One import style per file: everything comes from `org.mockito.kotlin.*`. A file
+must never mix `org.mockito.Mockito.*` / `org.mockito.ArgumentMatchers.*` with
+mockito-kotlin.
+
+- **Create**: `mock<TelegramClient>()` (reified) - never `mock(T::class.java)`.
+- **Stub**: `whenever(mock.call()).thenReturn(x)` - never the backtick `` `when` ``.
+  For void/throwing stubs use the prefix form: `doThrow(ex).whenever(mock).call()`,
+  `doReturn(x).whenever(mock).prop`.
+- **Verify**: `verify(mock).call(...)`, `verify(mock, never())`,
+  `verify(mock, times(2))`, `verifyNoInteractions(mock)`,
+  `verifyNoMoreInteractions(mock)`. For ordering use
+  `inOrder(a, b).verify(a)...`.
+- **Capture**: `argumentCaptor<SendMessage>()`, read via `captor.firstValue`
+  (or `lastValue` / `allValues`) - not `.value`. For a nullable argument use
+  `nullableArgumentCaptor<Instant>()`.
+- **Matchers**: `any()` / `any<T>()` for non-null arguments, `anyOrNull()` for
+  nullable arguments, `eq(value)` when mixing a literal with other matchers.
+  Pick `any<T>()` vs `anyOrNull()` by the parameter's nullability - the wrong
+  one yields an NPE or a stub that never matches.
+
+## Integration tests
+
+- Annotate the class with `@SpringIntegrationTest` and inject `TestRestTemplate`
+  (plus `ObjectMapper`, `CacheManager`, etc.) via `@Autowired constructor`.
+- Replace service/collaborator beans with `@MockitoBean` (Spring-native bean
+  override). This is the **only** sanctioned non-mockito-kotlin construct -
+  there is no mockito-kotlin equivalent, and it is not a style violation.
+- Seed and clean the database with `@Sql` (BEFORE/AFTER each method, isolated
+  transaction mode), pointing at `classpath:sql/...` scripts.
+- Time is deterministic: a fixed `Clock` comes from `TestTimeConfig`; in unit
+  tests build one explicitly (`Clock.fixed(...)`). Assert against UTC.
+- Assert on the observable contract: HTTP status, response body, error headers
+  (`X-Auth-Error-Code`), and the captured arguments forwarded to mocked beans.
+
+## Fixtures
+
+- Build DTOs through `DtoGenerator` (e.g. `generateNotificationDto(...)`,
+  `generateWaterStatisticDto(...)`). Add new factory methods there with sensible
+  defaults rather than hand-constructing DTOs in each test.
+
+## What we do NOT test
+
+We do not test third-party library behavior (the `no-tests-for-third-party-libs`
+rule). A test that only asserts what Spring, Hibernate, Jackson, Liquibase, or
+mockito already guarantee gives false confidence. Test **our** logic: branch
+selection, computed values, delegated calls, dispatched side effects, and the
+HTTP contract.
+
+## Intentional exceptions
+
+These deviate from the rules above on purpose - do not "fix" them:
+
+- **`@MockitoBean`** in integration tests - Spring bean override, kept as-is.
+- **`eq()` + `capture()`** and **`any<T>()` for non-null** - inherent
+  mockito-kotlin friction (Kotlin null-safety vs Mockito matchers); tolerated,
+  not worth a mock-engine migration.
+- **`CustomP6SpyLoggerTest`** uses the raw Mockito static-mocking API
+  (`mockStatic` + `MockedStatic.`when``): mockito-kotlin 5.2.1 ships no
+  `mockStatic` wrapper, so the Java API is the only option here.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jmailen.gradle.kotlinter.tasks.FormatTask
+import org.jmailen.gradle.kotlinter.tasks.LintTask
 import java.io.FileInputStream
 import java.util.*
 
@@ -12,6 +14,8 @@ plugins {
     alias(libs.plugins.kotlin.jpa)
     alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.kotlinter)
+    alias(libs.plugins.detekt)
 }
 
 group = "ru.illine"
@@ -89,6 +93,13 @@ ksp {
     arg("konvert.invalid-mapping-strategy", "fail")
     arg("konvert.non-constructor-properties-mapping", "all")
     arg("konvert.enforce-not-null", "true")
+}
+
+detekt {
+    // ktlint owns formatting; detekt runs code-smell/complexity rules only (no formatting ruleset).
+    buildUponDefaultConfig = true
+    config.setFrom("$projectDir/config/detekt/detekt.yml")
+    baseline = file("$projectDir/config/detekt/baseline.xml")
 }
 
 liquibase {
@@ -185,4 +196,8 @@ tasks {
             })
         )
     }
+
+    // ktlint (kotlinter) must not lint generated KSP/Konvert sources - KSP adds build/generated to the source set.
+    withType<LintTask>().configureEach { exclude { it.file.path.contains("/build/generated/") } }
+    withType<FormatTask>().configureEach { exclude { it.file.path.contains("/build/generated/") } }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -125,6 +125,17 @@ tasks {
     compileKotlin {
         compilerOptions {
             freeCompilerArgs.add("-Xjsr305=strict")
+            // KT-73255: opt in to the upcoming Kotlin default where a constructor-parameter
+            // annotation without an explicit use-site target is applied to both the parameter
+            // and the property/field. See https://youtrack.jetbrains.com/issue/KT-73255
+            freeCompilerArgs.add("-Xannotation-default-target=param-property")
+        }
+    }
+
+    compileTestKotlin {
+        compilerOptions {
+            // Keep the annotation default target consistent with main (KT-73255).
+            freeCompilerArgs.add("-Xannotation-default-target=param-property")
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,9 +34,15 @@ repositories {
 dependencies {
     implementation(libs.spring.boot.starter.actuator)
     implementation(libs.spring.boot.starter.cache)
-    implementation(libs.spring.boot.starter.data.jpa)
+    implementation(libs.spring.boot.starter.data.jpa) {
+        // Unused: caching/@Transactional are proxy-based, no AspectJ weaving needed.
+        exclude(group = "org.springframework", module = "spring-aspects")
+    }
     implementation(libs.spring.boot.starter.validation)
-    implementation(libs.spring.boot.starter.web)
+    implementation(libs.spring.boot.starter.web) {
+        // Unused: REST + long polling only, no websocket.
+        exclude(group = "org.apache.tomcat.embed", module = "tomcat-embed-websocket")
+    }
     implementation(libs.caffeine)
 
     implementation(libs.kotlin.reflect)
@@ -46,7 +52,12 @@ dependencies {
     implementation(libs.logbook.okhttp)
     implementation(libs.telegrambots.client)
     implementation(libs.telegrambots.longpolling)
-    implementation(libs.telegrambots.abilities)
+    implementation(libs.telegrambots.abilities) {
+        // Unused: webhook server, long polling only.
+        exclude(group = "org.telegram", module = "telegrambots-webhook")
+        // MapDB replaced by InMemoryDBContext.
+        exclude(group = "org.mapdb", module = "mapdb")
+    }
     implementation(libs.datasource.decorator.spring.boot)
     implementation(libs.p6spy)
     implementation(libs.micrometer.registry.prometheus)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.kotlin.jpa)
     alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
 }
 
 group = "ru.illine"
@@ -50,6 +51,7 @@ dependencies {
     implementation(libs.commons.codec)
     implementation(libs.commons.lang3)
     implementation(libs.springdoc.openapi.starter.webmvc.ui)
+    implementation(libs.konvert.api)
 
     liquibaseRuntime(libs.liquibase.core)
     liquibaseRuntime(libs.liquibase.groovy.dsl)
@@ -62,6 +64,7 @@ dependencies {
     runtimeOnly(libs.micrometer.exposition.formats)
 
     kapt(libs.spring.boot.configuration.processor)
+    ksp(libs.konvert)
 
     testImplementation(libs.spring.boot.starter.test) {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
@@ -79,6 +82,13 @@ allOpen {
     annotation("jakarta.persistence.Entity")
     annotation("jakarta.persistence.MappedSuperclass")
     annotation("jakarta.persistence.Embeddable")
+}
+
+ksp {
+    // Konvert: make the build fail on incomplete or invalid mappings - the core goal of DPTB-136.
+    arg("konvert.invalid-mapping-strategy", "fail")
+    arg("konvert.non-constructor-properties-mapping", "all")
+    arg("konvert.enforce-not-null", "true")
 }
 
 liquibase {

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>FunctionNaming:NotificationSettingRepository.kt:NotificationSettingRepository$@Suppress("ktlint:standard:function-naming") fun findByTelegramUser_ExternalUserId: NotificationSettingEntity?</ID>
+    <ID>FunctionOnlyReturningConstant:AdminAuthInterceptorIntegrationTest.kt:AdminAuthInterceptorIntegrationTest.AdminTestConfig.AdminTestController$@AdminOnly @GetMapping("/admin-test") fun adminTest: String</ID>
+    <ID>FunctionOnlyReturningConstant:WebConfigAuthInterceptorIntegrationTest.kt:WebConfigAuthInterceptorIntegrationTest.DefaultSecureTestConfig.DefaultSecureTestController$@GetMapping fun defaultSecure: String</ID>
+    <ID>InvalidPackageDeclaration:ClockHelperTest.kt:package ru.illine.drinking.ponies.test.util</ID>
+    <ID>LongMethod:NotificationTimeServiceTest.kt:NotificationTimeServiceTest.Companion$@JvmStatic fun nextNotificationAtScenarios: Stream&lt;Arguments&gt;</ID>
+    <ID>LongMethod:NotificationTimeServiceTest.kt:NotificationTimeServiceTest.Companion$@JvmStatic fun quietTimeScenarios: Stream&lt;Arguments&gt;</ID>
+    <ID>LongMethod:StatisticsAggregatorTest.kt:StatisticsAggregatorTest.Companion$@JvmStatic fun provideCalculateStreakCases: Stream&lt;Arguments&gt;</ID>
+    <ID>MagicNumber:CacheProperties.kt:CacheProperties.CacheEntry$1000</ID>
+    <ID>MagicNumber:CacheProperties.kt:CacheProperties.CacheEntry$5</ID>
+    <ID>MagicNumber:CacheProperties.kt:CacheProperties.CacheEntryOverride$1000</ID>
+    <ID>MagicNumber:IntervalNotificationType.kt:IntervalNotificationType.HALF_HOUR$30</ID>
+    <ID>MagicNumber:IntervalNotificationType.kt:IntervalNotificationType.HOUR$60</ID>
+    <ID>MagicNumber:IntervalNotificationType.kt:IntervalNotificationType.HOUR_AND_HALF$90</ID>
+    <ID>MagicNumber:IntervalNotificationType.kt:IntervalNotificationType.THREE_HOURS$180</ID>
+    <ID>MagicNumber:IntervalNotificationType.kt:IntervalNotificationType.TWO_HOURS$120</ID>
+    <ID>MagicNumber:NotificationController.kt:NotificationController$300</ID>
+    <ID>MagicNumber:NotificationSenderServiceImpl.kt:NotificationSenderServiceImpl$403</ID>
+    <ID>MagicNumber:NotificationSettingDto.kt:NotificationSettingDto.Companion$11</ID>
+    <ID>MagicNumber:NotificationSettingDto.kt:NotificationSettingDto.Companion$23</ID>
+    <ID>MagicNumber:PluralizationHelper.kt:PluralizationHelper$10</ID>
+    <ID>MagicNumber:PluralizationHelper.kt:PluralizationHelper$11</ID>
+    <ID>MagicNumber:PluralizationHelper.kt:PluralizationHelper$14</ID>
+    <ID>MagicNumber:PluralizationHelper.kt:PluralizationHelper$3</ID>
+    <ID>MagicNumber:PluralizationHelper.kt:PluralizationHelper$4</ID>
+    <ID>MagicNumber:SnoozeNotificationType.kt:SnoozeNotificationType.FIFTEEN_MINS$15</ID>
+    <ID>MagicNumber:SnoozeNotificationType.kt:SnoozeNotificationType.FIVE_MINS$5</ID>
+    <ID>MagicNumber:SnoozeNotificationType.kt:SnoozeNotificationType.TEN_MINS$10</ID>
+    <ID>MagicNumber:SnoozeNotificationType.kt:SnoozeNotificationType.TWENTY_MINS$20</ID>
+    <ID>MagicNumber:TelegramBotProperties.kt:TelegramBotProperties$10</ID>
+    <ID>MagicNumber:TelegramBotProperties.kt:TelegramBotProperties.Http$10</ID>
+    <ID>MagicNumber:TelegramBotProperties.kt:TelegramBotProperties.Http$120</ID>
+    <ID>MagicNumber:TelegramBotProperties.kt:TelegramBotProperties.Http$200</ID>
+    <ID>MagicNumber:TelegramBotProperties.kt:TelegramBotProperties.Http$30</ID>
+    <ID>MagicNumber:WaterAmountType.kt:WaterAmountType.ML_100$100</ID>
+    <ID>MagicNumber:WaterAmountType.kt:WaterAmountType.ML_150$150</ID>
+    <ID>MagicNumber:WaterAmountType.kt:WaterAmountType.ML_250$250</ID>
+    <ID>MagicNumber:WaterAmountType.kt:WaterAmountType.ML_450$450</ID>
+    <ID>MagicNumber:WaterAmountType.kt:WaterAmountType.ML_50$50</ID>
+    <ID>MaxLineLength:MeResponse.kt:MeResponse$// The JSON key is intentionally kept as "telegramUserId" - it is the public /users/me contract consumed by the MiniApp.</ID>
+    <ID>MaxLineLength:MessageEditorServiceImpl.kt:MessageEditorServiceImpl$"A previous message can't be deleted! A chatId: [${this.chatId}], messageId: [${this.messageId}]"</ID>
+    <ID>MaxLineLength:NotificationAccessServiceTest.kt:NotificationAccessServiceTest$"findNotificationSettingByExternalUserId(): throws NotificationSettingsNotFoundException when record not found by externalUserId"</ID>
+    <ID>MaxLineLength:NotificationAccessServiceTest.kt:NotificationAccessServiceTest$"updateNotificationSettings(): does not reset timeOfLastNotification and notificationAttempts when interval is the same"</ID>
+    <ID>MaxLineLength:NotificationAccessServiceTest.kt:NotificationAccessServiceTest$"updateNotificationSettings(): resets timeOfLastNotification and notificationAttempts when interval changes"</ID>
+    <ID>MaxLineLength:NotificationAccessServiceTest.kt:NotificationAccessServiceTest$"updateNotificationSettings(): throws NotificationSettingsNotFoundException when record not found by externalUserId"</ID>
+    <ID>MaxLineLength:NotificationAccessServiceTest.kt:NotificationAccessServiceTest$"updatePause(): throws NotificationSettingsNotFoundException for disabled user (filtered by @SQLRestriction)"</ID>
+    <ID>MaxLineLength:NotificationAccessServiceTest.kt:NotificationAccessServiceTest$"updatePause(): throws NotificationSettingsNotFoundException when record not found by externalUserId on cancel"</ID>
+    <ID>MaxLineLength:NotificationAccessServiceTest.kt:NotificationAccessServiceTest$"updateTimeOfLastNotification(): throws NotificationSettingsNotFoundException when record not found by externalUserId"</ID>
+    <ID>MaxLineLength:NotificationTimeServiceTest.kt:NotificationTimeServiceTest.Companion$"Exact quiet start boundary (inclusive): rawNext 14:00 == start -&gt; In quiet, shift to quietModeEnd"</ID>
+    <ID>MaxLineLength:NotificationTimeServiceTest.kt:NotificationTimeServiceTest.Companion$"Tokyo (UTC+9): rawNext 13:30Z = 22:30 local, inside 22-08 -&gt; Shift to 08:00 local next day = 23:00Z"</ID>
+    <ID>MaxLineLength:WaterStatisticAccessServiceImpl.kt:WaterStatisticAccessServiceImpl$"Finding water statistics for externalUserId [$externalUserId] between [$startInclusive] and [$endExclusive]"</ID>
+    <ID>MaxLineLength:WaterStatisticServiceImpl.kt:WaterStatisticServiceImpl$"Water amount must be between ${WaterEntryConstants.MIN_ML} and ${WaterEntryConstants.MAX_ML} ml, got: $amountMl"</ID>
+    <ID>MaxLineLength:WaterStatisticServiceTest.kt:WaterStatisticServiceTest$"manualRecordEvent(): saves statistic with source=MANUAL, eventType=YES and converts consumedAt to UTC LocalDateTime"</ID>
+    <ID>MayBeConstant:ClockHelperTest.kt:ClockHelperTest$val DEFAULT_TIME = "2025-01-01T12:00:00Z"</ID>
+    <ID>MayBeConstant:TelegramMessageConstants.kt:TelegramMessageConstants$val NOTIFICATION_ANSWER_CANCEL_MESSAGE = "Милый зайчик, пожалуйста, напейся в следующий раз!"</ID>
+    <ID>MayBeConstant:TelegramMessageConstants.kt:TelegramMessageConstants$val NOTIFICATION_ANSWER_YES_MESSAGE = "Ты - солнышко! Так держать!"</ID>
+    <ID>MayBeConstant:TelegramMessageConstants.kt:TelegramMessageConstants$val NOTIFICATION_QUESTION_MESSAGE = "Водица выпита?"</ID>
+    <ID>MayBeConstant:TelegramMessageConstants.kt:TelegramMessageConstants$val NOTIFICATION_SNOOZE_MENU_MESSAGE = "Выбери, на сколько хочешь отложить уведомление"</ID>
+    <ID>MayBeConstant:TelegramMessageConstants.kt:TelegramMessageConstants$val NOTIFICATION_WATER_AMOUNT_MENU_MESSAGE = "Сколько водицы выпито?"</ID>
+    <ID>MayBeConstant:TelegramWebAppDataHelper.kt:TelegramWebAppDataHelper$private val ALGORITHM_HASH_KEY = "WebAppData"</ID>
+    <ID>MayBeConstant:TelegramWebAppDataHelper.kt:TelegramWebAppDataHelper$private val ALGORITHM_NAME = "HmacSHA256"</ID>
+    <ID>MayBeConstant:TelegramWebAppDataHelper.kt:TelegramWebAppDataHelper$val AUTH_DATE_FIELD_NAME = "auth_date"</ID>
+    <ID>MayBeConstant:TelegramWebAppDataHelper.kt:TelegramWebAppDataHelper$val HASH_FIELD_NAME = "hash"</ID>
+    <ID>MayBeConstant:TelegramWebAppDataHelper.kt:TelegramWebAppDataHelper$val QUERY_ID_FIELD_NAME = "query_id"</ID>
+    <ID>MayBeConstant:TelegramWebAppDataHelper.kt:TelegramWebAppDataHelper$val USER_FIELD_NAME = "user"</ID>
+    <ID>ReturnCount:AdminAuthInterceptor.kt:AdminAuthInterceptor$override fun preHandle: Boolean</ID>
+    <ID>ReturnCount:NotificationTimeServiceImpl.kt:NotificationTimeServiceImpl$override fun calculateNextNotificationAt: Instant</ID>
+    <ID>ReturnCount:NotificationTimeServiceImpl.kt:NotificationTimeServiceImpl$override fun isOutsideQuietTime: Boolean</ID>
+    <ID>ReturnCount:StatisticsAggregator.kt:StatisticsAggregator$fun bestDay: BestDayDto?</ID>
+    <ID>ReturnCount:TelegramAuthInterceptor.kt:TelegramAuthInterceptor$override fun preHandle: Boolean</ID>
+    <ID>ReturnCount:TelegramWebAppDataHelper.kt:TelegramWebAppDataHelper$fun validateAuthDate: Boolean</ID>
+    <ID>ReturnCount:TelegramWebAppDataHelper.kt:TelegramWebAppDataHelper$fun validateHash: Boolean</ID>
+    <ID>TooGenericExceptionCaught:FunctionHelper.kt:FunctionHelper$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:NotificationScheduler.kt:NotificationScheduler$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:NotificationSettingsServiceImpl.kt:NotificationSettingsServiceImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:TelegramAuthInterceptor.kt:TelegramAuthInterceptor$e: Exception</ID>
+    <ID>TooGenericExceptionThrown:FunctionHelperTest.kt:FunctionHelperTest$throw RuntimeException()</ID>
+    <ID>TooManyFunctions:NotificationAccessService.kt:NotificationAccessService</ID>
+    <ID>TooManyFunctions:NotificationAccessServiceImpl.kt:NotificationAccessServiceImpl : NotificationAccessService</ID>
+    <ID>TooManyFunctions:NotificationSettingsService.kt:NotificationSettingsService</ID>
+    <ID>TooManyFunctions:NotificationSettingsServiceImpl.kt:NotificationSettingsServiceImpl : NotificationSettingsService</ID>
+    <ID>UtilityClassWithPublicConstructor:DtoGenerator.kt:DtoGenerator</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,856 @@
+config:
+  validation: true
+  warningsAsErrors: false
+  checkExhaustiveness: false
+  # when writing own rules with new properties, exclude the property path e.g.: ['my_rule_set', '.*>.*>[my_property]']
+  excludes: []
+
+processors:
+  active: true
+  exclude:
+  # - 'KtFileCountProcessor'
+  # - 'PackageCountProcessor'
+  # - 'ClassCountProcessor'
+  # - 'FunctionCountProcessor'
+  # - 'PropertyCountProcessor'
+  # - 'ProjectCyclomaticComplexityProcessor'
+  # - 'ProjectCognitiveComplexityProcessor'
+  # - 'ProjectLLOCProcessor'
+  # - 'ProjectCLOCProcessor'
+  # - 'ProjectLOCProcessor'
+  # - 'ProjectSLOCProcessor'
+
+console-reports:
+  active: true
+  exclude:
+     - 'ProjectStatisticsReport'
+     - 'ComplexityReport'
+     - 'NotificationReport'
+     - 'IssuesReport'
+     - 'FileBasedIssuesReport'
+  #  - 'LiteIssuesReport'
+
+comments:
+  active: true
+  AbsentOrWrongFileLicense:
+    active: false
+    licenseTemplateIsRegex: false
+    licenseTemplate: ''
+  DeprecatedBlockTag:
+    active: false
+  DocumentationOverPrivateFunction:
+    active: false
+  DocumentationOverPrivateProperty:
+    active: false
+  EndOfSentenceFormat:
+    active: false
+    endOfSentenceFormat: '([.?!][ \t\n\r\f<])|([.?!:]$)'
+  KDocReferencesNonPublicProperty:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+  OutdatedDocumentation:
+    active: false
+    matchTypeParameters: true
+    matchDeclarationsOrder: true
+    allowParamOnConstructorProperties: false
+  UndocumentedPublicClass:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    searchInNestedClass: true
+    searchInInnerClass: true
+    searchInInnerObject: true
+    searchInInnerInterface: true
+    searchInProtectedClass: false
+    ignoreDefaultCompanionObject: false
+  UndocumentedPublicFunction:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    searchProtectedFunction: false
+  UndocumentedPublicProperty:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    searchProtectedProperty: false
+    ignoreEnumEntries: false
+
+complexity:
+  active: true
+  CognitiveComplexMethod:
+    active: false
+    allowedComplexity: 15
+  ComplexCondition:
+    active: true
+    allowedConditions: 3
+  ComplexInterface:
+    active: false
+    allowedDefinitions: 10
+    includeStaticDeclarations: false
+    includePrivateDeclarations: false
+    ignoreOverloaded: false
+  CyclomaticComplexMethod:
+    active: true
+    allowedComplexity: 14
+    ignoreSingleWhenExpression: false
+    ignoreSimpleWhenEntries: false
+    ignoreNestingFunctions: false
+    ignoreLocalFunctions: false
+    nestingFunctions:
+      - 'also'
+      - 'apply'
+      - 'forEach'
+      - 'isNotNull'
+      - 'ifNull'
+      - 'let'
+      - 'run'
+      - 'use'
+      - 'with'
+  LabeledExpression:
+    active: false
+    ignoredLabels: []
+  LargeClass:
+    active: true
+    allowedLines: 600
+  LongMethod:
+    active: true
+    allowedLines: 60
+  LongParameterList:
+    active: true
+    allowedFunctionParameters: 5
+    allowedConstructorParameters: 6
+    ignoreDefaultParameters: false
+    ignoreDataClasses: true
+    ignoreAnnotatedParameter: []
+  MethodOverloading:
+    active: false
+    allowedOverloads: 6
+  NamedArguments:
+    active: false
+    allowedArguments: 3
+    ignoreMethods: []
+    ignoreArgumentsMatchingNames: false
+  NestedBlockDepth:
+    active: true
+    allowedDepth: 4
+  NestedScopeFunctions:
+    active: false
+    allowedDepth: 1
+    functions:
+      - 'kotlin.apply'
+      - 'kotlin.run'
+      - 'kotlin.with'
+      - 'kotlin.let'
+      - 'kotlin.also'
+  ReplaceSafeCallChainWithRun:
+    active: false
+  StringLiteralDuplication:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    allowedDuplications: 2
+    ignoreAnnotation: true
+    allowedWithLengthLessThan: 5
+    ignoreStringsRegex: '$^'
+  TooManyFunctions:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    allowedFunctionsPerFile: 11
+    allowedFunctionsPerClass: 11
+    allowedFunctionsPerInterface: 11
+    allowedFunctionsPerObject: 11
+    allowedFunctionsPerEnum: 11
+    ignoreDeprecated: false
+    ignorePrivate: false
+    ignoreInternal: false
+    ignoreOverridden: false
+    ignoreAnnotatedFunctions: []
+
+coroutines:
+  active: true
+  CoroutineLaunchedInTestWithoutRunTest:
+    active: false
+  GlobalCoroutineUsage:
+    active: false
+  InjectDispatcher:
+    active: true
+    dispatcherNames:
+      - 'IO'
+      - 'Default'
+      - 'Unconfined'
+  RedundantSuspendModifier:
+    active: true
+  SleepInsteadOfDelay:
+    active: true
+  SuspendFunInFinallySection:
+    active: false
+  SuspendFunSwallowedCancellation:
+    active: false
+  SuspendFunWithCoroutineScopeReceiver:
+    active: false
+    aliases: ['SuspendFunctionOnCoroutineScope']
+  SuspendFunWithFlowReturnType:
+    active: true
+
+empty-blocks:
+  active: true
+  EmptyCatchBlock:
+    active: true
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  EmptyClassBlock:
+    active: true
+  EmptyDefaultConstructor:
+    active: true
+  EmptyDoWhileBlock:
+    active: true
+  EmptyElseBlock:
+    active: true
+  EmptyFinallyBlock:
+    active: true
+  EmptyForBlock:
+    active: true
+  EmptyFunctionBlock:
+    active: true
+    ignoreOverridden: false
+  EmptyIfBlock:
+    active: true
+  EmptyInitBlock:
+    active: true
+  EmptyKotlinFile:
+    active: true
+  EmptySecondaryConstructor:
+    active: true
+  EmptyTryBlock:
+    active: true
+  EmptyWhenBlock:
+    active: true
+  EmptyWhileBlock:
+    active: true
+
+exceptions:
+  active: true
+  ErrorUsageWithThrowable:
+    active: false
+  ExceptionRaisedInUnexpectedLocation:
+    active: true
+    methodNames:
+      - 'equals'
+      - 'finalize'
+      - 'hashCode'
+      - 'toString'
+  InstanceOfCheckForException:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+  NotImplementedDeclaration:
+    active: false
+  ObjectExtendsThrowable:
+    active: false
+  PrintStackTrace:
+    active: true
+  RethrowCaughtException:
+    active: true
+  ReturnFromFinally:
+    active: true
+    ignoreLabeled: false
+  SwallowedException:
+    active: true
+    ignoredExceptionTypes:
+      - 'InterruptedException'
+      - 'MalformedURLException'
+      - 'NumberFormatException'
+      - 'ParseException'
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  ThrowingExceptionFromFinally:
+    active: true
+  ThrowingExceptionInMain:
+    active: false
+  ThrowingExceptionsWithoutMessageOrCause:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    exceptions:
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Exception'
+      - 'IllegalArgumentException'
+      - 'IllegalMonitorStateException'
+      - 'IllegalStateException'
+      - 'IndexOutOfBoundsException'
+      - 'NullPointerException'
+      - 'RuntimeException'
+      - 'Throwable'
+  ThrowingNewInstanceOfSameException:
+    active: true
+  TooGenericExceptionCaught:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    exceptionNames:
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Error'
+      - 'Exception'
+      - 'IllegalMonitorStateException'
+      - 'IndexOutOfBoundsException'
+      - 'NullPointerException'
+      - 'RuntimeException'
+      - 'Throwable'
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  TooGenericExceptionThrown:
+    active: true
+    exceptionNames:
+      - 'Error'
+      - 'Exception'
+      - 'RuntimeException'
+      - 'Throwable'
+
+naming:
+  active: true
+  BooleanPropertyNaming:
+    active: false
+    allowedPattern: '^(is|has|are)'
+  ClassNaming:
+    active: true
+    aliases: ['ClassName']
+    classPattern: '[A-Z][a-zA-Z0-9]*'
+  ConstructorParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    privateParameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+  EnumNaming:
+    active: true
+    aliases: ['EnumEntryName']
+    enumEntryPattern: '[A-Z][_a-zA-Z0-9]*'
+  ForbiddenClassName:
+    active: false
+    forbiddenName: []
+  FunctionNameMaxLength:
+    active: false
+    aliases: ['FunctionMaxNameLength']
+    maximumFunctionNameLength: 30
+  FunctionNameMinLength:
+    active: false
+    aliases: ['FunctionMinNameLength']
+    minimumFunctionNameLength: 3
+  FunctionNaming:
+    active: true
+    aliases: ['FunctionName']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    functionPattern: '[a-z][a-zA-Z0-9]*'
+    excludeClassPattern: '$^'
+  FunctionParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+  InvalidPackageDeclaration:
+    active: true
+    aliases: ['PackageDirectoryMismatch']
+    rootPackage: ''
+    requireRootInDeclaration: false
+  LambdaParameterNaming:
+    active: false
+    parameterPattern: '[a-z][A-Za-z0-9]*|_'
+  MatchingDeclarationName:
+    active: true
+    mustBeFirst: true
+    multiplatformTargets:
+      - 'ios'
+      - 'android'
+      - 'js'
+      - 'jvm'
+      - 'native'
+      - 'iosArm64'
+      - 'iosX64'
+      - 'macosX64'
+      - 'mingwX64'
+      - 'linuxX64'
+  MemberNameEqualsClassName:
+    active: true
+    ignoreOverridden: true
+  NoNameShadowing:
+    active: true
+  NonBooleanPropertyPrefixedWithIs:
+    active: false
+  ObjectPropertyNaming:
+    active: true
+    aliases: ['ObjectPropertyName']
+    constantPattern: '[A-Za-z][_A-Za-z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
+  PackageNaming:
+    active: true
+    aliases: ['PackageName']
+    packagePattern: '[a-z]+(\.[a-z][A-Za-z0-9]*)*'
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
+  VariableMaxLength:
+    active: false
+    maximumVariableNameLength: 64
+  VariableMinLength:
+    active: false
+    minimumVariableNameLength: 1
+  VariableNaming:
+    active: true
+    aliases: ['PropertyName']
+    variablePattern: '[a-z][A-Za-z0-9]*'
+    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+
+performance:
+  active: true
+  ArrayPrimitive:
+    active: true
+  CouldBeSequence:
+    active: false
+    allowedOperations: 2
+  ForEachOnRange:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+  SpreadOperator:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+  UnnecessaryInitOnArray:
+    active: false
+  UnnecessaryPartOfBinaryExpression:
+    active: false
+  UnnecessaryTemporaryInstantiation:
+    active: true
+  UnnecessaryTypeCasting:
+    active: false
+
+potential-bugs:
+  active: true
+  AvoidReferentialEquality:
+    active: true
+    forbiddenTypePatterns:
+      - 'kotlin.String'
+  CastNullableToNonNullableType:
+    active: false
+    ignorePlatformTypes: true
+  CastToNullableType:
+    active: false
+  CharArrayToStringCall:
+    active: false
+  Deprecation:
+    active: false
+    aliases: ['DEPRECATION']
+    excludeImportStatements: false
+  DontDowncastCollectionTypes:
+    active: false
+  DoubleMutabilityForCollection:
+    active: true
+    aliases: ['DoubleMutability']
+    mutableTypes:
+      - 'kotlin.collections.MutableList'
+      - 'kotlin.collections.MutableMap'
+      - 'kotlin.collections.MutableSet'
+      - 'java.util.ArrayList'
+      - 'java.util.LinkedHashSet'
+      - 'java.util.HashSet'
+      - 'java.util.LinkedHashMap'
+      - 'java.util.HashMap'
+  ElseCaseInsteadOfExhaustiveWhen:
+    active: false
+    ignoredSubjectTypes: []
+  EqualsAlwaysReturnsTrueOrFalse:
+    active: true
+  EqualsWithHashCodeExist:
+    active: true
+  ExitOutsideMain:
+    active: false
+  ExplicitGarbageCollectionCall:
+    active: true
+  HasPlatformType:
+    active: true
+  IgnoredReturnValue:
+    active: true
+    restrictToConfig: true
+    returnValueAnnotations:
+      - 'CheckResult'
+      - '*.CheckResult'
+      - 'CheckReturnValue'
+      - '*.CheckReturnValue'
+    ignoreReturnValueAnnotations:
+      - 'CanIgnoreReturnValue'
+      - '*.CanIgnoreReturnValue'
+    returnValueTypes:
+      - 'kotlin.Function*'
+      - 'kotlin.sequences.Sequence'
+      - 'kotlinx.coroutines.flow.*Flow'
+      - 'java.util.stream.*Stream'
+    ignoreFunctionCall: []
+  ImplicitDefaultLocale:
+    active: true
+  ImplicitUnitReturnType:
+    active: false
+    ignoreAnnotated: ['Test']
+    allowExplicitReturnType: true
+  InvalidRange:
+    active: true
+  IteratorHasNextCallsNextMethod:
+    active: true
+  IteratorNotThrowingNoSuchElementException:
+    active: true
+  LateinitUsage:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    ignoreOnClassesPattern: ''
+  MapGetWithNotNullAssertionOperator:
+    active: true
+  MissingPackageDeclaration:
+    active: false
+    excludes: ['**/*.kts']
+  MissingSuperCall:
+    active: false
+    mustInvokeSuperAnnotations:
+      - 'androidx.annotation.CallSuper'
+      - 'javax.annotation.OverridingMethodsMustInvokeSuper'
+  MissingUseCall:
+    active: false
+    ignoreClass:
+      - 'java.io.ByteArrayInputStream'
+      - 'java.io.ByteArrayOutputStream'
+  NullCheckOnMutableProperty:
+    active: false
+  NullableToStringCall:
+    active: false
+  PropertyUsedBeforeDeclaration:
+    active: false
+  UnconditionalJumpStatementInLoop:
+    active: false
+  UnnamedParameterUse:
+    active: false
+    allowAdjacentDifferentTypeParams: true
+    allowSingleParamUse: true
+    ignoreArgumentsMatchingNames: true
+    ignoreFunctionCall: []
+  UnnecessaryNotNullCheck:
+    active: false
+  UnnecessaryNotNullOperator:
+    active: true
+  UnnecessarySafeCall:
+    active: true
+  UnreachableCatchBlock:
+    active: true
+  UnreachableCode:
+    active: true
+  UnsafeCallOnNullableType:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+  UnsafeCast:
+    active: true
+    aliases: ['UNCHECKED_CAST']
+  UnusedUnaryOperator:
+    active: true
+  UselessPostfixExpression:
+    active: true
+  WrongEqualsTypeParameter:
+    active: true
+
+style:
+  active: true
+  AbstractClassCanBeConcreteClass:
+    active: true
+  AbstractClassCanBeInterface:
+    active: true
+  AlsoCouldBeApply:
+    active: false
+  BracesOnIfStatements:
+    active: false
+    singleLine: 'never'
+    multiLine: 'always'
+  BracesOnWhenStatements:
+    active: false
+    singleLine: 'necessary'
+    multiLine: 'consistent'
+  CanBeNonNullable:
+    active: false
+  CascadingCallWrapping:
+    active: false
+    includeElvis: true
+  ClassOrdering:
+    active: false
+  CollapsibleIfStatements:
+    active: false
+  DataClassContainsFunctions:
+    active: false
+    conversionFunctionPrefix:
+      - 'to'
+    allowOperators: false
+  DataClassShouldBeImmutable:
+    active: false
+  DestructuringDeclarationWithTooManyEntries:
+    active: true
+    maxDestructuringEntries: 3
+  DoubleNegativeExpression:
+    active: false
+  DoubleNegativeLambda:
+    active: false
+    negativeFunctions:
+      - reason: 'Use `takeIf` instead.'
+        value: 'takeUnless'
+      - reason: 'Use `all` instead.'
+        value: 'none'
+    negativeFunctionNameParts:
+      - 'not'
+      - 'non'
+  EqualsNullCall:
+    active: true
+  EqualsOnSignatureLine:
+    active: false
+  ExplicitCollectionElementAccessMethod:
+    active: false
+  ExplicitItLambdaMultipleParameters:
+    active: true
+  ExplicitItLambdaParameter:
+    active: true
+  ExpressionBodySyntax:
+    active: false
+    includeLineWrapping: false
+  ForbiddenAnnotation:
+    active: false
+    annotations:
+      - reason: 'it is a java annotation. Use `Suppress` instead.'
+        value: 'java.lang.SuppressWarnings'
+      - reason: 'it is a java annotation. Use `kotlin.Deprecated` instead.'
+        value: 'java.lang.Deprecated'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.MustBeDocumented` instead.'
+        value: 'java.lang.annotation.Documented'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.Target` instead.'
+        value: 'java.lang.annotation.Target'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.Retention` instead.'
+        value: 'java.lang.annotation.Retention'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.Repeatable` instead.'
+        value: 'java.lang.annotation.Repeatable'
+  ForbiddenComment:
+    active: true
+    comments:
+      - reason: 'Forbidden FIXME todo marker in comment, please fix the problem.'
+        value: 'FIXME:'
+      - reason: 'Forbidden STOPSHIP todo marker in comment, please address the problem before shipping the code.'
+        value: 'STOPSHIP:'
+      - reason: 'Forbidden TODO todo marker in comment, please do the changes.'
+        value: 'TODO:'
+    allowedPatterns: ''
+  ForbiddenImport:
+    active: false
+    forbiddenImports: []
+    allowedImports: []
+  ForbiddenMethodCall:
+    active: false
+    methods:
+      - reason: 'print does not allow you to configure the output stream. Use a logger instead.'
+        value: 'kotlin.io.print'
+      - reason: 'println does not allow you to configure the output stream. Use a logger instead.'
+        value: 'kotlin.io.println'
+      - reason: 'using `BigDecimal(Double)` can result in unexpected floating point precision behavior. Use `BigDecimal.valueOf(Double)` or `String.toBigDecimalOrNull()` instead.'
+        value: 'java.math.BigDecimal.<init>(kotlin.Double)'
+      - reason: 'using `BigDecimal(String)` can result in a `NumberFormatException`. Use `String.toBigDecimalOrNull()`'
+        value: 'java.math.BigDecimal.<init>(kotlin.String)'
+      - reason: 'It is marked as obsolete. Use `kotlin.time.measureTime` instead.'
+        value: 'kotlin.system.measureTimeMillis'
+  ForbiddenNamedParam:
+    active: false
+    methods: []
+  ForbiddenOptIn:
+    active: false
+    markerClasses: []
+  ForbiddenSuppress:
+    active: false
+    rules: []
+  ForbiddenVoid:
+    active: true
+    ignoreOverridden: false
+    ignoreUsageInGenerics: false
+  FunctionOnlyReturningConstant:
+    active: true
+    ignoreOverridableFunction: true
+    ignoreActualFunction: true
+    excludedFunctions: []
+  LoopWithTooManyJumpStatements:
+    active: true
+    maxJumpCount: 1
+  MagicNumber:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/*.kts']
+    ignoreNumbers:
+      - '-1'
+      - '0'
+      - '1'
+      - '2'
+    ignoreHashCodeFunction: true
+    ignorePropertyDeclaration: true
+    ignoreLocalVariableDeclaration: true
+    ignoreConstantDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+    ignoreAnnotation: false
+    ignoreNamedArgument: true
+    ignoreEnums: false
+    ignoreRanges: false
+    ignoreExtensionFunctions: true
+  MandatoryBracesLoops:
+    active: false
+  MaxChainedCallsOnSameLine:
+    active: false
+    maxChainedCalls: 5
+  MaxLineLength:
+    active: true
+    maxLineLength: 120
+    excludePackageStatements: true
+    excludeImportStatements: true
+    excludeCommentStatements: false
+    excludeRawStrings: true
+  MayBeConstant:
+    active: true
+  ModifierOrder:
+    active: true
+  MultilineLambdaItParameter:
+    active: false
+  MultilineRawStringIndentation:
+    active: false
+    indentSize: 4
+    trimmingMethods:
+      - 'trimIndent'
+      - 'trimMargin'
+  NestedClassesVisibility:
+    active: true
+  NewLineAtEndOfFile:
+    active: true
+  NoTabs:
+    active: false
+  NullableBooleanCheck:
+    active: false
+  ObjectLiteralToLambda:
+    active: true
+  OptionalAbstractKeyword:
+    active: true
+  OptionalUnit:
+    active: false
+  ProtectedMemberInFinalClass:
+    active: true
+  RangeUntilInsteadOfRangeTo:
+    active: false
+  RedundantConstructorKeyword:
+    active: false
+  RedundantExplicitType:
+    active: false
+  RedundantHigherOrderMapUsage:
+    active: true
+  RedundantVisibilityModifier:
+    active: false
+  ReturnCount:
+    active: true
+    max: 2
+    excludedFunctions:
+      - 'equals'
+    excludeLabeled: false
+    excludeReturnFromLambda: true
+    excludeGuardClauses: false
+  SafeCast:
+    active: true
+  SerialVersionUIDInSerializableClass:
+    active: true
+  SpacingAfterPackageAndImports:
+    active: false
+  StringShouldBeRawString:
+    active: false
+    maxEscapedCharacterCount: 2
+    ignoredCharacters: []
+  ThrowsCount:
+    active: true
+    max: 2
+    excludeGuardClauses: false
+  TrailingWhitespace:
+    active: false
+  TrimMultilineRawString:
+    active: false
+    trimmingMethods:
+      - 'trimIndent'
+      - 'trimMargin'
+  UnderscoresInNumericLiterals:
+    active: false
+    acceptableLength: 4
+    allowNonStandardGrouping: false
+  UnnecessaryAny:
+    active: false
+  UnnecessaryApply:
+    active: true
+  UnnecessaryBackticks:
+    active: false
+  UnnecessaryBracesAroundTrailingLambda:
+    active: false
+  UnnecessaryFilter:
+    active: true
+  UnnecessaryFullyQualifiedName:
+    active: false
+  UnnecessaryInheritance:
+    active: true
+  UnnecessaryInnerClass:
+    active: false
+  UnnecessaryLet:
+    active: false
+  UnnecessaryParentheses:
+    active: false
+    allowForUnclearPrecedence: false
+  UnnecessaryReversed:
+    active: false
+  UnusedImport:
+    active: false
+    additionalOperatorSet: []
+  UnusedParameter:
+    active: true
+    aliases: ['UNUSED_PARAMETER', 'unused']
+    allowedNames: 'ignored|expected'
+  UnusedPrivateClass:
+    active: true
+    aliases: ['unused']
+  UnusedPrivateFunction:
+    active: true
+    aliases: ['unused']
+    allowedNames: ''
+  UnusedPrivateProperty:
+    active: true
+    aliases: ['unused']
+    allowedNames: 'ignored|expected|serialVersionUID'
+  UnusedVariable:
+    active: true
+    aliases: ['UNUSED_VARIABLE', 'unused']
+    allowedNames: 'ignored|_'
+  UseAnyOrNoneInsteadOfFind:
+    active: true
+  UseArrayLiteralsInAnnotations:
+    active: true
+  UseCheckNotNull:
+    active: true
+  UseCheckOrError:
+    active: true
+  UseDataClass:
+    active: false
+    allowVars: false
+  UseEmptyCounterpart:
+    active: false
+  UseIfEmptyOrIfBlank:
+    active: false
+  UseIfInsteadOfWhen:
+    active: false
+    ignoreWhenContainingVariableDeclaration: false
+  UseIsNullOrEmpty:
+    active: true
+  UseLet:
+    active: false
+  UseOrEmpty:
+    active: true
+  UseRequire:
+    active: true
+  UseRequireNotNull:
+    active: true
+  UseSumOfInsteadOfFlatMapSize:
+    active: false
+  UselessCallOnNotNull:
+    active: true
+  UtilityClassWithPublicConstructor:
+    active: true
+  VarCouldBeVal:
+    active: true
+    aliases: ['CanBeVal']
+    ignoreLateinitVar: false
+  WildcardImport:
+    active: true
+    excludeImports:
+      - 'java.util.*'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,11 @@
 spring-boot-plugin = "3.5.9"
 spring-dependency-management-plugin = "1.1.7"
 liquibase-plugin = "2.2.1"
-kotlin-plugin = "2.3.10"
+kotlin-plugin = "2.3.21"
 ksp-plugin = "2.3.5"
 konvert = "4.5.0"
+kotlinter-plugin = "5.5.0"
+detekt-plugin = "2.0.0-alpha.3"
 
 validation-api = "2.0.1.Final"
 logbook = "3.9.0"
@@ -81,3 +83,5 @@ kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotl
 kotlin-jpa = { id = "org.jetbrains.kotlin.plugin.jpa", version.ref = "kotlin-plugin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin-plugin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp-plugin" }
+kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter-plugin" }
+detekt = { id = "dev.detekt", version.ref = "detekt-plugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,9 @@
 spring-boot-plugin = "3.5.9"
 spring-dependency-management-plugin = "1.1.7"
 liquibase-plugin = "2.2.1"
-kotlin-plugin = "2.1.21"
+kotlin-plugin = "2.3.10"
+ksp-plugin = "2.3.5"
+konvert = "4.5.0"
 
 validation-api = "2.0.1.Final"
 logbook = "3.9.0"
@@ -67,6 +69,8 @@ commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "co
 springdoc-openapi-starter-webmvc-ui = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc" }
 xmlunit = { module = "org.xmlunit:xmlunit-core", version.ref = "xmlunit" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
+konvert = { module = "io.mcarle:konvert", version.ref = "konvert" }
+konvert-api = { module = "io.mcarle:konvert-api", version.ref = "konvert" }
 
 [plugins]
 springframework-boot = { id = "org.springframework.boot", version.ref = "spring-boot-plugin" }
@@ -76,3 +80,4 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin-plugin" }
 kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin-plugin" }
 kotlin-jpa = { id = "org.jetbrains.kotlin.plugin.jpa", version.ref = "kotlin-plugin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin-plugin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp-plugin" }

--- a/src/main/kotlin/ru/illine/drinking/ponies/bot/DrinkingPoniesTelegramBot.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/bot/DrinkingPoniesTelegramBot.kt
@@ -2,7 +2,6 @@ package ru.illine.drinking.ponies.bot
 
 import org.telegram.telegrambots.abilitybots.api.bot.AbilityBot
 import org.telegram.telegrambots.abilitybots.api.bot.BaseAbilityBot
-import org.telegram.telegrambots.abilitybots.api.db.MapDBContext.offlineInstance
 import org.telegram.telegrambots.abilitybots.api.objects.Ability
 import org.telegram.telegrambots.abilitybots.api.objects.Flag
 import org.telegram.telegrambots.abilitybots.api.objects.Locality
@@ -27,7 +26,7 @@ class DrinkingPoniesTelegramBot(
 ) : AbilityBot(
         telegramClient,
         telegramBotProperties.username,
-        offlineInstance(telegramBotProperties.username),
+        InMemoryDBContext(),
         BareboneToggle(),
     ) {
     // Sentinel: Privacy.CREATOR is no longer used, but creatorId() is abstract in AbilityBot

--- a/src/main/kotlin/ru/illine/drinking/ponies/bot/DrinkingPoniesTelegramBot.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/bot/DrinkingPoniesTelegramBot.kt
@@ -3,7 +3,11 @@ package ru.illine.drinking.ponies.bot
 import org.telegram.telegrambots.abilitybots.api.bot.AbilityBot
 import org.telegram.telegrambots.abilitybots.api.bot.BaseAbilityBot
 import org.telegram.telegrambots.abilitybots.api.db.MapDBContext.offlineInstance
-import org.telegram.telegrambots.abilitybots.api.objects.*
+import org.telegram.telegrambots.abilitybots.api.objects.Ability
+import org.telegram.telegrambots.abilitybots.api.objects.Flag
+import org.telegram.telegrambots.abilitybots.api.objects.Locality
+import org.telegram.telegrambots.abilitybots.api.objects.Privacy
+import org.telegram.telegrambots.abilitybots.api.objects.Reply
 import org.telegram.telegrambots.abilitybots.api.toggle.BareboneToggle
 import org.telegram.telegrambots.meta.api.objects.Update
 import org.telegram.telegrambots.meta.generics.TelegramClient
@@ -14,20 +18,18 @@ import ru.illine.drinking.ponies.service.command.CommandService
 import ru.illine.drinking.ponies.service.notification.NotificationService
 import java.util.function.BiConsumer
 
-
 class DrinkingPoniesTelegramBot(
     telegramClient: TelegramClient,
     private val telegramBotProperties: TelegramBotProperties,
     private val notificationService: NotificationService,
     private val replyButtonFactory: ReplyButtonFactory,
-    private val commandService: CommandService
+    private val commandService: CommandService,
 ) : AbilityBot(
-    telegramClient,
-    telegramBotProperties.username,
-    offlineInstance(telegramBotProperties.username),
-    BareboneToggle()
-) {
-
+        telegramClient,
+        telegramBotProperties.username,
+        offlineInstance(telegramBotProperties.username),
+        BareboneToggle(),
+    ) {
     // Sentinel: Privacy.CREATOR is no longer used, but creatorId() is abstract in AbilityBot
     override fun creatorId(): Long = 0L
 
@@ -49,9 +51,10 @@ class DrinkingPoniesTelegramBot(
 
     @Suppress("unused")
     fun replyInlineButtons(): Reply {
-        val action = BiConsumer<BaseAbilityBot, Update> { _, update ->
-            replyButtonFactory.getStrategy(update.callbackQuery.data).reply(update.callbackQuery)
-        }
+        val action =
+            BiConsumer<BaseAbilityBot, Update> { _, update ->
+                replyButtonFactory.getStrategy(update.callbackQuery.data).reply(update.callbackQuery)
+            }
         return Reply.of(action, Flag.CALLBACK_QUERY)
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/bot/InMemoryDBContext.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/bot/InMemoryDBContext.kt
@@ -1,0 +1,80 @@
+package ru.illine.drinking.ponies.bot
+
+import org.telegram.telegrambots.abilitybots.api.db.DBContext
+import org.telegram.telegrambots.abilitybots.api.db.Var
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Heap-backed [DBContext] for [AbilityBot]. The bot keeps its state in PostgreSQL and never reads the
+ * ability db, so this stub replaces the default MapDB-based context.
+ */
+@Suppress("TooManyFunctions")
+class InMemoryDBContext : DBContext {
+    private val structures = ConcurrentHashMap<String, Any>()
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> getList(name: String): MutableList<T> =
+        structures.computeIfAbsent(name) { Collections.synchronizedList(mutableListOf<T>()) } as MutableList<T>
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <K, V> getMap(name: String): MutableMap<K, V> =
+        structures.computeIfAbsent(name) { ConcurrentHashMap<K & Any, V & Any>() } as MutableMap<K, V>
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> getSet(name: String): MutableSet<T> =
+        structures.computeIfAbsent(name) { ConcurrentHashMap.newKeySet<T>() } as MutableSet<T>
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> getVar(name: String): Var<T> = structures.computeIfAbsent(name) { InMemoryVar<T>() } as Var<T>
+
+    override fun summary(): String = structures.keys.joinToString("\n", transform = ::info)
+
+    override fun backup(): Any = HashMap(structures)
+
+    override fun recover(backup: Any): Boolean {
+        if (backup !is Map<*, *>) return false
+        structures.clear()
+        backup.forEach { (key, value) -> if (key is String && value != null) structures[key] = value }
+        return true
+    }
+
+    override fun info(name: String): String {
+        val structure = structures[name] ?: error("DB structure with name [$name] does not exist")
+        val description =
+            when (structure) {
+                is Set<*> -> "Set - ${structure.size}"
+                is List<*> -> "List - ${structure.size}"
+                is Map<*, *> -> "Map - ${structure.size}"
+                else -> "Var"
+            }
+        return "$name - $description"
+    }
+
+    override fun commit() = Unit
+
+    override fun clear() {
+        structures.values.forEach { structure ->
+            when (structure) {
+                is MutableCollection<*> -> structure.clear()
+                is MutableMap<*, *> -> structure.clear()
+            }
+        }
+    }
+
+    override fun contains(name: String): Boolean = structures.containsKey(name)
+
+    override fun close() = Unit
+
+    private class InMemoryVar<T> : Var<T> {
+        @Volatile
+        private var value: Any? = null
+
+        @Suppress("UNCHECKED_CAST")
+        override fun get(): T = value as T
+
+        override fun set(value: T) {
+            this.value = value
+        }
+    }
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/builder/NotificationSettingBuilder.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/builder/NotificationSettingBuilder.kt
@@ -1,5 +1,6 @@
 package ru.illine.drinking.ponies.builder
 
+import io.mcarle.konvert.api.Konverter
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
@@ -7,49 +8,35 @@ import ru.illine.drinking.ponies.model.entity.NotificationSettingEntity
 import ru.illine.drinking.ponies.model.entity.TelegramChatEntity
 import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 
+@Konverter
+interface NotificationSettingMapper {
+    fun toDto(
+        @Konverter.Source setting: NotificationSettingEntity,
+        telegramUser: TelegramUserDto,
+        telegramChat: TelegramChatDto,
+    ): NotificationSettingDto
+
+    fun toEntity(
+        @Konverter.Source setting: NotificationSettingDto,
+        telegramUser: TelegramUserEntity,
+        telegramChat: TelegramChatEntity,
+    ): NotificationSettingEntity
+}
+
 object NotificationSettingBuilder {
+    private val mapper: NotificationSettingMapper = Konverter.get<NotificationSettingMapper>()
+
     fun toDto(
         setting: NotificationSettingEntity,
         user: TelegramUserDto,
         chat: TelegramChatDto
     ): NotificationSettingDto =
-        NotificationSettingDto(
-            id = setting.id,
-            telegramUser = user,
-            telegramChat = chat,
-            notificationInterval = setting.notificationInterval,
-            timeOfLastNotification = setting.timeOfLastNotification,
-            notificationAttempts = setting.notificationAttempts,
-            quietModeStart = setting.quietModeStart,
-            quietModeEnd = setting.quietModeEnd,
-            pauseUntil = setting.pauseUntil,
-            dailyGoalMl = setting.dailyGoalMl,
-            enabled = setting.enabled,
-        )
+        mapper.toDto(setting, user, chat)
 
     fun toEntity(
         setting: NotificationSettingDto,
         user: TelegramUserEntity,
         chat: TelegramChatEntity
-    ): NotificationSettingEntity {
-
-        val setting = NotificationSettingEntity(
-            id = setting.id,
-            telegramUser = user,
-            telegramChat = chat,
-            notificationInterval = setting.notificationInterval,
-            timeOfLastNotification = setting.timeOfLastNotification,
-            notificationAttempts = setting.notificationAttempts,
-            quietModeStart = setting.quietModeStart,
-            quietModeEnd = setting.quietModeEnd,
-            pauseUntil = setting.pauseUntil,
-            dailyGoalMl = setting.dailyGoalMl,
-            enabled = setting.enabled,
-        )
-
-        user.notificationSettings = setting
-        user.telegramChats += chat
-
-        return setting
-    }
+    ): NotificationSettingEntity =
+        mapper.toEntity(setting, user, chat)
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/builder/SettingBuilder.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/builder/SettingBuilder.kt
@@ -4,6 +4,12 @@ import ru.illine.drinking.ponies.model.dto.SettingDto
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.util.TimeHelper
 
+// Intentionally hand-written, not migrated to Konvert (DPTB-136): this is a presentation
+// transformation, not a structural mapping - the interval enum is expanded into three fields,
+// LocalTime is formatted to String, and timezone is read from a nested object. Konvert would
+// express all of this as @Mapping(expression=...), which it does not verify, giving no real
+// safety over this named-constructor form. Correctness is guarded by
+// NotificationSettingsServiceTest."getAllSettings returns full dto when enabled", which asserts every field.
 object SettingBuilder {
     fun toDto(settings: NotificationSettingDto): SettingDto = SettingDto(
         interval = settings.notificationInterval.name,

--- a/src/main/kotlin/ru/illine/drinking/ponies/builder/SettingResponseBuilder.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/builder/SettingResponseBuilder.kt
@@ -1,0 +1,16 @@
+package ru.illine.drinking.ponies.builder
+
+import io.mcarle.konvert.api.Konverter
+import ru.illine.drinking.ponies.model.dto.SettingDto
+import ru.illine.drinking.ponies.model.dto.response.SettingResponse
+
+@Konverter
+interface SettingResponseMapper {
+    fun toResponse(dto: SettingDto): SettingResponse
+}
+
+object SettingResponseBuilder {
+    private val mapper: SettingResponseMapper = Konverter.get<SettingResponseMapper>()
+
+    fun toResponse(dto: SettingDto): SettingResponse = mapper.toResponse(dto)
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/builder/StatisticsBuilder.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/builder/StatisticsBuilder.kt
@@ -1,30 +1,34 @@
 package ru.illine.drinking.ponies.builder
 
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Mapping
 import ru.illine.drinking.ponies.model.dto.BestDayDto
 import ru.illine.drinking.ponies.model.dto.StatisticsDto
 import ru.illine.drinking.ponies.model.dto.StatisticsPointDto
 import ru.illine.drinking.ponies.model.dto.response.BestDayInfo
-import ru.illine.drinking.ponies.model.dto.response.InsightInfo
 import ru.illine.drinking.ponies.model.dto.response.StatisticsPoint
 import ru.illine.drinking.ponies.model.dto.response.StatisticsResponse
 
+@Konverter
+interface StatisticsMapper {
+    @Konvert(
+        mappings = [
+            Mapping(
+                target = "insight",
+                expression = "ru.illine.drinking.ponies.model.dto.response.InsightInfo(it.insightText)",
+            ),
+        ]
+    )
+    fun toResponse(dto: StatisticsDto): StatisticsResponse
+
+    fun toPoint(dto: StatisticsPointDto): StatisticsPoint
+
+    fun toBestDay(dto: BestDayDto): BestDayInfo
+}
+
 object StatisticsBuilder {
+    private val mapper: StatisticsMapper = Konverter.get<StatisticsMapper>()
 
-    fun toResponse(dto: StatisticsDto): StatisticsResponse =
-        StatisticsResponse(
-            points = dto.points.map(::toPoint),
-            dailyGoalMl = dto.dailyGoalMl,
-            averageMlPerDay = dto.averageMlPerDay,
-            bestDay = dto.bestDay?.let(::toBestDay),
-            currentStreakDays = dto.currentStreakDays,
-            insight = InsightInfo(text = dto.insightText),
-            firstEntryAt = dto.firstEntryAt,
-        )
-
-    private fun toPoint(point: StatisticsPointDto): StatisticsPoint =
-        StatisticsPoint(label = point.label, valueMl = point.valueMl)
-
-    private fun toBestDay(bestDay: BestDayDto): BestDayInfo =
-        BestDayInfo(date = bestDay.date, valueMl = bestDay.valueMl, weekday = bestDay.weekday)
-
+    fun toResponse(dto: StatisticsDto): StatisticsResponse = mapper.toResponse(dto)
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/builder/TelegramChatBuilder.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/builder/TelegramChatBuilder.kt
@@ -1,25 +1,30 @@
 package ru.illine.drinking.ponies.builder
 
+import io.mcarle.konvert.api.Konverter
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
 import ru.illine.drinking.ponies.model.entity.TelegramChatEntity
 import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 
+@Konverter
+interface TelegramChatMapper {
+    fun toDto(
+        @Konverter.Source chat: TelegramChatEntity,
+        telegramUser: TelegramUserDto,
+    ): TelegramChatDto
+
+    fun toEntity(
+        @Konverter.Source chat: TelegramChatDto,
+        telegramUser: TelegramUserEntity,
+    ): TelegramChatEntity
+}
+
 object TelegramChatBuilder {
+    private val mapper: TelegramChatMapper = Konverter.get<TelegramChatMapper>()
 
     fun toDto(chat: TelegramChatEntity, user: TelegramUserDto): TelegramChatDto =
-        TelegramChatDto(
-            id = chat.id,
-            telegramUser = user,
-            externalChatId = chat.externalChatId,
-            previousNotificationMessageId = chat.previousNotificationMessageId,
-        )
+        mapper.toDto(chat, user)
 
     fun toEntity(chat: TelegramChatDto, user: TelegramUserEntity): TelegramChatEntity =
-        TelegramChatEntity(
-            id = chat.id,
-            externalChatId = chat.externalChatId,
-            previousNotificationMessageId = chat.previousNotificationMessageId,
-            telegramUser = user,
-        )
+        mapper.toEntity(chat, user)
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/builder/TelegramUserBuilder.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/builder/TelegramUserBuilder.kt
@@ -1,26 +1,19 @@
 package ru.illine.drinking.ponies.builder
 
+import io.mcarle.konvert.api.Konverter
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
 import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 
-object TelegramUserBuilder {
-    fun toDto(entity: TelegramUserEntity): TelegramUserDto =
-        TelegramUserDto(
-            id = entity.id,
-            externalUserId = entity.externalUserId,
-            userTimeZone = entity.userTimeZone,
-            isAdmin = entity.isAdmin,
-            created = entity.created,
-            deleted = entity.deleted,
-        )
+@Konverter
+interface TelegramUserMapper {
+    fun toDto(entity: TelegramUserEntity): TelegramUserDto
+    fun toEntity(dto: TelegramUserDto): TelegramUserEntity
+}
 
-    fun toEntity(dto: TelegramUserDto): TelegramUserEntity =
-        TelegramUserEntity(
-            id = dto.id,
-            externalUserId = dto.externalUserId,
-            userTimeZone = dto.userTimeZone,
-            isAdmin = dto.isAdmin,
-            created = dto.created,
-            deleted = dto.deleted,
-        )
+object TelegramUserBuilder {
+    private val mapper: TelegramUserMapper = Konverter.get<TelegramUserMapper>()
+
+    fun toDto(entity: TelegramUserEntity): TelegramUserDto = mapper.toDto(entity)
+
+    fun toEntity(dto: TelegramUserDto): TelegramUserEntity = mapper.toEntity(dto)
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/builder/WaterStatisticBuilder.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/builder/WaterStatisticBuilder.kt
@@ -1,38 +1,44 @@
 package ru.illine.drinking.ponies.builder
 
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Mapping
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.model.dto.response.WaterEntry
 import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 import ru.illine.drinking.ponies.model.entity.WaterStatisticEntity
-import ru.illine.drinking.ponies.util.statistics.toUtcInstant
+
+@Konverter
+interface WaterStatisticMapper {
+    fun toDto(
+        @Konverter.Source entity: WaterStatisticEntity,
+        telegramUser: TelegramUserDto,
+    ): WaterStatisticDto
+
+    fun toEntity(
+        @Konverter.Source dto: WaterStatisticDto,
+        telegramUser: TelegramUserEntity,
+    ): WaterStatisticEntity
+
+    @Konvert(
+        mappings = [
+            Mapping(source = "waterAmountMl", target = "amountMl"),
+            Mapping(target = "eventTime", expression = "it.eventTime.toInstant(java.time.ZoneOffset.UTC)"),
+        ]
+    )
+    fun toWaterEntry(dto: WaterStatisticDto): WaterEntry
+}
 
 object WaterStatisticBuilder {
+    private val mapper: WaterStatisticMapper = Konverter.get<WaterStatisticMapper>()
 
     fun toDto(entity: WaterStatisticEntity, user: TelegramUserDto): WaterStatisticDto =
-        WaterStatisticDto(
-            id = entity.id,
-            telegramUser = user,
-            eventTime = entity.eventTime,
-            eventType = entity.eventType,
-            waterAmountMl = entity.waterAmountMl,
-            source = entity.source
-        )
+        mapper.toDto(entity, user)
 
     fun toEntity(dto: WaterStatisticDto, user: TelegramUserEntity): WaterStatisticEntity =
-        WaterStatisticEntity(
-            id = dto.id,
-            telegramUser = user,
-            eventTime = dto.eventTime,
-            eventType = dto.eventType,
-            waterAmountMl = dto.waterAmountMl,
-            source = dto.source
-        )
+        mapper.toEntity(dto, user)
 
     fun toWaterEntry(dto: WaterStatisticDto): WaterEntry =
-        WaterEntry(
-            eventTime = dto.eventTime.toUtcInstant(),
-            amountMl = dto.waterAmountMl,
-        )
-
+        mapper.toWaterEntry(dto)
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/LogbookConfig.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/LogbookConfig.kt
@@ -11,22 +11,27 @@ import ru.illine.drinking.ponies.config.property.LogbookProperties
 
 @Configuration
 class LogbookConfig {
-
     @Bean
     fun writer(properties: LogbookProperties) = DefaultHttpLogWriter(properties)
 
-    class DefaultHttpLogWriter(properties: LogbookProperties) : HttpLogWriter {
+    class DefaultHttpLogWriter(
+        properties: LogbookProperties,
+    ) : HttpLogWriter {
         private val logger: Logger
 
-        override fun isActive(): Boolean {
-            return logger.isInfoEnabled
-        }
+        override fun isActive(): Boolean = logger.isInfoEnabled
 
-        override fun write(precorrelation: Precorrelation, request: String) {
+        override fun write(
+            precorrelation: Precorrelation,
+            request: String,
+        ) {
             logger.info(request)
         }
 
-        override fun write(correlation: Correlation, response: String) {
+        override fun write(
+            correlation: Correlation,
+            response: String,
+        ) {
             logger.info(response)
         }
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/TelegramBotConfig.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/TelegramBotConfig.kt
@@ -19,17 +19,15 @@ import java.util.concurrent.TimeUnit
 
 @Configuration
 class TelegramBotConfig {
-
     @Bean(destroyMethod = "stop")
     fun telegramBotsApplication(
         abilityBot: BaseAbilityBot,
         telegramBotProperties: TelegramBotProperties,
-    ): TelegramBotsLongPollingApplication {
-        return TelegramBotsLongPollingApplication()
+    ): TelegramBotsLongPollingApplication =
+        TelegramBotsLongPollingApplication()
             .apply {
                 this.registerBot(telegramBotProperties.token, abilityBot)
             }
-    }
 
     @Bean(initMethod = "onRegister")
     fun abilityBot(
@@ -37,42 +35,38 @@ class TelegramBotConfig {
         telegramBotProperties: TelegramBotProperties,
         notificationService: NotificationService,
         replyButtonFactory: ReplyButtonFactory,
-        commandService: CommandService
-    ): BaseAbilityBot {
-        return DrinkingPoniesTelegramBot(
+        commandService: CommandService,
+    ): BaseAbilityBot =
+        DrinkingPoniesTelegramBot(
             telegramClient,
             telegramBotProperties,
             notificationService,
             replyButtonFactory,
-            commandService
+            commandService,
         )
-    }
 
     @Bean
     fun telegramClient(
         telegramBotProperties: TelegramBotProperties,
-        okHttpClient: OkHttpClient
-    ): TelegramClient {
-        return OkHttpTelegramClient(okHttpClient, telegramBotProperties.token)
-    }
+        okHttpClient: OkHttpClient,
+    ): TelegramClient = OkHttpTelegramClient(okHttpClient, telegramBotProperties.token)
 
     @Bean
     fun okHttpClient(
         connectionPool: ConnectionPool,
-        logbook: Logbook
-    ): OkHttpClient {
-        return OkHttpClient.Builder()
+        logbook: Logbook,
+    ): OkHttpClient =
+        OkHttpClient
+            .Builder()
             .addNetworkInterceptor(LogbookInterceptor(logbook))
             .connectionPool(connectionPool)
             .build()
-    }
 
     @Bean
-    fun connectionPool(
-        telegramBotProperties: TelegramBotProperties
-    ) = ConnectionPool(
-        telegramBotProperties.http.maxConnectionTotal,
-        telegramBotProperties.http.connectionTimeToLiveInSec,
-        TimeUnit.SECONDS
-    )
+    fun connectionPool(telegramBotProperties: TelegramBotProperties) =
+        ConnectionPool(
+            telegramBotProperties.http.maxConnectionTotal,
+            telegramBotProperties.http.connectionTimeToLiveInSec,
+            TimeUnit.SECONDS,
+        )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/TimeConfig.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/TimeConfig.kt
@@ -7,11 +7,9 @@ import kotlin.random.Random
 
 @Configuration
 class TimeConfig {
-
     @Bean
     fun clock(): Clock = Clock.systemUTC()
 
     @Bean
     fun random(): Random = Random.Default
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/cache/CacheConfig.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/cache/CacheConfig.kt
@@ -12,9 +12,8 @@ import ru.illine.drinking.ponies.config.property.CacheProperties
 @Configuration
 @EnableCaching
 class CacheConfig(
-    private val cacheProperties: CacheProperties
+    private val cacheProperties: CacheProperties,
 ) {
-
     companion object {
         const val USER_IS_ADMIN = "user-is-admin"
         const val WATER_FIRST_ENTRY = "water-first-entry"
@@ -34,10 +33,11 @@ class CacheConfig(
             val maximumSize = override?.maximumSize ?: cacheProperties.default.maximumSize
             target.registerCustomCache(
                 name,
-                Caffeine.newBuilder()
+                Caffeine
+                    .newBuilder()
                     .expireAfterWrite(ttl)
                     .maximumSize(maximumSize)
-                    .build()
+                    .build(),
             )
         }
         return TransactionAwareCacheManagerProxy(target)

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/property/AppProperties.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/property/AppProperties.kt
@@ -7,7 +7,6 @@ import javax.validation.constraints.NotBlank
 @Validated
 @ConfigurationProperties("app")
 data class AppProperties(
-
     @NotBlank
-    val version: String = "local"
+    val version: String = "local",
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/property/CacheProperties.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/property/CacheProperties.kt
@@ -12,26 +12,22 @@ import javax.validation.constraints.NotNull
 @ConfigurationProperties("cache")
 data class CacheProperties(
     val default: CacheEntry = CacheEntry(),
-    val overrides: Map<String, CacheEntryOverride> = emptyMap()
+    val overrides: Map<String, CacheEntryOverride> = emptyMap(),
 ) {
     data class CacheEntry(
-
         @NotNull
         @DurationMin(seconds = 10)
         var ttl: Duration = Duration.ofMinutes(5),
-
         @Min(1)
         @Max(1000)
-        val maximumSize: Long = 100
+        val maximumSize: Long = 100,
     )
 
     data class CacheEntryOverride(
-
         @DurationMin(seconds = 10)
         val ttl: Duration? = null,
-
         @Min(1)
         @Max(1000)
-        val maximumSize: Long? = null
+        val maximumSize: Long? = null,
     )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/property/CorsProperties.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/property/CorsProperties.kt
@@ -7,5 +7,5 @@ import org.springframework.validation.annotation.Validated
 @Validated
 @ConfigurationProperties("spring.cors")
 data class CorsProperties(
-    @NotEmpty val allowedOrigins: List<String>
+    @NotEmpty val allowedOrigins: List<String>,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/property/LogbookProperties.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/property/LogbookProperties.kt
@@ -7,6 +7,5 @@ import javax.validation.constraints.NotEmpty
 @Validated
 @ConfigurationProperties("logbook.logger")
 data class LogbookProperties(
-
-    @NotEmpty val name: String
+    @NotEmpty val name: String,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/property/TelegramBotProperties.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/property/TelegramBotProperties.kt
@@ -11,43 +11,32 @@ import javax.validation.constraints.NotNull
 @Validated
 @ConfigurationProperties("telegram-bot")
 data class TelegramBotProperties(
-
     @NotEmpty
     val token: String,
-
     @NotEmpty
     val username: String,
-
     @NotEmpty
     val miniAppUrl: String,
-
     @NonNull
     val autoUpdateTelegramConfig: Boolean,
-
     @Min(10)
     val authDateExpirationSeconds: Long = 600,
-
     @NotNull
     var http: Http,
-
     @NotNull
-    val notification: Notification = Notification()
-
+    val notification: Notification = Notification(),
 ) {
     data class Http(
-
         @Min(30)
         @Max(120)
         val connectionTimeToLiveInSec: Long,
-
         @Min(10)
         @Max(200)
-        val maxConnectionTotal: Int
+        val maxConnectionTotal: Int,
     )
 
     data class Notification(
-
         @Min(1)
-        val retryIntervalMinutes: Long = 1L
+        val retryIntervalMinutes: Long = 1L,
     )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/DefaultExceptionHandler.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/DefaultExceptionHandler.kt
@@ -17,7 +17,6 @@ import ru.illine.drinking.ponies.model.dto.response.ErrorResponse
 
 @RestControllerAdvice
 class DefaultExceptionHandler {
-
     private val logger = LoggerFactory.getLogger("EXCEPTION-HANDLER")
 
     @ExceptionHandler(value = [MissingServletRequestParameterException::class])
@@ -30,20 +29,23 @@ class DefaultExceptionHandler {
             .body(response)
     }
 
-    @ExceptionHandler(value = [
-        MethodArgumentNotValidException::class,
-        IllegalArgumentException::class,
-        HttpMessageNotReadableException::class,
-        MethodArgumentTypeMismatchException::class,
-        ConstraintViolationException::class
-    ])
+    @ExceptionHandler(
+        value = [
+            MethodArgumentNotValidException::class,
+            IllegalArgumentException::class,
+            HttpMessageNotReadableException::class,
+            MethodArgumentTypeMismatchException::class,
+            ConstraintViolationException::class,
+        ],
+    )
     fun handleValidationException(e: Exception): ResponseEntity<ErrorResponse> {
         if (e is MethodArgumentNotValidException) {
-            val errorMessages = e.bindingResult.fieldErrors.joinToString(", ") {
-                "${it.field}: ${it.defaultMessage}"
-            }
+            val errorMessages =
+                e.bindingResult.fieldErrors.joinToString(", ") {
+                    "${it.field}: ${it.defaultMessage}"
+                }
             logger.warn("Validation failed: $errorMessages", e)
-        } else  {
+        } else {
             logger.warn("Illegal argument", e)
         }
         val response = ErrorResponse("validation failed")

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/OpenApiConfig.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/OpenApiConfig.kt
@@ -11,19 +11,17 @@ import ru.illine.drinking.ponies.config.property.AppProperties
 
 @Configuration
 class OpenApiConfig(
-    private val appProperties: AppProperties
+    private val appProperties: AppProperties,
 ) {
-
     @Bean
-    fun openAPI(): OpenAPI {
-        return OpenAPI()
+    fun openAPI(): OpenAPI =
+        OpenAPI()
             .info(
                 Info()
                     .title("Drinking Ponies API")
                     .description("REST API for Drinking Ponies MiniApp")
-                    .version(appProperties.version)
-            )
-            .addSecurityItem(SecurityRequirement().addList("telegram-auth"))
+                    .version(appProperties.version),
+            ).addSecurityItem(SecurityRequirement().addList("telegram-auth"))
             .components(
                 Components()
                     .addSecuritySchemes(
@@ -31,8 +29,7 @@ class OpenApiConfig(
                         SecurityScheme()
                             .type(SecurityScheme.Type.APIKEY)
                             .`in`(SecurityScheme.In.HEADER)
-                            .name("X-Authorization-Telegram-Data")
-                    )
+                            .name("X-Authorization-Telegram-Data"),
+                    ),
             )
-    }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/WebConfig.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/WebConfig.kt
@@ -21,13 +21,12 @@ class WebConfig(
 
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(telegramAuthInterceptor)
-            .addPathPatterns(
-                "/settings",
-                "/settings/**",
-                "/notifications/**",
-                "/users/**",
-                "/systems/**",
-                "/statistics/**"
+            .addPathPatterns("/**")
+            .excludePathPatterns(
+                "/docs/**",
+                "/swagger-ui/**",
+                "/v3/api-docs/**",
+                "/actuator/**"
             )
 
         registry.addInterceptor(adminAuthInterceptor)

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/WebConfig.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/WebConfig.kt
@@ -18,36 +18,39 @@ class WebConfig(
     private val telegramAuthInterceptor: TelegramAuthInterceptor,
     private val adminAuthInterceptor: AdminAuthInterceptor,
 ) : WebMvcConfigurer {
-
     override fun addInterceptors(registry: InterceptorRegistry) {
-        registry.addInterceptor(telegramAuthInterceptor)
+        registry
+            .addInterceptor(telegramAuthInterceptor)
             .addPathPatterns("/**")
             .excludePathPatterns(
                 "/docs/**",
                 "/swagger-ui/**",
                 "/v3/api-docs/**",
-                "/actuator/**"
+                "/actuator/**",
             )
 
-        registry.addInterceptor(adminAuthInterceptor)
+        registry
+            .addInterceptor(adminAuthInterceptor)
             .addPathPatterns("/**")
     }
 
     @Bean
     fun corsFilter(): CorsFilter {
-        val config = CorsConfiguration().apply {
-            allowedOrigins = corsProperties.allowedOrigins
-            allowedMethods = listOf(
-                HttpMethod.GET.name(),
-                HttpMethod.OPTIONS.name(),
-                HttpMethod.POST.name(),
-                HttpMethod.PUT.name(),
-                HttpMethod.PATCH.name(),
-                HttpMethod.DELETE.name()
-            )
-            allowedHeaders = listOf("*")
-            allowCredentials = true
-        }
+        val config =
+            CorsConfiguration().apply {
+                allowedOrigins = corsProperties.allowedOrigins
+                allowedMethods =
+                    listOf(
+                        HttpMethod.GET.name(),
+                        HttpMethod.OPTIONS.name(),
+                        HttpMethod.POST.name(),
+                        HttpMethod.PUT.name(),
+                        HttpMethod.PATCH.name(),
+                        HttpMethod.DELETE.name(),
+                    )
+                allowedHeaders = listOf("*")
+                allowCredentials = true
+            }
         val source = UrlBasedCorsConfigurationSource()
         source.registerCorsConfiguration("/**", config)
         return CorsFilter(source)

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptor.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptor.kt
@@ -27,7 +27,7 @@ class AdminAuthInterceptor : HandlerInterceptor {
             return true
         }
 
-        logger.warn("Forbidden admin access for telegramId [{}]", telegramUser.telegramId)
+        logger.warn("Forbidden admin access for externalUserId [{}]", telegramUser.externalUserId)
         response.status = HttpServletResponse.SC_FORBIDDEN
         response.setHeader(AuthErrorType.HEADER_NAME, AuthErrorType.FORBIDDEN_ADMIN.value)
         return false

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptor.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptor.kt
@@ -13,14 +13,18 @@ import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
 
 @Component
 class AdminAuthInterceptor : HandlerInterceptor {
-
     private val logger = LoggerFactory.getLogger("INTERCEPTOR")
 
-    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+    ): Boolean {
         if (handler !is HandlerMethod) return true
         handler.getMethodAnnotation(AdminOnly::class.java) ?: return true
 
-        val telegramUser = request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) 
+        val telegramUser =
+            request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)
                 as? TelegramUserDto ?: error("@AdminOnly used on endpoint without TelegramAuthInterceptor")
 
         if (telegramUser.isAdmin) {

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptor.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptor.kt
@@ -17,13 +17,15 @@ class TelegramAuthInterceptor(
     private val telegramValidatorService: TelegramValidatorService,
     private val telegramUserAccessService: TelegramUserAccessService,
 ) : HandlerInterceptor {
-
     private val logger = LoggerFactory.getLogger("INTERCEPTOR")
 
     private val defaultHeaderName = "X-Authorization-Telegram-Data"
 
-
-    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+    ): Boolean {
         if (request.method == HttpMethod.OPTIONS.name()) {
             return true
         }
@@ -35,17 +37,18 @@ class TelegramAuthInterceptor(
             return false
         }
 
-        val validSignature = try {
-            telegramValidatorService.verifySignature(initData)
-        } catch (e: InvalidAuthSignatureException) {
-            logger.warn("Invalid signature: ${e.message}")
-            rejectResponse(response, HttpServletResponse.SC_UNAUTHORIZED, AuthErrorType.INVALID_AUTH_SIGNATURE)
-            return false
-        } catch (e: Exception) {
-            logger.error("Unexpected error", e)
-            rejectResponse(response, HttpServletResponse.SC_UNAUTHORIZED)
-            return false
-        }
+        val validSignature =
+            try {
+                telegramValidatorService.verifySignature(initData)
+            } catch (e: InvalidAuthSignatureException) {
+                logger.warn("Invalid signature: ${e.message}")
+                rejectResponse(response, HttpServletResponse.SC_UNAUTHORIZED, AuthErrorType.INVALID_AUTH_SIGNATURE)
+                return false
+            } catch (e: Exception) {
+                logger.error("Unexpected error", e)
+                rejectResponse(response, HttpServletResponse.SC_UNAUTHORIZED)
+                return false
+            }
 
         if (validSignature) {
             val telegramUser = telegramValidatorService.map(initData)
@@ -60,7 +63,9 @@ class TelegramAuthInterceptor(
     }
 
     private fun rejectResponse(
-        response: HttpServletResponse, status: Int, errorCode: AuthErrorType = AuthErrorType.UNKNOWN
+        response: HttpServletResponse,
+        status: Int,
+        errorCode: AuthErrorType = AuthErrorType.UNKNOWN,
     ) {
         response.status = status
         response.setHeader(AuthErrorType.HEADER_NAME, errorCode.value)

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptor.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptor.kt
@@ -49,7 +49,7 @@ class TelegramAuthInterceptor(
 
         if (validSignature) {
             val telegramUser = telegramValidatorService.map(initData)
-            val isAdmin = telegramUserAccessService.findIsAdminByExternalUserId(telegramUser.telegramId)
+            val isAdmin = telegramUserAccessService.findIsAdminByExternalUserId(telegramUser.externalUserId)
             val enriched = telegramUser.copy(isAdmin = isAdmin)
             request.setAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE, enriched)
             return true

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/security/AuthErrorType.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/security/AuthErrorType.kt
@@ -1,10 +1,13 @@
 package ru.illine.drinking.ponies.config.web.security
 
-enum class AuthErrorType(val value: String) {
+enum class AuthErrorType(
+    val value: String,
+) {
     UNKNOWN("unknown"),
     INVALID_AUTH_SIGNATURE("invalid_auth_signature"),
     SESSION_EXPIRED("session_expired"),
-    FORBIDDEN_ADMIN("forbidden_admin");
+    FORBIDDEN_ADMIN("forbidden_admin"),
+    ;
 
     companion object {
         const val HEADER_NAME = "X-Auth-Error-Code"

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/NotificationController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/NotificationController.kt
@@ -28,7 +28,7 @@ class NotificationController(
         @Parameter(hidden = true)
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
     ): NotificationNextResponse {
-        val nextAt = notificationSettingsService.getNextNotificationAt(telegramUser.telegramId)
+        val nextAt = notificationSettingsService.getNextNotificationAt(telegramUser.externalUserId)
         return NotificationNextResponse(nextNotificationAt = nextAt)
     }
 
@@ -37,7 +37,7 @@ class NotificationController(
     fun getPauseState(
         @Parameter(hidden = true)
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
-    ): PauseStateResponse = notificationSettingsService.getPauseState(telegramUser.telegramId)
+    ): PauseStateResponse = notificationSettingsService.getPauseState(telegramUser.externalUserId)
 
     @PutMapping("/pause")
     @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -49,9 +49,9 @@ class NotificationController(
         @RequestParam(name = "minutes", required = true) @Min(0) @Max(300) minutes: Long
     ) {
         if (minutes == 0L) {
-            notificationSettingsService.cancelPause(telegramUser.telegramId)
+            notificationSettingsService.cancelPause(telegramUser.externalUserId)
         } else {
-            notificationSettingsService.pauseNotifications(telegramUser.telegramId, minutes)
+            notificationSettingsService.pauseNotifications(telegramUser.externalUserId, minutes)
         }
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/NotificationController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/NotificationController.kt
@@ -7,7 +7,13 @@ import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestAttribute
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
 import ru.illine.drinking.ponies.model.dto.TelegramUserDto
 import ru.illine.drinking.ponies.model.dto.response.NotificationNextResponse
 import ru.illine.drinking.ponies.model.dto.response.PauseStateResponse
@@ -19,9 +25,8 @@ import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
 @Tag(name = "Notifications", description = "Notification timing")
 @Validated
 class NotificationController(
-    private val notificationSettingsService: NotificationSettingsService
+    private val notificationSettingsService: NotificationSettingsService,
 ) {
-
     @GetMapping("/next")
     @Operation(summary = "Get next notification time")
     fun getNextNotification(
@@ -46,7 +51,9 @@ class NotificationController(
         @Parameter(hidden = true)
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
         @Parameter(description = "Pause duration in minutes (0 = cancel pause, max 300 = 5 hours)", example = "60")
-        @RequestParam(name = "minutes", required = true) @Min(0) @Max(300) minutes: Long
+        @RequestParam(name = "minutes", required = true)
+        @Min(0)
+        @Max(300) minutes: Long,
     ) {
         if (minutes == 0L) {
             notificationSettingsService.cancelPause(telegramUser.externalUserId)

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/SettingController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/SettingController.kt
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
-import ru.illine.drinking.ponies.builder.SettingResponseBuilder
+import ru.illine.drinking.ponies.mapper.SettingResponseMapper
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.dto.TelegramUserDto
 import ru.illine.drinking.ponies.model.dto.response.SettingResponse
@@ -29,7 +29,7 @@ class SettingController(
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
     ): SettingResponse {
         val settings = notificationSettingsService.getAllSettings(telegramUser.externalUserId)
-        return SettingResponseBuilder.toResponse(settings)
+        return SettingResponseMapper.toResponse(settings)
     }
 
     @PutMapping("/quiet-mode")

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/SettingController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/SettingController.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
+import ru.illine.drinking.ponies.builder.SettingResponseBuilder
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.dto.TelegramUserDto
 import ru.illine.drinking.ponies.model.dto.response.SettingResponse
@@ -28,16 +29,7 @@ class SettingController(
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
     ): SettingResponse {
         val settings = notificationSettingsService.getAllSettings(telegramUser.externalUserId)
-        return SettingResponse(
-            interval = settings.interval,
-            intervalDisplayName = settings.intervalDisplayName,
-            intervalMinutes = settings.intervalMinutes,
-            quietModeStart = settings.quietModeStart,
-            quietModeEnd = settings.quietModeEnd,
-            timezone = settings.timezone,
-            dailyGoalMl = settings.dailyGoalMl,
-            notificationActive = settings.notificationActive,
-        )
+        return SettingResponseBuilder.toResponse(settings)
     }
 
     @PutMapping("/quiet-mode")

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/SettingController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/SettingController.kt
@@ -27,7 +27,7 @@ class SettingController(
         @Parameter(hidden = true)
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
     ): SettingResponse {
-        val settings = notificationSettingsService.getAllSettings(telegramUser.telegramId)
+        val settings = notificationSettingsService.getAllSettings(telegramUser.externalUserId)
         return SettingResponse(
             interval = settings.interval,
             intervalDisplayName = settings.intervalDisplayName,
@@ -51,7 +51,7 @@ class SettingController(
         @Parameter(description = "End time in HH:mm format", example = "08:00", schema = Schema(type = "string", pattern = "HH:mm"))
         @RequestParam(name = "end", required = true) @DateTimeFormat(pattern = "HH:mm") end: LocalTime
     ) {
-        notificationSettingsService.changeQuietMode(telegramUser.telegramId, start, end)
+        notificationSettingsService.changeQuietMode(telegramUser.externalUserId, start, end)
     }
 
     @PutMapping("/timezone")
@@ -63,7 +63,7 @@ class SettingController(
         @Parameter(description = "IANA timezone identifier", example = "Europe/Moscow")
         @RequestParam(name = "timezone", required = true) timezone: String
     ) {
-        notificationSettingsService.changeTimezone(telegramUser.telegramId, timezone)
+        notificationSettingsService.changeTimezone(telegramUser.externalUserId, timezone)
     }
 
     @PutMapping("/interval")
@@ -75,7 +75,7 @@ class SettingController(
         @Parameter(description = "Notification interval enum value", example = "HOUR")
         @RequestParam(name = "interval", required = true) interval: IntervalNotificationType
     ) {
-        notificationSettingsService.changeInterval(telegramUser.telegramId, interval)
+        notificationSettingsService.changeInterval(telegramUser.externalUserId, interval)
     }
 
     @PutMapping("/notification-status")
@@ -87,7 +87,7 @@ class SettingController(
         @Parameter(description = "Enable or disable notifications", example = "true")
         @RequestParam(name = "active", required = true) active: Boolean
     ) {
-        notificationSettingsService.changeNotificationStatus(telegramUser.telegramId, active)
+        notificationSettingsService.changeNotificationStatus(telegramUser.externalUserId, active)
     }
 
     @PutMapping("/goal")
@@ -102,6 +102,6 @@ class SettingController(
         )
         @RequestParam(name = "goalMl", required = true) goalMl: Int
     ) {
-        notificationSettingsService.changeDailyGoal(telegramUser.telegramId, goalMl)
+        notificationSettingsService.changeDailyGoal(telegramUser.externalUserId, goalMl)
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/SettingController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/SettingController.kt
@@ -6,7 +6,13 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestAttribute
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
 import ru.illine.drinking.ponies.mapper.SettingResponseMapper
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.dto.TelegramUserDto
@@ -19,9 +25,8 @@ import java.time.LocalTime
 @RequestMapping("/settings")
 @Tag(name = "Settings", description = "Notification settings management")
 class SettingController(
-    private val notificationSettingsService: NotificationSettingsService
+    private val notificationSettingsService: NotificationSettingsService,
 ) {
-
     @GetMapping
     @Operation(summary = "Get all notification settings")
     fun getSettings(
@@ -38,10 +43,20 @@ class SettingController(
     fun changeQuietMode(
         @Parameter(hidden = true)
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
-        @Parameter(description = "Start time in HH:mm format", example = "23:00", schema = Schema(type = "string", pattern = "HH:mm"))
-        @RequestParam(name = "start", required = true) @DateTimeFormat(pattern = "HH:mm") start: LocalTime,
-        @Parameter(description = "End time in HH:mm format", example = "08:00", schema = Schema(type = "string", pattern = "HH:mm"))
-        @RequestParam(name = "end", required = true) @DateTimeFormat(pattern = "HH:mm") end: LocalTime
+        @Parameter(
+            description = "Start time in HH:mm format",
+            example = "23:00",
+            schema = Schema(type = "string", pattern = "HH:mm"),
+        )
+        @RequestParam(name = "start", required = true)
+        @DateTimeFormat(pattern = "HH:mm") start: LocalTime,
+        @Parameter(
+            description = "End time in HH:mm format",
+            example = "08:00",
+            schema = Schema(type = "string", pattern = "HH:mm"),
+        )
+        @RequestParam(name = "end", required = true)
+        @DateTimeFormat(pattern = "HH:mm") end: LocalTime,
     ) {
         notificationSettingsService.changeQuietMode(telegramUser.externalUserId, start, end)
     }
@@ -53,7 +68,7 @@ class SettingController(
         @Parameter(hidden = true)
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
         @Parameter(description = "IANA timezone identifier", example = "Europe/Moscow")
-        @RequestParam(name = "timezone", required = true) timezone: String
+        @RequestParam(name = "timezone", required = true) timezone: String,
     ) {
         notificationSettingsService.changeTimezone(telegramUser.externalUserId, timezone)
     }
@@ -65,7 +80,7 @@ class SettingController(
         @Parameter(hidden = true)
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
         @Parameter(description = "Notification interval enum value", example = "HOUR")
-        @RequestParam(name = "interval", required = true) interval: IntervalNotificationType
+        @RequestParam(name = "interval", required = true) interval: IntervalNotificationType,
     ) {
         notificationSettingsService.changeInterval(telegramUser.externalUserId, interval)
     }
@@ -77,7 +92,7 @@ class SettingController(
         @Parameter(hidden = true)
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
         @Parameter(description = "Enable or disable notifications", example = "true")
-        @RequestParam(name = "active", required = true) active: Boolean
+        @RequestParam(name = "active", required = true) active: Boolean,
     ) {
         notificationSettingsService.changeNotificationStatus(telegramUser.externalUserId, active)
     }
@@ -92,7 +107,7 @@ class SettingController(
             description = "Daily goal in milliliters. Allowed values: 2000, 2250, 2500, 2750, 3000",
             example = "2000",
         )
-        @RequestParam(name = "goalMl", required = true) goalMl: Int
+        @RequestParam(name = "goalMl", required = true) goalMl: Int,
     ) {
         notificationSettingsService.changeDailyGoal(telegramUser.externalUserId, goalMl)
     }

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/StatisticsController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/StatisticsController.kt
@@ -8,7 +8,14 @@ import jakarta.validation.Valid
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestAttribute
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
 import ru.illine.drinking.ponies.mapper.StatisticsMapper
 import ru.illine.drinking.ponies.mapper.WaterStatisticMapper
 import ru.illine.drinking.ponies.model.dto.TelegramUserDto
@@ -28,7 +35,6 @@ class StatisticsController(
     private val statisticsService: StatisticsService,
     private val waterStatisticService: WaterStatisticService,
 ) {
-
     @GetMapping("/today")
     @Operation(summary = "Get today's water intake events")
     fun getToday(
@@ -49,15 +55,17 @@ class StatisticsController(
         @Parameter(
             description = "Range start (inclusive) in yyyy-MM-dd format",
             example = "2026-05-01",
-            schema = Schema(type = "string", format = "date")
+            schema = Schema(type = "string", format = "date"),
         )
-        @RequestParam(name = "from", required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
+        @RequestParam(name = "from", required = true)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
         @Parameter(
             description = "Range end (inclusive) in yyyy-MM-dd format",
             example = "2026-05-20",
-            schema = Schema(type = "string", format = "date")
+            schema = Schema(type = "string", format = "date"),
         )
-        @RequestParam(name = "to", required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
+        @RequestParam(name = "to", required = true)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
     ): StatisticsResponse =
         StatisticsMapper.toResponse(statisticsService.getStatistics(telegramUser.externalUserId, from, to))
 
@@ -75,5 +83,4 @@ class StatisticsController(
             amountMl = request.amountMl,
         )
     }
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/StatisticsController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/StatisticsController.kt
@@ -9,8 +9,8 @@ import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
-import ru.illine.drinking.ponies.builder.StatisticsBuilder
-import ru.illine.drinking.ponies.builder.WaterStatisticBuilder
+import ru.illine.drinking.ponies.mapper.StatisticsMapper
+import ru.illine.drinking.ponies.mapper.WaterStatisticMapper
 import ru.illine.drinking.ponies.model.dto.TelegramUserDto
 import ru.illine.drinking.ponies.model.dto.request.WaterEntryRequest
 import ru.illine.drinking.ponies.model.dto.response.StatisticsResponse
@@ -37,7 +37,7 @@ class StatisticsController(
     ): StatisticsTodayResponse {
         val entries = statisticsService.getToday(telegramUser.externalUserId)
         return StatisticsTodayResponse(
-            entries = entries.map(WaterStatisticBuilder::toWaterEntry),
+            entries = entries.map(WaterStatisticMapper::toWaterEntry),
         )
     }
 
@@ -59,7 +59,7 @@ class StatisticsController(
         )
         @RequestParam(name = "to", required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
     ): StatisticsResponse =
-        StatisticsBuilder.toResponse(statisticsService.getStatistics(telegramUser.externalUserId, from, to))
+        StatisticsMapper.toResponse(statisticsService.getStatistics(telegramUser.externalUserId, from, to))
 
     @PostMapping("/water")
     @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/StatisticsController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/StatisticsController.kt
@@ -35,7 +35,7 @@ class StatisticsController(
         @Parameter(hidden = true)
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
     ): StatisticsTodayResponse {
-        val entries = statisticsService.getToday(telegramUser.telegramId)
+        val entries = statisticsService.getToday(telegramUser.externalUserId)
         return StatisticsTodayResponse(
             entries = entries.map(WaterStatisticBuilder::toWaterEntry),
         )
@@ -59,7 +59,7 @@ class StatisticsController(
         )
         @RequestParam(name = "to", required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
     ): StatisticsResponse =
-        StatisticsBuilder.toResponse(statisticsService.getStatistics(telegramUser.telegramId, from, to))
+        StatisticsBuilder.toResponse(statisticsService.getStatistics(telegramUser.externalUserId, from, to))
 
     @PostMapping("/water")
     @ResponseStatus(HttpStatus.CREATED)
@@ -70,7 +70,7 @@ class StatisticsController(
         @Valid @RequestBody request: WaterEntryRequest,
     ) {
         waterStatisticService.manualRecordEvent(
-            externalUserId = telegramUser.telegramId,
+            externalUserId = telegramUser.externalUserId,
             consumedAt = request.consumedAt,
             amountMl = request.amountMl,
         )

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/SystemController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/SystemController.kt
@@ -14,7 +14,6 @@ import ru.illine.drinking.ponies.model.dto.response.VersionResponse
 class SystemController(
     private val appProperties: AppProperties,
 ) {
-
     @GetMapping("/version")
     @Operation(summary = "Get backend version")
     fun getVersion(): VersionResponse = VersionResponse(version = appProperties.version)

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/UserController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/UserController.kt
@@ -15,14 +15,14 @@ import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
 @RequestMapping("/users")
 @Tag(name = "User", description = "Current user identity and profile")
 class UserController {
-
     @GetMapping("/me")
     @Operation(summary = "Get current user identity")
     fun getMe(
         @Parameter(hidden = true)
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
-    ): MeResponse = MeResponse(
-        externalUserId = telegramUser.externalUserId,
-        isAdmin = telegramUser.isAdmin,
-    )
+    ): MeResponse =
+        MeResponse(
+            externalUserId = telegramUser.externalUserId,
+            isAdmin = telegramUser.isAdmin,
+        )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/UserController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/UserController.kt
@@ -22,7 +22,7 @@ class UserController {
         @Parameter(hidden = true)
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
     ): MeResponse = MeResponse(
-        telegramUserId = telegramUser.telegramId,
+        externalUserId = telegramUser.externalUserId,
         isAdmin = telegramUser.isAdmin,
     )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessService.kt
@@ -11,9 +11,9 @@ interface NotificationAccessService {
 
     fun findAllNotificationSettings(): Set<NotificationSettingDto>
 
-    fun findNotificationSettingByTelegramUserId(telegramUserId: Long): NotificationSettingDto
+    fun findNotificationSettingByExternalUserId(externalUserId: Long): NotificationSettingDto
 
-    fun existsByTelegramUserId(telegramUserId: Long): Boolean
+    fun existsByExternalUserId(externalUserId: Long): Boolean
 
     fun save(
         user: TelegramUserDto,
@@ -22,27 +22,27 @@ interface NotificationAccessService {
     ): TelegramUserDto
 
     fun updateNotificationSettings(
-        telegramUserId: Long, notificationInterval: IntervalNotificationType
+        externalUserId: Long, notificationInterval: IntervalNotificationType
     ): NotificationSettingDto
 
-    fun updateTimeOfLastNotification(telegramUserId: Long, time: LocalDateTime): NotificationSettingDto
+    fun updateTimeOfLastNotification(externalUserId: Long, time: LocalDateTime): NotificationSettingDto
 
     fun updateNotificationSettings(settings: Collection<NotificationSettingDto>): Set<NotificationSettingDto>
 
-    fun isEnabledNotifications(telegramUserId: Long): Boolean
+    fun isEnabledNotifications(externalUserId: Long): Boolean
 
-    fun enableNotifications(telegramUserId: Long)
+    fun enableNotifications(externalUserId: Long)
 
-    fun disableNotifications(telegramUserId: Long)
+    fun disableNotifications(externalUserId: Long)
 
-    fun changeQuietMode(userId: Long, start: LocalTime, end: LocalTime)
+    fun changeQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime)
 
-    fun disableQuietMode(userId: Long)
+    fun disableQuietMode(externalUserId: Long)
 
-    fun changeTimezone(telegramUserId: Long, timezone: String)
+    fun changeTimezone(externalUserId: Long, timezone: String)
 
-    fun setPause(telegramUserId: Long, pauseUntil: LocalDateTime?): NotificationSettingDto
+    fun setPause(externalUserId: Long, pauseUntil: LocalDateTime?): NotificationSettingDto
 
-    fun updateDailyGoal(telegramUserId: Long, goalMl: Int)
+    fun updateDailyGoal(externalUserId: Long, goalMl: Int)
 
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessService.kt
@@ -29,19 +29,19 @@ interface NotificationAccessService {
 
     fun updateNotificationSettings(settings: Collection<NotificationSettingDto>): Set<NotificationSettingDto>
 
-    fun isEnabledNotifications(externalUserId: Long): Boolean
+    fun findIsEnabledNotificationsByExternalUserId(externalUserId: Long): Boolean
 
-    fun enableNotifications(externalUserId: Long)
+    fun updateNotificationsEnabled(externalUserId: Long)
 
-    fun disableNotifications(externalUserId: Long)
+    fun updateNotificationsDisabled(externalUserId: Long)
 
-    fun changeQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime)
+    fun updateQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime)
 
-    fun disableQuietMode(externalUserId: Long)
+    fun updateQuietModeDisabled(externalUserId: Long)
 
-    fun changeTimezone(externalUserId: Long, timezone: String)
+    fun updateTimezone(externalUserId: Long, timezone: String)
 
-    fun setPause(externalUserId: Long, pauseUntil: LocalDateTime?): NotificationSettingDto
+    fun updatePause(externalUserId: Long, pauseUntil: LocalDateTime?): NotificationSettingDto
 
     fun updateDailyGoal(externalUserId: Long, goalMl: Int)
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessService.kt
@@ -8,7 +8,6 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 
 interface NotificationAccessService {
-
     fun findAllNotificationSettings(): Set<NotificationSettingDto>
 
     fun findNotificationSettingByExternalUserId(externalUserId: Long): NotificationSettingDto
@@ -18,14 +17,18 @@ interface NotificationAccessService {
     fun save(
         user: TelegramUserDto,
         chat: TelegramChatDto,
-        setting: NotificationSettingDto
+        setting: NotificationSettingDto,
     ): TelegramUserDto
 
     fun updateNotificationSettings(
-        externalUserId: Long, notificationInterval: IntervalNotificationType
+        externalUserId: Long,
+        notificationInterval: IntervalNotificationType,
     ): NotificationSettingDto
 
-    fun updateTimeOfLastNotification(externalUserId: Long, time: LocalDateTime): NotificationSettingDto
+    fun updateTimeOfLastNotification(
+        externalUserId: Long,
+        time: LocalDateTime,
+    ): NotificationSettingDto
 
     fun updateNotificationSettings(settings: Collection<NotificationSettingDto>): Set<NotificationSettingDto>
 
@@ -35,14 +38,26 @@ interface NotificationAccessService {
 
     fun updateNotificationsDisabled(externalUserId: Long)
 
-    fun updateQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime)
+    fun updateQuietMode(
+        externalUserId: Long,
+        start: LocalTime,
+        end: LocalTime,
+    )
 
     fun updateQuietModeDisabled(externalUserId: Long)
 
-    fun updateTimezone(externalUserId: Long, timezone: String)
+    fun updateTimezone(
+        externalUserId: Long,
+        timezone: String,
+    )
 
-    fun updatePause(externalUserId: Long, pauseUntil: LocalDateTime?): NotificationSettingDto
+    fun updatePause(
+        externalUserId: Long,
+        pauseUntil: LocalDateTime?,
+    ): NotificationSettingDto
 
-    fun updateDailyGoal(externalUserId: Long, goalMl: Int)
-
+    fun updateDailyGoal(
+        externalUserId: Long,
+        goalMl: Int,
+    )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessService.kt
@@ -1,6 +1,5 @@
 package ru.illine.drinking.ponies.dao.access
 
 interface TelegramUserAccessService {
-
     fun findIsAdminByExternalUserId(externalUserId: Long): Boolean
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/WaterStatisticAccessService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/WaterStatisticAccessService.kt
@@ -4,11 +4,10 @@ import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import java.time.LocalDateTime
 
 interface WaterStatisticAccessService {
-    
     fun findByUserAndEventTimeBetween(
         externalUserId: Long,
         startInclusive: LocalDateTime,
-        endExclusive: LocalDateTime
+        endExclusive: LocalDateTime,
     ): List<WaterStatisticDto>
 
     fun findEarliestEventTimeByUser(externalUserId: Long): LocalDateTime?
@@ -16,5 +15,4 @@ interface WaterStatisticAccessService {
     fun save(dto: WaterStatisticDto): WaterStatisticDto
 
     fun saveAll(statistics: Collection<WaterStatisticDto>): List<WaterStatisticDto>
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
@@ -27,20 +27,19 @@ class NotificationAccessServiceImpl(
     private val chatRepository: TelegramChatRepository,
     private val clock: Clock,
 ) : NotificationAccessService {
-
     private val logger = LoggerFactory.getLogger("ACCESS-SERVICE")
 
     @Transactional(readOnly = true)
     override fun findAllNotificationSettings(): Set<NotificationSettingDto> {
         logger.debug("Finding all notification setting records")
 
-        return settingRepository.findAll()
+        return settingRepository
+            .findAll()
             .map {
                 val user = TelegramUserMapper.toDto(it.telegramUser)
                 val chat = TelegramChatMapper.toDto(it.telegramChat, user)
                 NotificationSettingMapper.toDto(it, user, chat)
-            }
-            .toSet()
+            }.toSet()
     }
 
     @Transactional(readOnly = true)
@@ -64,7 +63,7 @@ class NotificationAccessServiceImpl(
     override fun save(
         user: TelegramUserDto,
         chat: TelegramChatDto,
-        setting: NotificationSettingDto
+        setting: NotificationSettingDto,
     ): TelegramUserDto {
         logger.debug("Saving a new user, chat and setting for a telegram user: [${user.externalUserId}]")
 
@@ -73,7 +72,7 @@ class NotificationAccessServiceImpl(
 
         val userEntity =
             userRepository.findByExternalUserId(
-                externalUserId
+                externalUserId,
             ) ?: TelegramUserMapper.toEntity(user)
 
         val chatEntity =
@@ -81,7 +80,7 @@ class NotificationAccessServiceImpl(
 
         val settingEntity =
             settingRepository.findByTelegramUser_ExternalUserId(
-                externalUserId
+                externalUserId,
             ) ?: NotificationSettingMapper.toEntity(setting, userEntity, chatEntity)
 
         userEntity.addTelegramChat(chatEntity)
@@ -92,21 +91,23 @@ class NotificationAccessServiceImpl(
 
     @Transactional
     override fun updateNotificationSettings(
-        externalUserId: Long, notificationInterval: IntervalNotificationType
+        externalUserId: Long,
+        notificationInterval: IntervalNotificationType,
     ): NotificationSettingDto {
-        logger.debug("The Notification Settings will be updated for an existed entity by id: [${externalUserId}]")
+        logger.debug("The Notification Settings will be updated for an existed entity by id: [$externalUserId]")
 
         val settings = requireSettings(externalUserId)
 
         if (settings.notificationInterval != notificationInterval) {
             // Reset timer so the new interval counts from now, not from the last notification time.
             // Also clear active pause - changing interval implicitly cancels the pause.
-            settings.apply {
-                this.notificationInterval = notificationInterval
-                this.timeOfLastNotification = LocalDateTime.now(clock)
-                this.notificationAttempts = 0
-                this.pauseUntil = null
-            }.let { settingRepository.save(it) }
+            settings
+                .apply {
+                    this.notificationInterval = notificationInterval
+                    this.timeOfLastNotification = LocalDateTime.now(clock)
+                    this.notificationAttempts = 0
+                    this.pauseUntil = null
+                }.let { settingRepository.save(it) }
         }
 
         return settings.let {
@@ -141,18 +142,19 @@ class NotificationAccessServiceImpl(
                     user.notificationSettings = setting
                     user.telegramChats += chat
                 }
-            }
-            .apply { settingRepository.saveAll(this) }
+            }.apply { settingRepository.saveAll(this) }
             .map {
                 val user = TelegramUserMapper.toDto(it.telegramUser)
                 val chat = TelegramChatMapper.toDto(it.telegramChat, user)
                 NotificationSettingMapper.toDto(it, user, chat)
-            }
-            .toSet()
+            }.toSet()
     }
 
     @Transactional
-    override fun updateTimeOfLastNotification(externalUserId: Long, time: LocalDateTime): NotificationSettingDto {
+    override fun updateTimeOfLastNotification(
+        externalUserId: Long,
+        time: LocalDateTime,
+    ): NotificationSettingDto {
         logger.debug("Updating a time of last notification by externalUserId [$externalUserId]")
 
         val setting = requireSettings(externalUserId)
@@ -177,8 +179,17 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional
-    override fun updateQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime) {
-        logger.debug("The quiet mod will be updated for a user [{}], start time: [{}], end time: [{}]", externalUserId, start, end)
+    override fun updateQuietMode(
+        externalUserId: Long,
+        start: LocalTime,
+        end: LocalTime,
+    ) {
+        logger.debug(
+            "The quiet mod will be updated for a user [{}], start time: [{}], end time: [{}]",
+            externalUserId,
+            start,
+            end,
+        )
         settingRepository.clearPause(externalUserId)
         settingRepository.updateQuietMode(externalUserId, start, end)
     }
@@ -191,18 +202,25 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional
-    override fun updateTimezone(externalUserId: Long, timezone: String) {
+    override fun updateTimezone(
+        externalUserId: Long,
+        timezone: String,
+    ) {
         logger.debug("Changing timezone for user [$externalUserId] to [$timezone]")
-        val user = requireNotNull(
-            userRepository.findByExternalUserId(externalUserId),
-            { "Not found a Telegram User by externalUserId [$externalUserId]" }
-        )
+        val user =
+            requireNotNull(
+                userRepository.findByExternalUserId(externalUserId),
+                { "Not found a Telegram User by externalUserId [$externalUserId]" },
+            )
         user.userTimeZone = timezone
         userRepository.save(user)
     }
 
     @Transactional
-    override fun updatePause(externalUserId: Long, pauseUntil: LocalDateTime?): NotificationSettingDto {
+    override fun updatePause(
+        externalUserId: Long,
+        pauseUntil: LocalDateTime?,
+    ): NotificationSettingDto {
         logger.debug("Setting pause for externalUserId [$externalUserId] to [$pauseUntil]")
 
         val setting = requireSettings(externalUserId)
@@ -232,7 +250,10 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional
-    override fun updateDailyGoal(externalUserId: Long, goalMl: Int) {
+    override fun updateDailyGoal(
+        externalUserId: Long,
+        goalMl: Int,
+    ) {
         logger.debug("Updating daily goal for externalUserId [$externalUserId] to [$goalMl] ml")
         settingRepository.updateDailyGoal(externalUserId, goalMl)
     }
@@ -240,6 +261,6 @@ class NotificationAccessServiceImpl(
     private fun requireSettings(externalUserId: Long): NotificationSettingEntity =
         settingRepository.findByTelegramUser_ExternalUserId(externalUserId)
             ?: throw NotificationSettingsNotFoundException(
-                "Not found a Notification Setting by externalUserId [$externalUserId]"
+                "Not found a Notification Setting by externalUserId [$externalUserId]",
             )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
@@ -137,7 +137,10 @@ class NotificationAccessServiceImpl(
             .map {
                 val user = TelegramUserBuilder.toEntity(it.telegramUser)
                 val chat = TelegramChatBuilder.toEntity(it.telegramChat, user)
-                NotificationSettingBuilder.toEntity(it, user, chat)
+                NotificationSettingBuilder.toEntity(it, user, chat).also { setting ->
+                    user.notificationSettings = setting
+                    user.telegramChats += chat
+                }
             }
             .apply { settingRepository.saveAll(this) }
             .map {

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
@@ -117,13 +117,13 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional
-    override fun enableNotifications(externalUserId: Long) {
+    override fun updateNotificationsEnabled(externalUserId: Long) {
         logger.debug("A notification settings will be enabled (enabled = true) by externalUserId [$externalUserId]")
         settingRepository.switchEnabled(externalUserId, true)
     }
 
     @Transactional
-    override fun disableNotifications(externalUserId: Long) {
+    override fun updateNotificationsDisabled(externalUserId: Long) {
         logger.debug("A notification settings will be disabled (enabled = false) by externalUserId [$externalUserId]")
         settingRepository.clearPause(externalUserId)
         settingRepository.switchEnabled(externalUserId, false)
@@ -168,27 +168,27 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun isEnabledNotifications(externalUserId: Long): Boolean {
+    override fun findIsEnabledNotificationsByExternalUserId(externalUserId: Long): Boolean {
         logger.debug("Checking if notifications are active by externalUserId: [$externalUserId]")
         return settingRepository.isEnabledByExternalUserId(externalUserId)
     }
 
     @Transactional
-    override fun changeQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime) {
+    override fun updateQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime) {
         logger.debug("The quiet mod will be updated for a user [{}], start time: [{}], end time: [{}]", externalUserId, start, end)
         settingRepository.clearPause(externalUserId)
         settingRepository.updateQuietMode(externalUserId, start, end)
     }
 
     @Transactional
-    override fun disableQuietMode(externalUserId: Long) {
+    override fun updateQuietModeDisabled(externalUserId: Long) {
         logger.debug("The quiet mod will be disabled for a user [$externalUserId]")
         settingRepository.clearPause(externalUserId)
         settingRepository.updateQuietMode(externalUserId)
     }
 
     @Transactional
-    override fun changeTimezone(externalUserId: Long, timezone: String) {
+    override fun updateTimezone(externalUserId: Long, timezone: String) {
         logger.debug("Changing timezone for user [$externalUserId] to [$timezone]")
         val user = requireNotNull(
             userRepository.findByExternalUserId(externalUserId),
@@ -199,7 +199,7 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional
-    override fun setPause(externalUserId: Long, pauseUntil: LocalDateTime?): NotificationSettingDto {
+    override fun updatePause(externalUserId: Long, pauseUntil: LocalDateTime?): NotificationSettingDto {
         logger.debug("Setting pause for externalUserId [$externalUserId] to [$pauseUntil]")
 
         val setting = requireSettings(externalUserId)

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
@@ -3,14 +3,14 @@ package ru.illine.drinking.ponies.dao.access.impl
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import ru.illine.drinking.ponies.builder.NotificationSettingBuilder
-import ru.illine.drinking.ponies.builder.TelegramChatBuilder
-import ru.illine.drinking.ponies.builder.TelegramUserBuilder
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.dao.repository.NotificationSettingRepository
 import ru.illine.drinking.ponies.dao.repository.TelegramChatRepository
 import ru.illine.drinking.ponies.dao.repository.TelegramUserRepository
 import ru.illine.drinking.ponies.exception.NotificationSettingsNotFoundException
+import ru.illine.drinking.ponies.mapper.NotificationSettingMapper
+import ru.illine.drinking.ponies.mapper.TelegramChatMapper
+import ru.illine.drinking.ponies.mapper.TelegramUserMapper
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
@@ -36,9 +36,9 @@ class NotificationAccessServiceImpl(
 
         return settingRepository.findAll()
             .map {
-                val user = TelegramUserBuilder.toDto(it.telegramUser)
-                val chat = TelegramChatBuilder.toDto(it.telegramChat, user)
-                NotificationSettingBuilder.toDto(it, user, chat)
+                val user = TelegramUserMapper.toDto(it.telegramUser)
+                val chat = TelegramChatMapper.toDto(it.telegramChat, user)
+                NotificationSettingMapper.toDto(it, user, chat)
             }
             .toSet()
     }
@@ -48,9 +48,9 @@ class NotificationAccessServiceImpl(
         logger.debug("Finding a Notification by externalUserId [$externalUserId]")
 
         return requireSettings(externalUserId).let {
-            val user = TelegramUserBuilder.toDto(it.telegramUser)
-            val chat = TelegramChatBuilder.toDto(it.telegramChat, user)
-            NotificationSettingBuilder.toDto(it, user, chat)
+            val user = TelegramUserMapper.toDto(it.telegramUser)
+            val chat = TelegramChatMapper.toDto(it.telegramChat, user)
+            NotificationSettingMapper.toDto(it, user, chat)
         }
     }
 
@@ -74,20 +74,20 @@ class NotificationAccessServiceImpl(
         val userEntity =
             userRepository.findByExternalUserId(
                 externalUserId
-            ) ?: TelegramUserBuilder.toEntity(user)
+            ) ?: TelegramUserMapper.toEntity(user)
 
         val chatEntity =
-            chatRepository.findByExternalChatId(externalChatId) ?: TelegramChatBuilder.toEntity(chat, userEntity)
+            chatRepository.findByExternalChatId(externalChatId) ?: TelegramChatMapper.toEntity(chat, userEntity)
 
         val settingEntity =
             settingRepository.findByTelegramUser_ExternalUserId(
                 externalUserId
-            ) ?: NotificationSettingBuilder.toEntity(setting, userEntity, chatEntity)
+            ) ?: NotificationSettingMapper.toEntity(setting, userEntity, chatEntity)
 
         userEntity.addTelegramChat(chatEntity)
         userEntity.notificationSettings = settingEntity
 
-        return userRepository.save(userEntity).let { TelegramUserBuilder.toDto(it) }
+        return userRepository.save(userEntity).let { TelegramUserMapper.toDto(it) }
     }
 
     @Transactional
@@ -110,9 +110,9 @@ class NotificationAccessServiceImpl(
         }
 
         return settings.let {
-            val user = TelegramUserBuilder.toDto(it.telegramUser)
-            val chat = TelegramChatBuilder.toDto(it.telegramChat, user)
-            NotificationSettingBuilder.toDto(it, user, chat)
+            val user = TelegramUserMapper.toDto(it.telegramUser)
+            val chat = TelegramChatMapper.toDto(it.telegramChat, user)
+            NotificationSettingMapper.toDto(it, user, chat)
         }
     }
 
@@ -135,18 +135,18 @@ class NotificationAccessServiceImpl(
 
         return settings
             .map {
-                val user = TelegramUserBuilder.toEntity(it.telegramUser)
-                val chat = TelegramChatBuilder.toEntity(it.telegramChat, user)
-                NotificationSettingBuilder.toEntity(it, user, chat).also { setting ->
+                val user = TelegramUserMapper.toEntity(it.telegramUser)
+                val chat = TelegramChatMapper.toEntity(it.telegramChat, user)
+                NotificationSettingMapper.toEntity(it, user, chat).also { setting ->
                     user.notificationSettings = setting
                     user.telegramChats += chat
                 }
             }
             .apply { settingRepository.saveAll(this) }
             .map {
-                val user = TelegramUserBuilder.toDto(it.telegramUser)
-                val chat = TelegramChatBuilder.toDto(it.telegramChat, user)
-                NotificationSettingBuilder.toDto(it, user, chat)
+                val user = TelegramUserMapper.toDto(it.telegramUser)
+                val chat = TelegramChatMapper.toDto(it.telegramChat, user)
+                NotificationSettingMapper.toDto(it, user, chat)
             }
             .toSet()
     }
@@ -164,9 +164,9 @@ class NotificationAccessServiceImpl(
             }.let {
                 settingRepository.save(it)
             }.let {
-                val user = TelegramUserBuilder.toDto(it.telegramUser)
-                val chat = TelegramChatBuilder.toDto(it.telegramChat, user)
-                NotificationSettingBuilder.toDto(it, user, chat)
+                val user = TelegramUserMapper.toDto(it.telegramUser)
+                val chat = TelegramChatMapper.toDto(it.telegramChat, user)
+                NotificationSettingMapper.toDto(it, user, chat)
             }
     }
 
@@ -225,9 +225,9 @@ class NotificationAccessServiceImpl(
             }.let {
                 settingRepository.save(it)
             }.let {
-                val user = TelegramUserBuilder.toDto(it.telegramUser)
-                val chat = TelegramChatBuilder.toDto(it.telegramChat, user)
-                NotificationSettingBuilder.toDto(it, user, chat)
+                val user = TelegramUserMapper.toDto(it.telegramUser)
+                val chat = TelegramChatMapper.toDto(it.telegramChat, user)
+                NotificationSettingMapper.toDto(it, user, chat)
             }
     }
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
@@ -44,10 +44,10 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun findNotificationSettingByTelegramUserId(telegramUserId: Long): NotificationSettingDto {
-        logger.debug("Finding a Notification by telegramUserId [$telegramUserId]")
+    override fun findNotificationSettingByExternalUserId(externalUserId: Long): NotificationSettingDto {
+        logger.debug("Finding a Notification by externalUserId [$externalUserId]")
 
-        return requireSettings(telegramUserId).let {
+        return requireSettings(externalUserId).let {
             val user = TelegramUserBuilder.toDto(it.telegramUser)
             val chat = TelegramChatBuilder.toDto(it.telegramChat, user)
             NotificationSettingBuilder.toDto(it, user, chat)
@@ -55,9 +55,9 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun existsByTelegramUserId(telegramUserId: Long): Boolean {
-        logger.debug("Does a notification exist for the telegramUserId: [$telegramUserId]?")
-        return userRepository.existsByExternalUserId(telegramUserId)
+    override fun existsByExternalUserId(externalUserId: Long): Boolean {
+        logger.debug("Does a notification exist for the externalUserId: [$externalUserId]?")
+        return userRepository.existsByExternalUserId(externalUserId)
     }
 
     @Transactional
@@ -92,11 +92,11 @@ class NotificationAccessServiceImpl(
 
     @Transactional
     override fun updateNotificationSettings(
-        telegramUserId: Long, notificationInterval: IntervalNotificationType
+        externalUserId: Long, notificationInterval: IntervalNotificationType
     ): NotificationSettingDto {
-        logger.debug("The Notification Settings will be updated for an existed entity by id: [${telegramUserId}]")
+        logger.debug("The Notification Settings will be updated for an existed entity by id: [${externalUserId}]")
 
-        val settings = requireSettings(telegramUserId)
+        val settings = requireSettings(externalUserId)
 
         if (settings.notificationInterval != notificationInterval) {
             // Reset timer so the new interval counts from now, not from the last notification time.
@@ -117,16 +117,16 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional
-    override fun enableNotifications(telegramUserId: Long) {
-        logger.debug("A notification settings will be enabled (enabled = true) by telegramUserId [$telegramUserId]")
-        settingRepository.switchEnabled(telegramUserId, true)
+    override fun enableNotifications(externalUserId: Long) {
+        logger.debug("A notification settings will be enabled (enabled = true) by externalUserId [$externalUserId]")
+        settingRepository.switchEnabled(externalUserId, true)
     }
 
     @Transactional
-    override fun disableNotifications(telegramUserId: Long) {
-        logger.debug("A notification settings will be disabled (enabled = false) by telegramUserId [$telegramUserId]")
-        settingRepository.clearPause(telegramUserId)
-        settingRepository.switchEnabled(telegramUserId, false)
+    override fun disableNotifications(externalUserId: Long) {
+        logger.debug("A notification settings will be disabled (enabled = false) by externalUserId [$externalUserId]")
+        settingRepository.clearPause(externalUserId)
+        settingRepository.switchEnabled(externalUserId, false)
     }
 
     @Transactional
@@ -149,10 +149,10 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional
-    override fun updateTimeOfLastNotification(telegramUserId: Long, time: LocalDateTime): NotificationSettingDto {
-        logger.debug("Updating a time of last notification by telegramUserId [$telegramUserId]")
+    override fun updateTimeOfLastNotification(externalUserId: Long, time: LocalDateTime): NotificationSettingDto {
+        logger.debug("Updating a time of last notification by externalUserId [$externalUserId]")
 
-        val setting = requireSettings(telegramUserId)
+        val setting = requireSettings(externalUserId)
 
         return setting
             .apply {
@@ -168,41 +168,41 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun isEnabledNotifications(telegramUserId: Long): Boolean {
-        logger.debug("Checking if notifications are active by telegramUserId: [$telegramUserId]")
-        return settingRepository.isEnabledByTelegramUserId(telegramUserId)
+    override fun isEnabledNotifications(externalUserId: Long): Boolean {
+        logger.debug("Checking if notifications are active by externalUserId: [$externalUserId]")
+        return settingRepository.isEnabledByExternalUserId(externalUserId)
     }
 
     @Transactional
-    override fun changeQuietMode(userId: Long, start: LocalTime, end: LocalTime) {
-        logger.debug("The quiet mod will be updated for a user [{}], start time: [{}], end time: [{}]", userId, start, end)
-        settingRepository.clearPause(userId)
-        settingRepository.updateQuietMode(userId, start, end)
+    override fun changeQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime) {
+        logger.debug("The quiet mod will be updated for a user [{}], start time: [{}], end time: [{}]", externalUserId, start, end)
+        settingRepository.clearPause(externalUserId)
+        settingRepository.updateQuietMode(externalUserId, start, end)
     }
 
     @Transactional
-    override fun disableQuietMode(userId: Long) {
-        logger.debug("The quiet mod will be disabled for a user [$userId]")
-        settingRepository.clearPause(userId)
-        settingRepository.updateQuietMode(userId)
+    override fun disableQuietMode(externalUserId: Long) {
+        logger.debug("The quiet mod will be disabled for a user [$externalUserId]")
+        settingRepository.clearPause(externalUserId)
+        settingRepository.updateQuietMode(externalUserId)
     }
 
     @Transactional
-    override fun changeTimezone(telegramUserId: Long, timezone: String) {
-        logger.debug("Changing timezone for user [$telegramUserId] to [$timezone]")
+    override fun changeTimezone(externalUserId: Long, timezone: String) {
+        logger.debug("Changing timezone for user [$externalUserId] to [$timezone]")
         val user = requireNotNull(
-            userRepository.findByExternalUserId(telegramUserId),
-            { "Not found a Telegram User by telegramUserId [$telegramUserId]" }
+            userRepository.findByExternalUserId(externalUserId),
+            { "Not found a Telegram User by externalUserId [$externalUserId]" }
         )
         user.userTimeZone = timezone
         userRepository.save(user)
     }
 
     @Transactional
-    override fun setPause(telegramUserId: Long, pauseUntil: LocalDateTime?): NotificationSettingDto {
-        logger.debug("Setting pause for telegramUserId [$telegramUserId] to [$pauseUntil]")
+    override fun setPause(externalUserId: Long, pauseUntil: LocalDateTime?): NotificationSettingDto {
+        logger.debug("Setting pause for externalUserId [$externalUserId] to [$pauseUntil]")
 
-        val setting = requireSettings(telegramUserId)
+        val setting = requireSettings(externalUserId)
         val now = LocalDateTime.now(clock)
 
         return setting
@@ -229,14 +229,14 @@ class NotificationAccessServiceImpl(
     }
 
     @Transactional
-    override fun updateDailyGoal(telegramUserId: Long, goalMl: Int) {
-        logger.debug("Updating daily goal for telegramUserId [$telegramUserId] to [$goalMl] ml")
-        settingRepository.updateDailyGoal(telegramUserId, goalMl)
+    override fun updateDailyGoal(externalUserId: Long, goalMl: Int) {
+        logger.debug("Updating daily goal for externalUserId [$externalUserId] to [$goalMl] ml")
+        settingRepository.updateDailyGoal(externalUserId, goalMl)
     }
 
-    private fun requireSettings(telegramUserId: Long): NotificationSettingEntity =
-        settingRepository.findByTelegramUser_ExternalUserId(telegramUserId)
+    private fun requireSettings(externalUserId: Long): NotificationSettingEntity =
+        settingRepository.findByTelegramUser_ExternalUserId(externalUserId)
             ?: throw NotificationSettingsNotFoundException(
-                "Not found a Notification Setting by telegramUserId [$telegramUserId]"
+                "Not found a Notification Setting by externalUserId [$externalUserId]"
             )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/TelegramUserAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/TelegramUserAccessServiceImpl.kt
@@ -12,7 +12,6 @@ import ru.illine.drinking.ponies.dao.repository.TelegramUserRepository
 class TelegramUserAccessServiceImpl(
     private val telegramUserRepository: TelegramUserRepository,
 ) : TelegramUserAccessService {
-
     private val logger = LoggerFactory.getLogger("ACCESS-SERVICE")
 
     // When admin promote/demote endpoints are added,

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/WaterStatisticAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/WaterStatisticAccessServiceImpl.kt
@@ -5,12 +5,12 @@ import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import ru.illine.drinking.ponies.builder.TelegramUserBuilder
-import ru.illine.drinking.ponies.builder.WaterStatisticBuilder
 import ru.illine.drinking.ponies.config.cache.CacheConfig
 import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.dao.repository.TelegramUserRepository
 import ru.illine.drinking.ponies.dao.repository.WaterStatisticRepository
+import ru.illine.drinking.ponies.mapper.TelegramUserMapper
+import ru.illine.drinking.ponies.mapper.WaterStatisticMapper
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import java.time.LocalDateTime
 
@@ -33,7 +33,7 @@ class WaterStatisticAccessServiceImpl(
         )
         return waterStatisticRepository
             .findByUserAndEventTimeBetween(externalUserId, startInclusive, endExclusive)
-            .map { WaterStatisticBuilder.toDto(it, TelegramUserBuilder.toDto(it.telegramUser)) }
+            .map { WaterStatisticMapper.toDto(it, TelegramUserMapper.toDto(it.telegramUser)) }
     }
 
     @Transactional(readOnly = true)
@@ -53,8 +53,8 @@ class WaterStatisticAccessServiceImpl(
             { "Not found a Telegram User by externalUserId [${dto.telegramUser.externalUserId}]" }
         )
 
-        return waterStatisticRepository.save(WaterStatisticBuilder.toEntity(dto, userEntity))
-            .let { WaterStatisticBuilder.toDto(it, TelegramUserBuilder.toDto(it.telegramUser)) }
+        return waterStatisticRepository.save(WaterStatisticMapper.toEntity(dto, userEntity))
+            .let { WaterStatisticMapper.toDto(it, TelegramUserMapper.toDto(it.telegramUser)) }
     }
 
     @Transactional
@@ -71,9 +71,9 @@ class WaterStatisticAccessServiceImpl(
                 if (userEntity == null) {
                     logger.warn("Not found user by external id: [{}], skipping", statistic.telegramUser.externalUserId)
                 }
-                userEntity?.let { WaterStatisticBuilder.toEntity(statistic, userEntity) }
+                userEntity?.let { WaterStatisticMapper.toEntity(statistic, userEntity) }
             }
             .let { waterStatisticRepository.saveAll(it) }
-            .map { WaterStatisticBuilder.toDto(it, TelegramUserBuilder.toDto(it.telegramUser)) }
+            .map { WaterStatisticMapper.toDto(it, TelegramUserMapper.toDto(it.telegramUser)) }
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/WaterStatisticAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/WaterStatisticAccessServiceImpl.kt
@@ -19,17 +19,16 @@ class WaterStatisticAccessServiceImpl(
     private val waterStatisticRepository: WaterStatisticRepository,
     private val userRepository: TelegramUserRepository,
 ) : WaterStatisticAccessService {
-
     private val logger = LoggerFactory.getLogger("ACCESS-SERVICE")
 
     @Transactional(readOnly = true)
     override fun findByUserAndEventTimeBetween(
         externalUserId: Long,
         startInclusive: LocalDateTime,
-        endExclusive: LocalDateTime
+        endExclusive: LocalDateTime,
     ): List<WaterStatisticDto> {
         logger.debug(
-            "Finding water statistics for externalUserId [$externalUserId] between [$startInclusive] and [$endExclusive]"
+            "Finding water statistics for externalUserId [$externalUserId] between [$startInclusive] and [$endExclusive]",
         )
         return waterStatisticRepository
             .findByUserAndEventTimeBetween(externalUserId, startInclusive, endExclusive)
@@ -48,12 +47,14 @@ class WaterStatisticAccessServiceImpl(
     override fun save(dto: WaterStatisticDto): WaterStatisticDto {
         logger.debug("Saving a water statistic record for a telegram user: [${dto.telegramUser.externalUserId}]")
 
-        val userEntity = requireNotNull(
-            userRepository.findByExternalUserId(dto.telegramUser.externalUserId),
-            { "Not found a Telegram User by externalUserId [${dto.telegramUser.externalUserId}]" }
-        )
+        val userEntity =
+            requireNotNull(
+                userRepository.findByExternalUserId(dto.telegramUser.externalUserId),
+                { "Not found a Telegram User by externalUserId [${dto.telegramUser.externalUserId}]" },
+            )
 
-        return waterStatisticRepository.save(WaterStatisticMapper.toEntity(dto, userEntity))
+        return waterStatisticRepository
+            .save(WaterStatisticMapper.toEntity(dto, userEntity))
             .let { WaterStatisticMapper.toDto(it, TelegramUserMapper.toDto(it.telegramUser)) }
     }
 
@@ -72,8 +73,7 @@ class WaterStatisticAccessServiceImpl(
                     logger.warn("Not found user by external id: [{}], skipping", statistic.telegramUser.externalUserId)
                 }
                 userEntity?.let { WaterStatisticMapper.toEntity(statistic, userEntity) }
-            }
-            .let { waterStatisticRepository.saveAll(it) }
+            }.let { waterStatisticRepository.saveAll(it) }
             .map { WaterStatisticMapper.toDto(it, TelegramUserMapper.toDto(it.telegramUser)) }
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/NotificationSettingRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/NotificationSettingRepository.kt
@@ -20,7 +20,7 @@ interface NotificationSettingRepository : JpaRepository<NotificationSettingEntit
         """,
         nativeQuery = true
     )
-    fun isEnabledByTelegramUserId(@Param("externalUserId") externalUserId: Long): Boolean
+    fun isEnabledByExternalUserId(@Param("externalUserId") externalUserId: Long): Boolean
 
     @Modifying
     @Query(

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/NotificationSettingRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/NotificationSettingRepository.kt
@@ -8,7 +8,10 @@ import ru.illine.drinking.ponies.model.entity.NotificationSettingEntity
 import java.time.LocalTime
 
 interface NotificationSettingRepository : JpaRepository<NotificationSettingEntity, Long> {
-
+    // Spring Data derived query: the underscore explicitly resolves the nested property path
+    // telegramUser.externalUserId. Renaming it would break query derivation, so the ktlint
+    // naming rule is suppressed here intentionally.
+    @Suppress("ktlint:standard:function-naming")
     fun findByTelegramUser_ExternalUserId(externalUserId: Long): NotificationSettingEntity?
 
     @Query(
@@ -18,9 +21,11 @@ interface NotificationSettingRepository : JpaRepository<NotificationSettingEntit
             inner join telegram_users u on ns.telegram_user_id = u.id
             where u.external_user_id = :externalUserId
         """,
-        nativeQuery = true
+        nativeQuery = true,
     )
-    fun isEnabledByExternalUserId(@Param("externalUserId") externalUserId: Long): Boolean
+    fun isEnabledByExternalUserId(
+        @Param("externalUserId") externalUserId: Long,
+    ): Boolean
 
     @Modifying
     @Query(
@@ -31,11 +36,11 @@ interface NotificationSettingRepository : JpaRepository<NotificationSettingEntit
         where ns.telegram_user_id = u.id
           and u.external_user_id = :externalUserId
         """,
-        nativeQuery = true
+        nativeQuery = true,
     )
     fun switchEnabled(
         @Param("externalUserId") externalUserId: Long,
-        @Param("enabled") enabled: Boolean
+        @Param("enabled") enabled: Boolean,
     )
 
     @Modifying
@@ -47,12 +52,12 @@ interface NotificationSettingRepository : JpaRepository<NotificationSettingEntit
         where ns.telegram_user_id = u.id
           and u.external_user_id = :externalUserId
         """,
-        nativeQuery = true
+        nativeQuery = true,
     )
     fun updateQuietMode(
         @Param("externalUserId") externalUserId: Long,
         @Param("start") start: LocalTime? = null,
-        @Param("end") end: LocalTime? = null
+        @Param("end") end: LocalTime? = null,
     )
 
     @Modifying
@@ -64,9 +69,11 @@ interface NotificationSettingRepository : JpaRepository<NotificationSettingEntit
         where ns.telegram_user_id = u.id
           and u.external_user_id = :externalUserId
         """,
-        nativeQuery = true
+        nativeQuery = true,
     )
-    fun clearPause(@Param("externalUserId") externalUserId: Long)
+    fun clearPause(
+        @Param("externalUserId") externalUserId: Long,
+    )
 
     @Modifying
     @Query(
@@ -77,11 +84,10 @@ interface NotificationSettingRepository : JpaRepository<NotificationSettingEntit
         where ns.telegram_user_id = u.id
           and u.external_user_id = :externalUserId
         """,
-        nativeQuery = true
+        nativeQuery = true,
     )
     fun updateDailyGoal(
         @Param("externalUserId") externalUserId: Long,
-        @Param("goalMl") goalMl: Int
+        @Param("goalMl") goalMl: Int,
     )
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/TelegramChatRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/TelegramChatRepository.kt
@@ -4,7 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 import ru.illine.drinking.ponies.model.entity.TelegramChatEntity
 
 interface TelegramChatRepository : JpaRepository<TelegramChatEntity, Long> {
-
     fun findByExternalChatId(externalChatId: Long): TelegramChatEntity?
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/TelegramUserRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/TelegramUserRepository.kt
@@ -5,9 +5,9 @@ import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 
 interface TelegramUserRepository : JpaRepository<TelegramUserEntity, Long> {
 
-    fun findByExternalUserId(telegramUserId: Long): TelegramUserEntity?
+    fun findByExternalUserId(externalUserId: Long): TelegramUserEntity?
 
-    fun findAllByExternalUserIdIn(telegramUserId: Collection<Long>): Set<TelegramUserEntity>
+    fun findAllByExternalUserIdIn(externalUserId: Collection<Long>): Set<TelegramUserEntity>
 
-    fun existsByExternalUserId(telegramUserId: Long): Boolean
+    fun existsByExternalUserId(externalUserId: Long): Boolean
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/TelegramUserRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/TelegramUserRepository.kt
@@ -4,7 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 
 interface TelegramUserRepository : JpaRepository<TelegramUserEntity, Long> {
-
     fun findByExternalUserId(externalUserId: Long): TelegramUserEntity?
 
     fun findAllByExternalUserIdIn(externalUserId: Collection<Long>): Set<TelegramUserEntity>

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/WaterStatisticRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/WaterStatisticRepository.kt
@@ -7,7 +7,6 @@ import ru.illine.drinking.ponies.model.entity.WaterStatisticEntity
 import java.time.LocalDateTime
 
 interface WaterStatisticRepository : JpaRepository<WaterStatisticEntity, Long> {
-
     @Query(
         value = """
             select ws from WaterStatisticEntity ws
@@ -16,12 +15,12 @@ interface WaterStatisticRepository : JpaRepository<WaterStatisticEntity, Long> {
               and ws.eventTime >= :startInclusive
               and ws.eventTime < :endExclusive
             order by ws.eventTime asc
-        """
+        """,
     )
     fun findByUserAndEventTimeBetween(
         @Param("externalUserId") externalUserId: Long,
         @Param("startInclusive") startInclusive: LocalDateTime,
-        @Param("endExclusive") endExclusive: LocalDateTime
+        @Param("endExclusive") endExclusive: LocalDateTime,
     ): List<WaterStatisticEntity>
 
     @Query(
@@ -32,7 +31,9 @@ interface WaterStatisticRepository : JpaRepository<WaterStatisticEntity, Long> {
                 where external_user_id = :externalUserId and deleted = false
             )
         """,
-        nativeQuery = true
+        nativeQuery = true,
     )
-    fun findEarliestEventTimeByUser(@Param("externalUserId") externalUserId: Long): LocalDateTime?
+    fun findEarliestEventTimeByUser(
+        @Param("externalUserId") externalUserId: Long,
+    ): LocalDateTime?
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/exception/InvalidAuthSignatureException.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/exception/InvalidAuthSignatureException.kt
@@ -1,3 +1,5 @@
 package ru.illine.drinking.ponies.exception
 
-class InvalidAuthSignatureException(message: String) : RuntimeException(message)
+class InvalidAuthSignatureException(
+    message: String,
+) : RuntimeException(message)

--- a/src/main/kotlin/ru/illine/drinking/ponies/exception/MessageTemplateException.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/exception/MessageTemplateException.kt
@@ -1,3 +1,5 @@
 package ru.illine.drinking.ponies.exception
 
-class MessageTemplateException(message: String) : RuntimeException(message)
+class MessageTemplateException(
+    message: String,
+) : RuntimeException(message)

--- a/src/main/kotlin/ru/illine/drinking/ponies/exception/NotificationSettingsNotFoundException.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/exception/NotificationSettingsNotFoundException.kt
@@ -1,3 +1,5 @@
 package ru.illine.drinking.ponies.exception
 
-class NotificationSettingsNotFoundException(message: String) : RuntimeException(message)
+class NotificationSettingsNotFoundException(
+    message: String,
+) : RuntimeException(message)

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/NotificationSettingMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/NotificationSettingMapper.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.builder
+package ru.illine.drinking.ponies.mapper
 
 import io.mcarle.konvert.api.Konverter
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
@@ -21,22 +21,6 @@ interface NotificationSettingMapper {
         telegramUser: TelegramUserEntity,
         telegramChat: TelegramChatEntity,
     ): NotificationSettingEntity
-}
 
-object NotificationSettingBuilder {
-    private val mapper: NotificationSettingMapper = Konverter.get<NotificationSettingMapper>()
-
-    fun toDto(
-        setting: NotificationSettingEntity,
-        user: TelegramUserDto,
-        chat: TelegramChatDto
-    ): NotificationSettingDto =
-        mapper.toDto(setting, user, chat)
-
-    fun toEntity(
-        setting: NotificationSettingDto,
-        user: TelegramUserEntity,
-        chat: TelegramChatEntity
-    ): NotificationSettingEntity =
-        mapper.toEntity(setting, user, chat)
+    companion object : NotificationSettingMapper by Konverter.get<NotificationSettingMapper>()
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/SettingMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/SettingMapper.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.builder
+package ru.illine.drinking.ponies.mapper
 
 import ru.illine.drinking.ponies.model.dto.SettingDto
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
@@ -10,7 +10,7 @@ import ru.illine.drinking.ponies.util.TimeHelper
 // express all of this as @Mapping(expression=...), which it does not verify, giving no real
 // safety over this named-constructor form. Correctness is guarded by
 // NotificationSettingsServiceTest."getAllSettings returns full dto when enabled", which asserts every field.
-object SettingBuilder {
+object SettingMapper {
     fun toDto(settings: NotificationSettingDto): SettingDto = SettingDto(
         interval = settings.notificationInterval.name,
         intervalDisplayName = settings.notificationInterval.displayName,

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/SettingMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/SettingMapper.kt
@@ -11,14 +11,15 @@ import ru.illine.drinking.ponies.util.TimeHelper
 // safety over this named-constructor form. Correctness is guarded by
 // NotificationSettingsServiceTest."getAllSettings returns full dto when enabled", which asserts every field.
 object SettingMapper {
-    fun toDto(settings: NotificationSettingDto): SettingDto = SettingDto(
-        interval = settings.notificationInterval.name,
-        intervalDisplayName = settings.notificationInterval.displayName,
-        intervalMinutes = settings.notificationInterval.minutes,
-        quietModeStart = TimeHelper.timeToString(settings.quietModeStart!!),
-        quietModeEnd = TimeHelper.timeToString(settings.quietModeEnd!!),
-        timezone = settings.telegramUser.userTimeZone,
-        dailyGoalMl = settings.dailyGoalMl,
-        notificationActive = settings.enabled,
-    )
+    fun toDto(settings: NotificationSettingDto): SettingDto =
+        SettingDto(
+            interval = settings.notificationInterval.name,
+            intervalDisplayName = settings.notificationInterval.displayName,
+            intervalMinutes = settings.notificationInterval.minutes,
+            quietModeStart = TimeHelper.timeToString(settings.quietModeStart!!),
+            quietModeEnd = TimeHelper.timeToString(settings.quietModeEnd!!),
+            timezone = settings.telegramUser.userTimeZone,
+            dailyGoalMl = settings.dailyGoalMl,
+            notificationActive = settings.enabled,
+        )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/SettingResponseMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/SettingResponseMapper.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.builder
+package ru.illine.drinking.ponies.mapper
 
 import io.mcarle.konvert.api.Konverter
 import ru.illine.drinking.ponies.model.dto.SettingDto
@@ -7,10 +7,6 @@ import ru.illine.drinking.ponies.model.dto.response.SettingResponse
 @Konverter
 interface SettingResponseMapper {
     fun toResponse(dto: SettingDto): SettingResponse
-}
 
-object SettingResponseBuilder {
-    private val mapper: SettingResponseMapper = Konverter.get<SettingResponseMapper>()
-
-    fun toResponse(dto: SettingDto): SettingResponse = mapper.toResponse(dto)
+    companion object : SettingResponseMapper by Konverter.get<SettingResponseMapper>()
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/StatisticsMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/StatisticsMapper.kt
@@ -18,7 +18,7 @@ interface StatisticsMapper {
                 target = "insight",
                 expression = "ru.illine.drinking.ponies.model.dto.response.InsightInfo(it.insightText)",
             ),
-        ]
+        ],
     )
     fun toResponse(dto: StatisticsDto): StatisticsResponse
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/StatisticsMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/StatisticsMapper.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.builder
+package ru.illine.drinking.ponies.mapper
 
 import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Konverter
@@ -25,10 +25,6 @@ interface StatisticsMapper {
     fun toPoint(dto: StatisticsPointDto): StatisticsPoint
 
     fun toBestDay(dto: BestDayDto): BestDayInfo
-}
 
-object StatisticsBuilder {
-    private val mapper: StatisticsMapper = Konverter.get<StatisticsMapper>()
-
-    fun toResponse(dto: StatisticsDto): StatisticsResponse = mapper.toResponse(dto)
+    companion object : StatisticsMapper by Konverter.get<StatisticsMapper>()
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/TelegramChatMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/TelegramChatMapper.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.builder
+package ru.illine.drinking.ponies.mapper
 
 import io.mcarle.konvert.api.Konverter
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
@@ -17,14 +17,6 @@ interface TelegramChatMapper {
         @Konverter.Source chat: TelegramChatDto,
         telegramUser: TelegramUserEntity,
     ): TelegramChatEntity
-}
 
-object TelegramChatBuilder {
-    private val mapper: TelegramChatMapper = Konverter.get<TelegramChatMapper>()
-
-    fun toDto(chat: TelegramChatEntity, user: TelegramUserDto): TelegramChatDto =
-        mapper.toDto(chat, user)
-
-    fun toEntity(chat: TelegramChatDto, user: TelegramUserEntity): TelegramChatEntity =
-        mapper.toEntity(chat, user)
+    companion object : TelegramChatMapper by Konverter.get<TelegramChatMapper>()
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/TelegramUserMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/TelegramUserMapper.kt
@@ -7,6 +7,7 @@ import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 @Konverter
 interface TelegramUserMapper {
     fun toDto(entity: TelegramUserEntity): TelegramUserDto
+
     fun toEntity(dto: TelegramUserDto): TelegramUserEntity
 
     companion object : TelegramUserMapper by Konverter.get<TelegramUserMapper>()

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/TelegramUserMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/TelegramUserMapper.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.builder
+package ru.illine.drinking.ponies.mapper
 
 import io.mcarle.konvert.api.Konverter
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
@@ -8,12 +8,6 @@ import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 interface TelegramUserMapper {
     fun toDto(entity: TelegramUserEntity): TelegramUserDto
     fun toEntity(dto: TelegramUserDto): TelegramUserEntity
-}
 
-object TelegramUserBuilder {
-    private val mapper: TelegramUserMapper = Konverter.get<TelegramUserMapper>()
-
-    fun toDto(entity: TelegramUserEntity): TelegramUserDto = mapper.toDto(entity)
-
-    fun toEntity(dto: TelegramUserDto): TelegramUserEntity = mapper.toEntity(dto)
+    companion object : TelegramUserMapper by Konverter.get<TelegramUserMapper>()
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/WaterStatisticMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/WaterStatisticMapper.kt
@@ -25,7 +25,7 @@ interface WaterStatisticMapper {
         mappings = [
             Mapping(source = "waterAmountMl", target = "amountMl"),
             Mapping(target = "eventTime", expression = "it.eventTime.toInstant(java.time.ZoneOffset.UTC)"),
-        ]
+        ],
     )
     fun toWaterEntry(dto: WaterStatisticDto): WaterEntry
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/WaterStatisticMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/WaterStatisticMapper.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.builder
+package ru.illine.drinking.ponies.mapper
 
 import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Konverter
@@ -28,17 +28,6 @@ interface WaterStatisticMapper {
         ]
     )
     fun toWaterEntry(dto: WaterStatisticDto): WaterEntry
-}
 
-object WaterStatisticBuilder {
-    private val mapper: WaterStatisticMapper = Konverter.get<WaterStatisticMapper>()
-
-    fun toDto(entity: WaterStatisticEntity, user: TelegramUserDto): WaterStatisticDto =
-        mapper.toDto(entity, user)
-
-    fun toEntity(dto: WaterStatisticDto, user: TelegramUserEntity): WaterStatisticEntity =
-        mapper.toEntity(dto, user)
-
-    fun toWaterEntry(dto: WaterStatisticDto): WaterEntry =
-        mapper.toWaterEntry(dto)
+    companion object : WaterStatisticMapper by Konverter.get<WaterStatisticMapper>()
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/base/AnswerNotificationType.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/base/AnswerNotificationType.kt
@@ -1,24 +1,21 @@
 package ru.illine.drinking.ponies.model.base
 
-import java.util.*
+import java.util.Objects
+import java.util.UUID
 
 @Suppress("unused")
 enum class AnswerNotificationType(
     val displayName: String,
-    val queryData: UUID
+    val queryData: UUID,
 ) {
-
     YES("Да", UUID.fromString("1906562b-d065-4cb9-bfe2-2150f62cb053")),
     SNOOZE("Отложить", UUID.fromString("3d1122fd-f091-4fa7-ae0c-731f8d203e9f")),
-    CANCEL("Отменить", UUID.fromString("16854759-b421-44bb-acee-51b4e5140a1a"));
+    CANCEL("Отменить", UUID.fromString("16854759-b421-44bb-acee-51b4e5140a1a")),
+    ;
 
     companion object {
-
-        fun typeOf(queryData: String): AnswerNotificationType? {
-            return AnswerNotificationType.entries
+        fun typeOf(queryData: String): AnswerNotificationType? =
+            AnswerNotificationType.entries
                 .find { Objects.equals(queryData, it.queryData.toString()) }
-        }
-
     }
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/base/IntervalNotificationType.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/base/IntervalNotificationType.kt
@@ -11,5 +11,5 @@ enum class IntervalNotificationType(
     HOUR(TelegramTimeConstants.HOUR, 60),
     HOUR_AND_HALF(TelegramTimeConstants.HOUR_AND_HALF, 90),
     TWO_HOURS(TelegramTimeConstants.TWO_HOURS, 120),
-    THREE_HOURS(TelegramTimeConstants.THREE_HOURS, 180);
+    THREE_HOURS(TelegramTimeConstants.THREE_HOURS, 180),
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/base/SnoozeNotificationType.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/base/SnoozeNotificationType.kt
@@ -1,25 +1,23 @@
 package ru.illine.drinking.ponies.model.base
 
 import ru.illine.drinking.ponies.util.telegram.TelegramTimeConstants
-import java.util.*
+import java.util.Objects
+import java.util.UUID
 
 @Suppress("unused")
 enum class SnoozeNotificationType(
     val displayName: String,
     val minutes: Long,
-    val queryData: UUID
+    val queryData: UUID,
 ) {
     FIVE_MINS(TelegramTimeConstants.FIVE_MINS, 5, UUID.fromString("c4a7e3f1-2b8d-4a5e-9c6f-1d3e7b8a2c4d")),
     TEN_MINS(TelegramTimeConstants.TEN_MINS, 10, UUID.fromString("f8b2d6e4-3a7c-4f1e-8b5d-2c9f6a3e7d1b")),
     FIFTEEN_MINS(TelegramTimeConstants.FIFTEEN_MINS, 15, UUID.fromString("e3f7a2b8-5c1d-4e9f-b6a3-8d2c7e4f1a5b")),
-    TWENTY_MINS(TelegramTimeConstants.TWENTY_MINS, 20, UUID.fromString("b5d1f9c3-7e4a-4b2f-a8e5-3c6f9d2b7e1a"));
+    TWENTY_MINS(TelegramTimeConstants.TWENTY_MINS, 20, UUID.fromString("b5d1f9c3-7e4a-4b2f-a8e5-3c6f9d2b7e1a")),
+    ;
 
     companion object {
-
-        fun typeOf(queryData: String): SnoozeNotificationType? {
-            return entries.find { Objects.equals(queryData, it.queryData.toString()) }
-        }
-
+        fun typeOf(queryData: String): SnoozeNotificationType? =
+            entries.find { Objects.equals(queryData, it.queryData.toString()) }
     }
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/base/TelegramCommandType.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/base/TelegramCommandType.kt
@@ -4,9 +4,8 @@ enum class TelegramCommandType(
     val command: String,
     val info: String,
 ) {
-
-    START("start", "Start command");
+    START("start", "Start command"),
+    ;
 
     override fun toString(): String = command
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/base/WaterAmountType.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/base/WaterAmountType.kt
@@ -1,27 +1,25 @@
 package ru.illine.drinking.ponies.model.base
 
 import ru.illine.drinking.ponies.util.telegram.TelegramWaterAmountConstants
-import java.util.*
+import java.util.Objects
+import java.util.UUID
 
 @Suppress("unused")
 enum class WaterAmountType(
     val displayName: String,
     val amountMl: Int,
-    val queryData: UUID
+    val queryData: UUID,
 ) {
     ML_50(TelegramWaterAmountConstants.ML_50, 50, UUID.fromString("a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d")),
     ML_100(TelegramWaterAmountConstants.ML_100, 100, UUID.fromString("b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e")),
     ML_150(TelegramWaterAmountConstants.ML_150, 150, UUID.fromString("c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f")),
     ML_250(TelegramWaterAmountConstants.ML_250, 250, UUID.fromString("d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a")),
-    ML_450(TelegramWaterAmountConstants.ML_450, 450, UUID.fromString("e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8a9b"));
+    ML_450(TelegramWaterAmountConstants.ML_450, 450, UUID.fromString("e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8a9b")),
+    ;
 
     companion object {
-
-        fun typeOf(queryData: String): WaterAmountType? {
-            return WaterAmountType.entries
+        fun typeOf(queryData: String): WaterAmountType? =
+            WaterAmountType.entries
                 .find { Objects.equals(queryData, it.queryData.toString()) }
-        }
-
     }
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/base/WaterEntrySourceType.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/base/WaterEntrySourceType.kt
@@ -1,8 +1,6 @@
 package ru.illine.drinking.ponies.model.base
 
 enum class WaterEntrySourceType {
-
     NOTIFICATION,
-    MANUAL
-
+    MANUAL,
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/BestDayDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/BestDayDto.kt
@@ -6,5 +6,5 @@ import java.time.LocalDate
 data class BestDayDto(
     val date: LocalDate,
     val valueMl: Int,
-    val weekday: DayOfWeek
+    val weekday: DayOfWeek,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/InsightDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/InsightDto.kt
@@ -2,5 +2,5 @@ package ru.illine.drinking.ponies.model.dto
 
 data class InsightDto(
     val currentStreakDays: Int,
-    val text: String
+    val text: String,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/StatisticsDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/StatisticsDto.kt
@@ -9,5 +9,5 @@ data class StatisticsDto(
     val bestDay: BestDayDto?,
     val currentStreakDays: Int,
     val insightText: String,
-    val firstEntryAt: Instant?
+    val firstEntryAt: Instant?,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/StatisticsPointDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/StatisticsPointDto.kt
@@ -2,5 +2,5 @@ package ru.illine.drinking.ponies.model.dto
 
 data class StatisticsPointDto(
     val label: String,
-    val valueMl: Int
+    val valueMl: Int,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/TelegramUserDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/TelegramUserDto.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class TelegramUserDto(
     @JsonProperty("id")
-    val telegramId: Long,
+    val externalUserId: Long,
     @JsonProperty("first_name")
     val firstName: String?,
     @JsonProperty("last_name")

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/TelegramUserDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/TelegramUserDto.kt
@@ -20,9 +20,8 @@ data class TelegramUserDto(
     val isPremium: Boolean = false,
     @JsonProperty("allows_write_to_pm")
     val allowsWriteToPm: Boolean = false,
-
     // Internal-only flag enriched by TelegramAuthInterceptor from DB.
     // Never accept from incoming JSON (initData) and never expose in API responses.
     @JsonIgnore
-    val isAdmin: Boolean = false
+    val isAdmin: Boolean = false,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/NotificationSettingDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/NotificationSettingDto.kt
@@ -6,26 +6,16 @@ import java.time.LocalTime
 
 data class NotificationSettingDto(
     var id: Long? = null,
-
     val telegramUser: TelegramUserDto,
-
     val telegramChat: TelegramChatDto,
-
     val notificationInterval: IntervalNotificationType,
-
     var timeOfLastNotification: LocalDateTime = LocalDateTime.now(),
-
     var notificationAttempts: Int = 0,
-
     var quietModeStart: LocalTime? = null,
-
     var quietModeEnd: LocalTime? = null,
-
     var pauseUntil: LocalDateTime? = null,
-
     var dailyGoalMl: Int = 2000,
-
-    var enabled: Boolean = true
+    var enabled: Boolean = true,
 ) {
     companion object {
         fun create(
@@ -34,14 +24,15 @@ data class NotificationSettingDto(
             notificationInterval: IntervalNotificationType = IntervalNotificationType.TWO_HOURS,
             quietModeStart: LocalTime = LocalTime.of(23, 0),
             quietModeEnd: LocalTime = LocalTime.of(11, 0),
-            dailyGoalMl: Int = 2000
-        ): NotificationSettingDto = NotificationSettingDto(
-            telegramUser = telegramUser,
-            telegramChat = telegramChat,
-            notificationInterval = notificationInterval,
-            quietModeStart = quietModeStart,
-            quietModeEnd = quietModeEnd,
-            dailyGoalMl = dailyGoalMl,
-        )
+            dailyGoalMl: Int = 2000,
+        ): NotificationSettingDto =
+            NotificationSettingDto(
+                telegramUser = telegramUser,
+                telegramChat = telegramChat,
+                notificationInterval = notificationInterval,
+                quietModeStart = quietModeStart,
+                quietModeEnd = quietModeEnd,
+                dailyGoalMl = dailyGoalMl,
+            )
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/TelegramChatDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/TelegramChatDto.kt
@@ -2,15 +2,15 @@ package ru.illine.drinking.ponies.model.dto.internal
 
 data class TelegramChatDto(
     var id: Long? = null,
-
     val telegramUser: TelegramUserDto,
-
     var externalChatId: Long,
-
-    var previousNotificationMessageId: Int? = null
+    var previousNotificationMessageId: Int? = null,
 ) {
     companion object {
-        fun create(externalChatId: Long, telegramUser: TelegramUserDto): TelegramChatDto =
+        fun create(
+            externalChatId: Long,
+            telegramUser: TelegramUserDto,
+        ): TelegramChatDto =
             TelegramChatDto(
                 telegramUser = telegramUser,
                 externalChatId = externalChatId,

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/TelegramUserDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/TelegramUserDto.kt
@@ -4,16 +4,11 @@ import java.time.LocalDateTime
 
 data class TelegramUserDto(
     var id: Long? = null,
-
     var externalUserId: Long,
-
     var userTimeZone: String,
-
     var isAdmin: Boolean = false,
-
     var created: LocalDateTime = LocalDateTime.now(),
-
-    var deleted: Boolean = false
+    var deleted: Boolean = false,
 ) {
     companion object {
         fun create(externalUserId: Long): TelegramUserDto =

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/WaterStatisticDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/WaterStatisticDto.kt
@@ -6,14 +6,9 @@ import java.time.LocalDateTime
 
 data class WaterStatisticDto(
     var id: Long? = null,
-
     val telegramUser: TelegramUserDto,
-
     val eventTime: LocalDateTime,
-
     val eventType: AnswerNotificationType,
-
     val waterAmountMl: Int = 0,
-
-    val source: WaterEntrySourceType = WaterEntrySourceType.NOTIFICATION
+    val source: WaterEntrySourceType = WaterEntrySourceType.NOTIFICATION,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/message/InsightStatsContext.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/message/InsightStatsContext.kt
@@ -6,5 +6,5 @@ data class InsightStatsContext(
     val avgMlPerDay: Int,
     val bestDay: BestDayDto?,
     val currentStreakDays: Int,
-    val dailyGoalMl: Int
+    val dailyGoalMl: Int,
 ) : MessageContext

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/message/MessageDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/message/MessageDto.kt
@@ -1,5 +1,5 @@
 package ru.illine.drinking.ponies.model.dto.message
 
 data class MessageDto(
-    val text: String
+    val text: String,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/WaterEntryRequest.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/WaterEntryRequest.kt
@@ -13,14 +13,14 @@ import java.time.Instant
 data class WaterEntryRequest(
     @field:PastOrPresent
     @Schema(
-        description = "Consumption time in ISO 8601 UTC format. " +
-            "If null or omitted, server's current time is used.",
+        description =
+            "Consumption time in ISO 8601 UTC format. " +
+                "If null or omitted, server's current time is used.",
         example = "2025-01-01T14:00:00Z",
         nullable = true,
         requiredMode = Schema.RequiredMode.NOT_REQUIRED,
     )
     val consumedAt: Instant?,
-
     @field:Min(WaterEntryConstants.MIN_ML)
     @field:Max(WaterEntryConstants.MAX_ML)
     @Schema(

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/InsightInfo.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/InsightInfo.kt
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class InsightInfo(
     @Schema(
         description = "Localized text with placeholders already substituted",
-        example = "Котик, ты пьёшь водицу 3 дней подряд - так держать!"
+        example = "Котик, ты пьёшь водицу 3 дней подряд - так держать!",
     )
     val text: String,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/MeResponse.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/MeResponse.kt
@@ -1,11 +1,15 @@
 package ru.illine.drinking.ponies.model.dto.response
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "Current user identity")
 data class MeResponse(
+    // Kotlin field unified to externalUserId across the codebase (DPTB-140).
+    // The JSON key is intentionally kept as "telegramUserId" - it is the public /users/me contract consumed by the MiniApp.
+    @JsonProperty("telegramUserId")
     @Schema(description = "Telegram user id", example = "123456789")
-    val telegramUserId: Long,
+    val externalUserId: Long,
     @Schema(description = "Whether the user has admin privileges", example = "false")
     val isAdmin: Boolean,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/PauseStateResponse.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/PauseStateResponse.kt
@@ -7,6 +7,9 @@ import java.time.Instant
 data class PauseStateResponse(
     @Schema(description = "Whether notifications are currently paused", example = "true")
     val paused: Boolean,
-    @Schema(description = "Pause expiration time in ISO 8601 UTC format, null if not paused", example = "2025-01-01T18:30:00Z")
+    @Schema(
+        description = "Pause expiration time in ISO 8601 UTC format, null if not paused",
+        example = "2025-01-01T18:30:00Z",
+    )
     val pauseUntil: Instant? = null,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/StatisticsPoint.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/StatisticsPoint.kt
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class StatisticsPoint(
     @Schema(
         description = "Point label: \"HH:mm\" for DAY or \"YYYY-MM-DD\" for WEEK/MONTH",
-        example = "2026-05-06"
+        example = "2026-05-06",
     )
     val label: String,
     @Schema(description = "Aggregated water amount for this point in milliliters", example = "1800")

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/StatisticsResponse.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/StatisticsResponse.kt
@@ -20,7 +20,7 @@ data class StatisticsResponse(
     @Schema(
         description = "Timestamp of the user's earliest water entry; used as the left bound of the calendar",
         example = "2026-04-15T10:30:00Z",
-        nullable = true
+        nullable = true,
     )
     val firstEntryAt: Instant?,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/StatisticsTodayResponse.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/StatisticsTodayResponse.kt
@@ -5,5 +5,5 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(description = "Today's water intake events in user's timezone")
 data class StatisticsTodayResponse(
     @Schema(description = "Individual water intake events sorted by event time")
-    val entries: List<WaterEntry>
+    val entries: List<WaterEntry>,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/entity/NotificationSettingEntity.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/entity/NotificationSettingEntity.kt
@@ -1,7 +1,20 @@
 package ru.illine.drinking.ponies.model.entity
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import jakarta.persistence.*
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToOne
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
@@ -13,58 +26,46 @@ import java.time.LocalTime
 @SQLDelete(sql = "update notification_settings set enabled = false where id = ?")
 @SQLRestriction(value = "enabled = true")
 class NotificationSettingEntity(
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "notificationSettingSeqGenerator")
     @SequenceGenerator(
         name = "notificationSettingSeqGenerator",
         sequenceName = "notification_setting_seq",
-        allocationSize = 1
+        allocationSize = 1,
     )
     var id: Long? = null,
-
     @OneToOne(
         fetch = FetchType.LAZY,
         cascade = [CascadeType.MERGE, CascadeType.REFRESH],
     )
     @JoinColumn(name = "telegram_user_id", nullable = false, unique = true)
     var telegramUser: TelegramUserEntity,
-
     @ManyToOne(
         fetch = FetchType.LAZY,
         cascade = [CascadeType.MERGE, CascadeType.REFRESH],
     )
     @JoinColumn(name = "telegram_chat_id", nullable = false)
     var telegramChat: TelegramChatEntity,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "notification_interval", nullable = false)
     var notificationInterval: IntervalNotificationType,
-
     @Column(name = "time_of_last_notification", nullable = false)
     var timeOfLastNotification: LocalDateTime,
-
     @Column(name = "notification_attempts", nullable = false)
     var notificationAttempts: Int = 0,
-
     @Column(name = "quiet_mode_start")
     @JsonIgnore
     var quietModeStart: LocalTime? = null,
-
     @Column(name = "quiet_mode_end")
     @JsonIgnore
     var quietModeEnd: LocalTime? = null,
-
     @Column(name = "pause_until")
     var pauseUntil: LocalDateTime? = null,
-
     @Column(name = "daily_goal_ml", nullable = false)
     var dailyGoalMl: Int = 2000,
-
     @Column(name = "enabled", nullable = false)
-    var enabled: Boolean = true
+    var enabled: Boolean = true,
 ) {
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/entity/TelegramChatEntity.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/entity/TelegramChatEntity.kt
@@ -1,33 +1,42 @@
 package ru.illine.drinking.ponies.model.entity
 
-import jakarta.persistence.*
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
 
 @Entity
 @Table(
     name = "telegram_chats",
-    indexes = [Index(
-        name = "telegram_chats_external_chat_id_unique_index",
-        columnList = "external_chat_id",
-        unique = true
-    )]
+    indexes = [
+        Index(
+            name = "telegram_chats_external_chat_id_unique_index",
+            columnList = "external_chat_id",
+            unique = true,
+        ),
+    ],
 )
 class TelegramChatEntity(
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "telegramChatSeqGenerator")
     @SequenceGenerator(
         name = "telegramChatSeqGenerator",
         sequenceName = "telegram_chat_seq",
-        allocationSize = 1
+        allocationSize = 1,
     )
     var id: Long? = null,
-
     @Column(name = "external_chat_id", nullable = false)
     var externalChatId: Long,
-
     @Column(name = "previous_notification_external_message_id")
     var previousNotificationMessageId: Int? = null,
-
     @ManyToOne(
         fetch = FetchType.LAZY,
         cascade = [CascadeType.MERGE, CascadeType.REFRESH],

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/entity/TelegramUserEntity.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/entity/TelegramUserEntity.kt
@@ -1,7 +1,19 @@
 package ru.illine.drinking.ponies.model.entity
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import jakarta.persistence.*
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OneToOne
+import jakarta.persistence.PreRemove
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 import java.time.LocalDateTime
@@ -9,37 +21,36 @@ import java.time.LocalDateTime
 @Entity
 @Table(
     name = "telegram_users",
-    indexes = [Index(name = "telegram_users_external_user_id_unique_index", columnList = "external_user_id", unique = true)]
+    indexes = [
+        Index(
+            name = "telegram_users_external_user_id_unique_index",
+            columnList = "external_user_id",
+            unique = true,
+        ),
+    ],
 )
 @SQLDelete(sql = "update telegram_users set deleted = true where id = ?")
 @SQLRestriction(value = "deleted = false")
 class TelegramUserEntity(
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "telegramUserSeqGenerator")
     @SequenceGenerator(
         name = "telegramUserSeqGenerator",
         sequenceName = "telegram_user_seq",
-        allocationSize = 1
+        allocationSize = 1,
     )
     var id: Long? = null,
-
     @Column(name = "external_user_id", nullable = false)
     var externalUserId: Long,
-
     @Column(name = "user_time_zone", nullable = false)
     var userTimeZone: String,
-
     @Column(name = "is_admin", nullable = false)
     var isAdmin: Boolean = false,
-
     @Column(name = "created", nullable = false, updatable = false)
     @JsonIgnore
     var created: LocalDateTime = LocalDateTime.now(),
-
     @Column(name = "deleted", nullable = false)
     var deleted: Boolean = false,
-
     @OneToMany(
         fetch = FetchType.LAZY,
         mappedBy = "telegramUser",
@@ -47,14 +58,13 @@ class TelegramUserEntity(
         cascade = [CascadeType.ALL],
     )
     val telegramChats: MutableSet<TelegramChatEntity> = mutableSetOf(),
-
     @OneToOne(
         fetch = FetchType.LAZY,
         mappedBy = "telegramUser",
         orphanRemoval = true,
         cascade = [CascadeType.ALL],
     )
-    var notificationSettings: NotificationSettingEntity? = null
+    var notificationSettings: NotificationSettingEntity? = null,
 ) {
     @PreRemove
     private fun onDelete() {

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/entity/WaterStatisticEntity.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/entity/WaterStatisticEntity.kt
@@ -1,6 +1,19 @@
 package ru.illine.drinking.ponies.model.entity
 
-import jakarta.persistence.*
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
 import java.time.LocalDateTime
@@ -8,42 +21,34 @@ import java.time.LocalDateTime
 @Entity
 @Table(
     name = "water_statistics",
-    indexes = [Index(name = "water_statistics_user_id_event_time_index", columnList = "user_id, event_time")]
+    indexes = [Index(name = "water_statistics_user_id_event_time_index", columnList = "user_id, event_time")],
 )
 class WaterStatisticEntity(
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "waterStatisticsSeqGenerator")
     @SequenceGenerator(
         name = "waterStatisticsSeqGenerator",
         sequenceName = "water_statistics_seq",
-        allocationSize = 1
+        allocationSize = 1,
     )
     var id: Long? = null,
-
     @ManyToOne(
         fetch = FetchType.LAZY,
         cascade = [CascadeType.MERGE, CascadeType.REFRESH],
     )
     @JoinColumn(name = "user_id", nullable = false)
     var telegramUser: TelegramUserEntity,
-
     @Column(name = "event_time", nullable = false)
     var eventTime: LocalDateTime,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "event_type", nullable = false)
     var eventType: AnswerNotificationType,
-
     @Column(name = "water_amount_ml", nullable = false)
     var waterAmountMl: Int = 0,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "source", nullable = false)
-    var source: WaterEntrySourceType = WaterEntrySourceType.NOTIFICATION
-
+    var source: WaterEntrySourceType = WaterEntrySourceType.NOTIFICATION,
 ) {
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -67,5 +72,4 @@ class WaterStatisticEntity(
         result = 31 * result + source.hashCode()
         return result
     }
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/scheduler/NotificationScheduler.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/scheduler/NotificationScheduler.kt
@@ -12,11 +12,8 @@ import ru.illine.drinking.ponies.service.notification.NotificationTimeService
 class NotificationScheduler(
     private val notificationSettingsService: NotificationSettingsService,
     private val notificationSenderService: NotificationSenderService,
-    private val notificationTimeService: NotificationTimeService
+    private val notificationTimeService: NotificationTimeService,
 ) {
-
-    private val MAX_REMINDED_NOTIFICATION_ATTEMPTS = 3
-
     private val logger = LoggerFactory.getLogger("SCHEDULER")
 
     @Scheduled(cron = "\${telegram-bot.schedule.notification.cron}")
@@ -24,11 +21,13 @@ class NotificationScheduler(
         logger.info("Starting drinking notification scheduler")
 
         try {
-            val (exhaustedNotifications, activeNotifications) = notificationSettingsService.getAllNotificationSettings()
-                .filter { it.enabled }
-                .filter(notificationTimeService::isOutsideQuietTime)
-                .filter { notificationTimeService.isNotificationDue(it) }
-                .partition { it.notificationAttempts == MAX_REMINDED_NOTIFICATION_ATTEMPTS }
+            val (exhaustedNotifications, activeNotifications) =
+                notificationSettingsService
+                    .getAllNotificationSettings()
+                    .filter { it.enabled }
+                    .filter(notificationTimeService::isOutsideQuietTime)
+                    .filter { notificationTimeService.isNotificationDue(it) }
+                    .partition { it.notificationAttempts == MAX_REMINDED_NOTIFICATION_ATTEMPTS }
 
             cancelAll(exhaustedNotifications)
             notifyAll(activeNotifications)
@@ -55,5 +54,9 @@ class NotificationScheduler(
 
         logger.info("Suspending notifications for [{}] users (max attempts reached)", notifications.size)
         notificationSenderService.suspendNotifications(notifications)
+    }
+
+    companion object {
+        private const val MAX_REMINDED_NOTIFICATION_ATTEMPTS = 3
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactory.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactory.kt
@@ -1,7 +1,5 @@
 package ru.illine.drinking.ponies.service.button
 
 fun interface ReplyButtonFactory {
-
     fun getStrategy(queryData: String): ReplyButtonStrategy
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonStrategy.kt
@@ -3,7 +3,6 @@ package ru.illine.drinking.ponies.service.button
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 
 interface ReplyButtonStrategy {
-
     fun reply(callbackQuery: CallbackQuery)
 
     fun isQueryData(queryData: String): Boolean

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/impl/ReplyButtonFactoryImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/impl/ReplyButtonFactoryImpl.kt
@@ -6,11 +6,9 @@ import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
 
 @Service
 class ReplyButtonFactoryImpl(
-    private val strategies: List<ReplyButtonStrategy>
+    private val strategies: List<ReplyButtonStrategy>,
 ) : ReplyButtonFactory {
-
-    override fun getStrategy(queryData: String): ReplyButtonStrategy {
-        return strategies.find { it.isQueryData(queryData) }
+    override fun getStrategy(queryData: String): ReplyButtonStrategy =
+        strategies.find { it.isQueryData(queryData) }
             ?: throw IllegalArgumentException("Unknown query data: $queryData")
-    }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/AbstractAnswerNotificationReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/AbstractAnswerNotificationReplyButtonStrategy.kt
@@ -7,33 +7,32 @@ import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
-import java.util.*
+import java.util.Objects
 
 abstract class AbstractAnswerNotificationReplyButtonStrategy<T>(
     private val messageSender: TelegramClient,
-    private val messageEditorService: MessageEditorService
+    private val messageEditorService: MessageEditorService,
 ) : ReplyButtonStrategy {
-
     override fun reply(callbackQuery: CallbackQuery) {
         editNotification(callbackQuery)
 
         updateLastNotificationTime(callbackQuery).invoke()
 
         SendMessage(
-            callbackQuery.message.chatId.toString(), getMessageText()
+            callbackQuery.message.chatId.toString(),
+            getMessageText(),
         ).apply { messageSender.execute(this) }
     }
 
-    override fun isQueryData(queryData: String): Boolean {
-        return Objects.equals(getAnswerType().queryData.toString(), queryData)
-    }
+    override fun isQueryData(queryData: String): Boolean =
+        Objects.equals(getAnswerType().queryData.toString(), queryData)
 
     protected fun editNotification(callbackQuery: CallbackQuery) {
         messageEditorService.editReplyMarkup(
             TelegramMessageConstants.NOTIFICATION_QUESTION_EDITED_MESSAGE_PATTERN.format(getAnswerType().displayName),
             callbackQuery.message.chatId,
             callbackQuery.message.messageId,
-            true
+            true,
         )
     }
 
@@ -42,5 +41,4 @@ abstract class AbstractAnswerNotificationReplyButtonStrategy<T>(
     protected abstract fun getMessageText(): String
 
     protected abstract fun getAnswerType(): AnswerNotificationType
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategy.kt
@@ -20,25 +20,26 @@ class CancelAnswerNotificationReplyButtonStrategy(
     messageEditorService: MessageEditorService,
     private val notificationSettingsService: NotificationSettingsService,
     private val waterStatisticService: WaterStatisticService,
-    private val clock: Clock
+    private val clock: Clock,
 ) : AbstractAnswerNotificationReplyButtonStrategy<NotificationSettingDto>(sender, messageEditorService) {
-
     private val logger = LoggerFactory.getLogger("STRATEGY")
 
-    override fun updateLastNotificationTime(callbackQuery: CallbackQuery): () -> NotificationSettingDto = {
-        notificationSettingsService.resetNotificationTimer(callbackQuery.from.id, LocalDateTime.now(clock))
-            .also { setting ->
-                runCatching {
-                    waterStatisticService.recordEvent(setting.telegramUser, getAnswerType())
-                }.onFailure { e ->
-                    logger.error(
-                        "Failed to record water statistic for user [{}]",
-                        setting.telegramUser.externalUserId,
-                        e
-                    )
+    override fun updateLastNotificationTime(callbackQuery: CallbackQuery): () -> NotificationSettingDto =
+        {
+            notificationSettingsService
+                .resetNotificationTimer(callbackQuery.from.id, LocalDateTime.now(clock))
+                .also { setting ->
+                    runCatching {
+                        waterStatisticService.recordEvent(setting.telegramUser, getAnswerType())
+                    }.onFailure { e ->
+                        logger.error(
+                            "Failed to record water statistic for user [{}]",
+                            setting.telegramUser.externalUserId,
+                            e,
+                        )
+                    }
                 }
-            }
-    }
+        }
 
     override fun getMessageText(): String = TelegramMessageConstants.NOTIFICATION_ANSWER_CANCEL_MESSAGE
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategy.kt
@@ -9,34 +9,31 @@ import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.telegram.TelegramBotKeyboardHelper
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
-import java.util.*
+import java.util.Objects
 
 @Service
 class YesAnswerNotificationReplyButtonStrategy(
     private val sender: TelegramClient,
-    private val messageEditorService: MessageEditorService
+    private val messageEditorService: MessageEditorService,
 ) : ReplyButtonStrategy {
-
     override fun reply(callbackQuery: CallbackQuery) {
         val chatId = callbackQuery.message.chatId
         val messageId = callbackQuery.message.messageId
         val messageText =
             TelegramMessageConstants.NOTIFICATION_QUESTION_EDITED_MESSAGE_PATTERN.format(
-                AnswerNotificationType.YES.displayName
+                AnswerNotificationType.YES.displayName,
             )
 
         messageEditorService.editReplyMarkup(messageText, chatId, messageId, true)
 
         SendMessage(
             chatId.toString(),
-            TelegramMessageConstants.NOTIFICATION_WATER_AMOUNT_MENU_MESSAGE
+            TelegramMessageConstants.NOTIFICATION_WATER_AMOUNT_MENU_MESSAGE,
         ).apply {
             replyMarkup = TelegramBotKeyboardHelper.waterAmountButtons()
         }.apply { sender.execute(this) }
     }
 
-    override fun isQueryData(queryData: String): Boolean {
-        return Objects.equals(AnswerNotificationType.YES.queryData.toString(), queryData)
-    }
-
+    override fun isQueryData(queryData: String): Boolean =
+        Objects.equals(AnswerNotificationType.YES.queryData.toString(), queryData)
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategy.kt
@@ -21,15 +21,14 @@ class SnoozeApplyReplyButtonStrategy(
     private val notificationSettingsService: NotificationSettingsService,
     private val waterStatisticService: WaterStatisticService,
     private val messageEditorService: MessageEditorService,
-    private val clock: Clock
+    private val clock: Clock,
 ) : ReplyButtonStrategy {
-
     private val logger = LoggerFactory.getLogger("STRATEGY")
 
     override fun reply(callbackQuery: CallbackQuery) {
         messageEditorService.deleteReplyMarkup(
             callbackQuery.message.chatId,
-            callbackQuery.message.messageId
+            callbackQuery.message.messageId,
         )
 
         val externalUserId = callbackQuery.from.id
@@ -42,7 +41,7 @@ class SnoozeApplyReplyButtonStrategy(
             "A telegram user [{}] for telegram chat [{}] will snooze notification for [{}] minutes",
             externalUserId,
             chatId,
-            snoozeType.minutes
+            snoozeType.minutes,
         )
 
         val notificationSetting = notificationSettingsService.getNotificationSettings(externalUserId)
@@ -50,10 +49,11 @@ class SnoozeApplyReplyButtonStrategy(
             TimeHelper.nextNotificationTimeByNow(
                 clock,
                 notificationSetting.notificationInterval.minutes,
-                snoozeType.minutes
+                snoozeType.minutes,
             )
 
-        notificationSettingsService.resetNotificationTimer(externalUserId, nextNotificationTime)
+        notificationSettingsService
+            .resetNotificationTimer(externalUserId, nextNotificationTime)
             .also { setting ->
                 runCatching {
                     waterStatisticService.recordEvent(setting.telegramUser, AnswerNotificationType.SNOOZE)
@@ -61,17 +61,16 @@ class SnoozeApplyReplyButtonStrategy(
                     logger.error(
                         "Failed to record water statistic for user [{}]",
                         setting.telegramUser.externalUserId,
-                        e
+                        e,
                     )
                 }
             }
 
         SendMessage(
             chatId.toString(),
-            TelegramMessageConstants.NOTIFICATION_SUSPEND_MESSAGE.format(snoozeType.displayName)
+            TelegramMessageConstants.NOTIFICATION_SUSPEND_MESSAGE.format(snoozeType.displayName),
         ).apply { sender.execute(this) }
     }
 
     override fun isQueryData(queryData: String): Boolean = SnoozeNotificationType.typeOf(queryData) != null
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategy.kt
@@ -32,7 +32,7 @@ class SnoozeApplyReplyButtonStrategy(
             callbackQuery.message.messageId
         )
 
-        val userId = callbackQuery.from.id
+        val externalUserId = callbackQuery.from.id
         val chatId = callbackQuery.message.chatId
         val queryData = callbackQuery.data
 
@@ -40,12 +40,12 @@ class SnoozeApplyReplyButtonStrategy(
 
         logger.info(
             "A telegram user [{}] for telegram chat [{}] will snooze notification for [{}] minutes",
-            userId,
+            externalUserId,
             chatId,
             snoozeType.minutes
         )
 
-        val notificationSetting = notificationSettingsService.getNotificationSettings(userId)
+        val notificationSetting = notificationSettingsService.getNotificationSettings(externalUserId)
         val nextNotificationTime =
             TimeHelper.nextNotificationTimeByNow(
                 clock,
@@ -53,7 +53,7 @@ class SnoozeApplyReplyButtonStrategy(
                 snoozeType.minutes
             )
 
-        notificationSettingsService.resetNotificationTimer(userId, nextNotificationTime)
+        notificationSettingsService.resetNotificationTimer(externalUserId, nextNotificationTime)
             .also { setting ->
                 runCatching {
                     waterStatisticService.recordEvent(setting.telegramUser, AnswerNotificationType.SNOOZE)

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeMenuReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeMenuReplyButtonStrategy.kt
@@ -9,34 +9,31 @@ import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.util.telegram.TelegramBotKeyboardHelper
 import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
-import java.util.*
+import java.util.Objects
 
 @Service
 class SnoozeMenuReplyButtonStrategy(
     private val sender: TelegramClient,
-    private val messageEditorService: MessageEditorService
+    private val messageEditorService: MessageEditorService,
 ) : ReplyButtonStrategy {
-
     override fun reply(callbackQuery: CallbackQuery) {
         val chatId = callbackQuery.message.chatId
         val messageId = callbackQuery.message.messageId
         val messageText =
             TelegramMessageConstants.NOTIFICATION_QUESTION_EDITED_MESSAGE_PATTERN.format(
-                AnswerNotificationType.SNOOZE.displayName
+                AnswerNotificationType.SNOOZE.displayName,
             )
 
         messageEditorService.editReplyMarkup(messageText, chatId, messageId, true)
 
         SendMessage(
             chatId.toString(),
-            TelegramMessageConstants.NOTIFICATION_SNOOZE_MENU_MESSAGE
+            TelegramMessageConstants.NOTIFICATION_SNOOZE_MENU_MESSAGE,
         ).apply {
             replyMarkup = TelegramBotKeyboardHelper.snoozeTimeButtons()
         }.apply { sender.execute(this) }
     }
 
-    override fun isQueryData(queryData: String): Boolean {
-        return Objects.equals(AnswerNotificationType.SNOOZE.queryData.toString(), queryData)
-    }
-
+    override fun isQueryData(queryData: String): Boolean =
+        Objects.equals(AnswerNotificationType.SNOOZE.queryData.toString(), queryData)
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategy.kt
@@ -21,15 +21,14 @@ class WaterAmountApplyReplyButtonStrategy(
     private val notificationSettingsService: NotificationSettingsService,
     private val waterStatisticService: WaterStatisticService,
     private val messageEditorService: MessageEditorService,
-    private val clock: Clock
+    private val clock: Clock,
 ) : ReplyButtonStrategy {
-
     private val logger = LoggerFactory.getLogger("STRATEGY")
 
     override fun reply(callbackQuery: CallbackQuery) {
         messageEditorService.deleteReplyMarkup(
             callbackQuery.message.chatId,
-            callbackQuery.message.messageId
+            callbackQuery.message.messageId,
         )
 
         val externalUserId = callbackQuery.from.id
@@ -46,32 +45,32 @@ class WaterAmountApplyReplyButtonStrategy(
             "A telegram user [{}] for telegram chat [{}] drank [{}] ml of water",
             externalUserId,
             chatId,
-            waterAmountType.amountMl
+            waterAmountType.amountMl,
         )
 
-        notificationSettingsService.resetNotificationTimer(externalUserId, LocalDateTime.now(clock))
+        notificationSettingsService
+            .resetNotificationTimer(externalUserId, LocalDateTime.now(clock))
             .also { setting ->
                 runCatching {
                     waterStatisticService.recordEvent(
                         setting.telegramUser,
                         AnswerNotificationType.YES,
-                        waterAmountType.amountMl
+                        waterAmountType.amountMl,
                     )
                 }.onFailure { e ->
                     logger.error(
                         "Failed to record water statistic for user [{}]",
                         setting.telegramUser.externalUserId,
-                        e
+                        e,
                     )
                 }
             }
 
         SendMessage(
             chatId.toString(),
-            TelegramMessageConstants.NOTIFICATION_ANSWER_YES_MESSAGE
+            TelegramMessageConstants.NOTIFICATION_ANSWER_YES_MESSAGE,
         ).apply { sender.execute(this) }
     }
 
     override fun isQueryData(queryData: String): Boolean = WaterAmountType.typeOf(queryData) != null
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategy.kt
@@ -32,7 +32,7 @@ class WaterAmountApplyReplyButtonStrategy(
             callbackQuery.message.messageId
         )
 
-        val userId = callbackQuery.from.id
+        val externalUserId = callbackQuery.from.id
         val chatId = callbackQuery.message.chatId
         val queryData = callbackQuery.data
 
@@ -44,12 +44,12 @@ class WaterAmountApplyReplyButtonStrategy(
 
         logger.info(
             "A telegram user [{}] for telegram chat [{}] drank [{}] ml of water",
-            userId,
+            externalUserId,
             chatId,
             waterAmountType.amountMl
         )
 
-        notificationSettingsService.resetNotificationTimer(userId, LocalDateTime.now(clock))
+        notificationSettingsService.resetNotificationTimer(externalUserId, LocalDateTime.now(clock))
             .also { setting ->
                 runCatching {
                     waterStatisticService.recordEvent(

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/command/CommandService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/command/CommandService.kt
@@ -1,7 +1,5 @@
 package ru.illine.drinking.ponies.service.command
 
 fun interface CommandService {
-
     fun register()
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/command/impl/CommandServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/command/impl/CommandServiceImpl.kt
@@ -13,9 +13,8 @@ import ru.illine.drinking.ponies.util.telegram.TelegramMenuConstants
 @Service
 class CommandServiceImpl(
     private val telegramBotProperties: TelegramBotProperties,
-    private val sender: TelegramClient
+    private val sender: TelegramClient,
 ) : CommandService {
-
     private val logger = LoggerFactory.getLogger("SERVICE")
 
     override fun register() {
@@ -31,11 +30,14 @@ class CommandServiceImpl(
     }
 
     private fun registerMenu() {
-        val menuButton = MenuButtonWebApp.builder()
-            .text(TelegramMenuConstants.MENU_BUTTON_TEXT)
-            .webAppInfo(WebAppInfo.builder().url(telegramBotProperties.miniAppUrl).build())
-            .build()
-        SetChatMenuButton.builder()
+        val menuButton =
+            MenuButtonWebApp
+                .builder()
+                .text(TelegramMenuConstants.MENU_BUTTON_TEXT)
+                .webAppInfo(WebAppInfo.builder().url(telegramBotProperties.miniAppUrl).build())
+                .build()
+        SetChatMenuButton
+            .builder()
             .menuButton(menuButton)
             .build()
             .apply { sender.execute(this) }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/message/MessageProvider.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/message/MessageProvider.kt
@@ -5,7 +5,8 @@ import ru.illine.drinking.ponies.model.dto.message.MessageDto
 import ru.illine.drinking.ponies.util.message.MessageSpec
 
 interface MessageProvider {
-
-    fun <C : MessageContext> getMessage(spec: MessageSpec<C>, context: C): MessageDto
-
+    fun <C : MessageContext> getMessage(
+        spec: MessageSpec<C>,
+        context: C,
+    ): MessageDto
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/message/impl/LocalMessageProvider.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/message/impl/LocalMessageProvider.kt
@@ -12,25 +12,28 @@ import kotlin.random.Random
 
 @Service
 class LocalMessageProvider(
-    private val random: Random
+    private val random: Random,
 ) : MessageProvider {
-
     private val rulesBySpec: Map<MessageSpec<*>, List<RuleBucket<*>>> =
         mapOf(MessageSpec.InsightStats to LocalInsightStats.PHRASES)
 
-    override fun <C : MessageContext> getMessage(spec: MessageSpec<C>, context: C): MessageDto {
+    override fun <C : MessageContext> getMessage(
+        spec: MessageSpec<C>,
+        context: C,
+    ): MessageDto {
         @Suppress("UNCHECKED_CAST")
-        val buckets = rulesBySpec[spec] as? List<RuleBucket<C>>
-            ?: throw MessageTemplateException("No local templates registered for message spec [${spec.id}]")
+        val buckets =
+            rulesBySpec[spec] as? List<RuleBucket<C>>
+                ?: throw MessageTemplateException("No local templates registered for message spec [${spec.id}]")
         // Guarantee comes from a `{ true }` fallback bucket placed after the specific ones.
         // Explicit error makes a missing fallback fail loudly instead of throwing a bare NoSuchElementException.
-        val candidates = buckets.firstNotNullOfOrNull { bucket ->
-            bucket.filter { it.predicate(context) }.takeIf { it.isNotEmpty() }
-        } ?: throw MessageTemplateException(
-            "No matching rule for message spec [${spec.id}] - is the fallback bucket missing?"
-        )
+        val candidates =
+            buckets.firstNotNullOfOrNull { bucket ->
+                bucket.filter { it.predicate(context) }.takeIf { it.isNotEmpty() }
+            } ?: throw MessageTemplateException(
+                "No matching rule for message spec [${spec.id}] - is the fallback bucket missing?",
+            )
         val rule = candidates.random(random)
         return MessageDto(text = rule.templates.random(random)(context))
     }
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderService.kt
@@ -3,9 +3,7 @@ package ru.illine.drinking.ponies.service.notification
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 
 interface NotificationSenderService {
-
     fun sendNotifications(notifications: Collection<NotificationSettingDto>)
 
     fun suspendNotifications(notifications: Collection<NotificationSettingDto>)
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationService.kt
@@ -3,7 +3,5 @@ package ru.illine.drinking.ponies.service.notification
 import org.telegram.telegrambots.abilitybots.api.objects.MessageContext
 
 interface NotificationService {
-
     fun start(messageContext: MessageContext)
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsService.kt
@@ -10,36 +10,36 @@ import java.time.LocalTime
 
 interface NotificationSettingsService {
 
-    fun getAllSettings(telegramUserId: Long): SettingDto
+    fun getAllSettings(externalUserId: Long): SettingDto
 
-    fun getNextNotificationAt(telegramUserId: Long): Instant
+    fun getNextNotificationAt(externalUserId: Long): Instant
 
-    fun getNotificationSettings(telegramUserId: Long): NotificationSettingDto
+    fun getNotificationSettings(externalUserId: Long): NotificationSettingDto
 
     fun getAllNotificationSettings(): Collection<NotificationSettingDto>
 
-    fun getQuietMode(telegramUserId: Long): Pair<LocalTime, LocalTime>
+    fun getQuietMode(externalUserId: Long): Pair<LocalTime, LocalTime>
 
-    fun resetNotificationTimer(telegramUserId: Long, time: LocalDateTime): NotificationSettingDto
+    fun resetNotificationTimer(externalUserId: Long, time: LocalDateTime): NotificationSettingDto
 
-    fun changeInterval(telegramUserId: Long, notificationInterval: IntervalNotificationType): NotificationSettingDto
+    fun changeInterval(externalUserId: Long, notificationInterval: IntervalNotificationType): NotificationSettingDto
 
-    fun changeQuietMode(userId: Long, start: LocalTime, end: LocalTime)
+    fun changeQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime)
 
-    fun disableQuietMode(userId: Long)
+    fun disableQuietMode(externalUserId: Long)
 
-    fun isEnabledNotifications(telegramUserId: Long): Boolean
+    fun isEnabledNotifications(externalUserId: Long): Boolean
 
-    fun changeNotificationStatus(telegramUserId: Long, active: Boolean)
+    fun changeNotificationStatus(externalUserId: Long, active: Boolean)
 
-    fun changeTimezone(telegramUserId: Long, timezone: String)
+    fun changeTimezone(externalUserId: Long, timezone: String)
 
-    fun pauseNotifications(telegramUserId: Long, minutes: Long)
+    fun pauseNotifications(externalUserId: Long, minutes: Long)
 
-    fun cancelPause(telegramUserId: Long)
+    fun cancelPause(externalUserId: Long)
 
-    fun getPauseState(telegramUserId: Long): PauseStateResponse
+    fun getPauseState(externalUserId: Long): PauseStateResponse
 
-    fun changeDailyGoal(telegramUserId: Long, goalMl: Int)
+    fun changeDailyGoal(externalUserId: Long, goalMl: Int)
 
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsService.kt
@@ -9,7 +9,6 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 
 interface NotificationSettingsService {
-
     fun getAllSettings(externalUserId: Long): SettingDto
 
     fun getNextNotificationAt(externalUserId: Long): Instant
@@ -20,26 +19,47 @@ interface NotificationSettingsService {
 
     fun getQuietMode(externalUserId: Long): Pair<LocalTime, LocalTime>
 
-    fun resetNotificationTimer(externalUserId: Long, time: LocalDateTime): NotificationSettingDto
+    fun resetNotificationTimer(
+        externalUserId: Long,
+        time: LocalDateTime,
+    ): NotificationSettingDto
 
-    fun changeInterval(externalUserId: Long, notificationInterval: IntervalNotificationType): NotificationSettingDto
+    fun changeInterval(
+        externalUserId: Long,
+        notificationInterval: IntervalNotificationType,
+    ): NotificationSettingDto
 
-    fun changeQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime)
+    fun changeQuietMode(
+        externalUserId: Long,
+        start: LocalTime,
+        end: LocalTime,
+    )
 
     fun disableQuietMode(externalUserId: Long)
 
     fun isEnabledNotifications(externalUserId: Long): Boolean
 
-    fun changeNotificationStatus(externalUserId: Long, active: Boolean)
+    fun changeNotificationStatus(
+        externalUserId: Long,
+        active: Boolean,
+    )
 
-    fun changeTimezone(externalUserId: Long, timezone: String)
+    fun changeTimezone(
+        externalUserId: Long,
+        timezone: String,
+    )
 
-    fun pauseNotifications(externalUserId: Long, minutes: Long)
+    fun pauseNotifications(
+        externalUserId: Long,
+        minutes: Long,
+    )
 
     fun cancelPause(externalUserId: Long)
 
     fun getPauseState(externalUserId: Long): PauseStateResponse
 
-    fun changeDailyGoal(externalUserId: Long, goalMl: Int)
-
+    fun changeDailyGoal(
+        externalUserId: Long,
+        goalMl: Int,
+    )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationTimeService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationTimeService.kt
@@ -4,11 +4,9 @@ import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import java.time.Instant
 
 interface NotificationTimeService {
-
     fun isOutsideQuietTime(dto: NotificationSettingDto): Boolean
 
     fun isNotificationDue(dto: NotificationSettingDto): Boolean
 
     fun calculateNextNotificationAt(dto: NotificationSettingDto): Instant
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSenderServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSenderServiceImpl.kt
@@ -27,7 +27,6 @@ class NotificationSenderServiceImpl(
     private val waterStatisticService: WaterStatisticService,
     private val clock: Clock,
 ) : NotificationSenderService {
-
     private val logger = LoggerFactory.getLogger("SERVICE")
 
     override fun sendNotifications(notifications: Collection<NotificationSettingDto>) {
@@ -38,21 +37,26 @@ class NotificationSenderServiceImpl(
 
         deletePreviousNotificationMessages(notifications)
 
-        val sent = notifications.filter {
-            sendOrDisableOnBlock(it) {
-                ++it.notificationAttempts
-                it.timeOfLastNotification = TimeHelper.nextNotificationTimeByNow(
-                    clock, it.notificationInterval.minutes, telegramBotProperties.notification.retryIntervalMinutes
-                )
-                it.telegramChat.previousNotificationMessageId =
-                    SendMessage(
-                        it.telegramChat.externalChatId.toString(),
-                        TelegramMessageConstants.NOTIFICATION_QUESTION_MESSAGE
-                    ).apply {
-                        replyMarkup = TelegramBotKeyboardHelper.notifyButtons()
-                    }.let { sender.execute(it) }.messageId
+        val sent =
+            notifications.filter {
+                sendOrDisableOnBlock(it) {
+                    ++it.notificationAttempts
+                    it.timeOfLastNotification =
+                        TimeHelper.nextNotificationTimeByNow(
+                            clock,
+                            it.notificationInterval.minutes,
+                            telegramBotProperties.notification.retryIntervalMinutes,
+                        )
+                    it.telegramChat.previousNotificationMessageId =
+                        SendMessage(
+                            it.telegramChat.externalChatId.toString(),
+                            TelegramMessageConstants.NOTIFICATION_QUESTION_MESSAGE,
+                        ).apply {
+                            replyMarkup = TelegramBotKeyboardHelper.notifyButtons()
+                        }.let { sender.execute(it) }
+                            .messageId
+                }
             }
-        }
 
         notificationAccessService.updateNotificationSettings(sent)
     }
@@ -65,37 +69,43 @@ class NotificationSenderServiceImpl(
 
         deletePreviousNotificationMessages(notifications)
 
-        val sent = notifications.filter {
-            sendOrDisableOnBlock(it) {
-                SendMessage(
-                    it.telegramChat.externalChatId.toString(),
-                    TelegramMessageConstants.NOTIFICATION_SUSPEND_MESSAGE.format(it.notificationInterval.displayName)
-                ).apply {
-                    disableNotification = true
-                }.apply { sender.execute(this) }
+        val sent =
+            notifications.filter {
+                sendOrDisableOnBlock(it) {
+                    SendMessage(
+                        it.telegramChat.externalChatId.toString(),
+                        TelegramMessageConstants.NOTIFICATION_SUSPEND_MESSAGE.format(
+                            it.notificationInterval.displayName,
+                        ),
+                    ).apply {
+                        disableNotification = true
+                    }.apply { sender.execute(this) }
 
-                it.notificationAttempts = 0
-                it.timeOfLastNotification = LocalDateTime.now(clock)
-                it.telegramChat.previousNotificationMessageId = null
+                    it.notificationAttempts = 0
+                    it.timeOfLastNotification = LocalDateTime.now(clock)
+                    it.telegramChat.previousNotificationMessageId = null
+                }
             }
-        }
 
         notificationAccessService.updateNotificationSettings(sent)
         waterStatisticService.recordEvents(
             sent.map { it.telegramUser },
-            AnswerNotificationType.CANCEL
+            AnswerNotificationType.CANCEL,
         )
     }
 
-    private fun sendOrDisableOnBlock(notification: NotificationSettingDto, send: () -> Unit): Boolean {
-        return try {
+    private fun sendOrDisableOnBlock(
+        notification: NotificationSettingDto,
+        send: () -> Unit,
+    ): Boolean =
+        try {
             send()
             true
         } catch (e: TelegramApiRequestException) {
             if (e.errorCode == 403) {
                 logger.warn(
                     "User (externalUserId: [{}]) blocked the bot, disabling notifications",
-                    notification.telegramUser.externalUserId
+                    notification.telegramUser.externalUserId,
                 )
                 notificationAccessService.updateNotificationsDisabled(notification.telegramUser.externalUserId)
                 false
@@ -103,15 +113,15 @@ class NotificationSenderServiceImpl(
                 throw e
             }
         }
-    }
 
     private fun deletePreviousNotificationMessages(settings: Collection<NotificationSettingDto>) {
         logger.info("Deleting all old notifications messages...")
 
-        val messageInfo = settings
-            .filter { it.telegramChat.previousNotificationMessageId != null }
-            .map { Pair(it.telegramChat.externalChatId, it.telegramChat.previousNotificationMessageId!!) }
-            .toList()
+        val messageInfo =
+            settings
+                .filter { it.telegramChat.previousNotificationMessageId != null }
+                .map { Pair(it.telegramChat.externalChatId, it.telegramChat.previousNotificationMessageId!!) }
+                .toList()
 
         logger.info("Found [${messageInfo.size}] the old notification messages")
         logger.debug("The old messages: \n{}", messageInfo)

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSenderServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSenderServiceImpl.kt
@@ -97,7 +97,7 @@ class NotificationSenderServiceImpl(
                     "User (externalUserId: [{}]) blocked the bot, disabling notifications",
                     notification.telegramUser.externalUserId
                 )
-                notificationAccessService.disableNotifications(notification.telegramUser.externalUserId)
+                notificationAccessService.updateNotificationsDisabled(notification.telegramUser.externalUserId)
                 false
             } else {
                 throw e

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
@@ -27,15 +27,15 @@ class NotificationServiceImpl(
             TelegramMessageConstants.START_GREETING_MESSAGE.format(messageContext.user().userName)
         ).apply { sender.execute(this) }
 
-        val userId = messageContext.user().id
+        val externalUserId = messageContext.user().id
         val chatId = messageContext.chatId()
 
-        val setting = notificationAccessService.existsByTelegramUserId(userId).check(
+        val setting = notificationAccessService.existsByExternalUserId(externalUserId).check(
             ifTrue = {
-                notificationAccessService.findNotificationSettingByTelegramUserId(userId)
+                notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
             },
             ifFalse = {
-                createNewUser(userId, chatId)
+                createNewUser(externalUserId, chatId)
             }
         )
 
@@ -46,14 +46,14 @@ class NotificationServiceImpl(
     }
 
     private fun createNewUser(
-        userId: Long,
+        externalUserId: Long,
         chatId: Long
     ): NotificationSettingDto {
-        val user = TelegramUserDto.create(userId)
+        val user = TelegramUserDto.create(externalUserId)
         val chat = TelegramChatDto.create(chatId, user)
         val setting = NotificationSettingDto.create(user, chat)
 
         notificationAccessService.save(user, chat, setting)
-        return notificationAccessService.findNotificationSettingByTelegramUserId(userId)
+        return notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
@@ -16,38 +16,38 @@ import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
 @Service
 class NotificationServiceImpl(
     private val sender: TelegramClient,
-    private val notificationAccessService: NotificationAccessService
+    private val notificationAccessService: NotificationAccessService,
 ) : NotificationService {
-
     private val logger = LoggerFactory.getLogger("SERVICE")
 
     override fun start(messageContext: MessageContext) {
         SendMessage(
             messageContext.chatId().toString(),
-            TelegramMessageConstants.START_GREETING_MESSAGE.format(messageContext.user().userName)
+            TelegramMessageConstants.START_GREETING_MESSAGE.format(messageContext.user().userName),
         ).apply { sender.execute(this) }
 
         val externalUserId = messageContext.user().id
         val chatId = messageContext.chatId()
 
-        val setting = notificationAccessService.existsByExternalUserId(externalUserId).check(
-            ifTrue = {
-                notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
-            },
-            ifFalse = {
-                createNewUser(externalUserId, chatId)
-            }
-        )
+        val setting =
+            notificationAccessService.existsByExternalUserId(externalUserId).check(
+                ifTrue = {
+                    notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
+                },
+                ifFalse = {
+                    createNewUser(externalUserId, chatId)
+                },
+            )
 
         SendMessage(
             messageContext.chatId().toString(),
-            TelegramMessageConstants.START_DEFAULT_SETTINGS_MESSAGE.format(setting.notificationInterval.displayName)
+            TelegramMessageConstants.START_DEFAULT_SETTINGS_MESSAGE.format(setting.notificationInterval.displayName),
         ).apply { sender.execute(this) }
     }
 
     private fun createNewUser(
         externalUserId: Long,
-        chatId: Long
+        chatId: Long,
     ): NotificationSettingDto {
         val user = TelegramUserDto.create(externalUserId)
         val chat = TelegramChatDto.create(chatId, user)

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSettingsServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSettingsServiceImpl.kt
@@ -2,8 +2,8 @@ package ru.illine.drinking.ponies.service.notification.impl
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import ru.illine.drinking.ponies.builder.SettingBuilder
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.mapper.SettingMapper
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.dto.SettingDto
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
@@ -39,7 +39,7 @@ class NotificationSettingsServiceImpl(
         }
 
         logger.debug("Settings for externalUserId [$externalUserId] has been enabled")
-        return getNotificationSettings(externalUserId).let { SettingBuilder.toDto(it) }
+        return getNotificationSettings(externalUserId).let { SettingMapper.toDto(it) }
     }
 
     override fun getNotificationSettings(externalUserId: Long): NotificationSettingDto {

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSettingsServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSettingsServiceImpl.kt
@@ -12,7 +12,11 @@ import ru.illine.drinking.ponies.service.notification.NotificationSettingsServic
 import ru.illine.drinking.ponies.service.notification.NotificationTimeService
 import ru.illine.drinking.ponies.util.statistics.toUtcInstant
 import ru.illine.drinking.ponies.util.telegram.TelegramDailyGoalConstants
-import java.time.*
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
 
 @Service
 class NotificationSettingsServiceImpl(
@@ -20,7 +24,6 @@ class NotificationSettingsServiceImpl(
     private val notificationTimeService: NotificationTimeService,
     private val clock: Clock,
 ) : NotificationSettingsService {
-
     private val logger = LoggerFactory.getLogger("SERVICE")
 
     override fun getNextNotificationAt(externalUserId: Long): Instant {
@@ -66,20 +69,27 @@ class NotificationSettingsServiceImpl(
         return start to end
     }
 
-    override fun resetNotificationTimer(externalUserId: Long, time: LocalDateTime): NotificationSettingDto {
+    override fun resetNotificationTimer(
+        externalUserId: Long,
+        time: LocalDateTime,
+    ): NotificationSettingDto {
         logger.info("Resetting notification timer for telegram user [$externalUserId] to [$time]")
         return notificationAccessService.updateTimeOfLastNotification(externalUserId, time)
     }
 
     override fun changeInterval(
         externalUserId: Long,
-        notificationInterval: IntervalNotificationType
+        notificationInterval: IntervalNotificationType,
     ): NotificationSettingDto {
         logger.info("Changing notification interval for telegram user [$externalUserId] to [$notificationInterval]")
         return notificationAccessService.updateNotificationSettings(externalUserId, notificationInterval)
     }
 
-    override fun changeQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime) {
+    override fun changeQuietMode(
+        externalUserId: Long,
+        start: LocalTime,
+        end: LocalTime,
+    ) {
         logger.info("Change time of quiet mode for telegram user [$externalUserId], start: [$start], end: [$end]")
         require(start != end) { "Start must be before end" }
         notificationAccessService.updateQuietMode(externalUserId, start, end)
@@ -95,7 +105,10 @@ class NotificationSettingsServiceImpl(
         return notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)
     }
 
-    override fun changeNotificationStatus(externalUserId: Long, active: Boolean) {
+    override fun changeNotificationStatus(
+        externalUserId: Long,
+        active: Boolean,
+    ) {
         logger.info("Changing notification status for telegram user [$externalUserId] to [$active]")
         if (active) {
             notificationAccessService.updateNotificationsEnabled(externalUserId)
@@ -104,7 +117,10 @@ class NotificationSettingsServiceImpl(
         }
     }
 
-    override fun changeTimezone(externalUserId: Long, timezone: String) {
+    override fun changeTimezone(
+        externalUserId: Long,
+        timezone: String,
+    ) {
         logger.info("Changing timezone for telegram user [$externalUserId] to [$timezone]")
         try {
             ZoneId.of(timezone)
@@ -114,7 +130,10 @@ class NotificationSettingsServiceImpl(
         notificationAccessService.updateTimezone(externalUserId, timezone)
     }
 
-    override fun pauseNotifications(externalUserId: Long, minutes: Long) {
+    override fun pauseNotifications(
+        externalUserId: Long,
+        minutes: Long,
+    ) {
         logger.info("Pausing notifications for telegram user [$externalUserId] for [$minutes] minutes")
         require(minutes > 0) { "Pause duration must be positive: $minutes" }
         val pauseUntil = LocalDateTime.now(clock).plusMinutes(minutes)
@@ -126,7 +145,10 @@ class NotificationSettingsServiceImpl(
         notificationAccessService.updatePause(externalUserId, null)
     }
 
-    override fun changeDailyGoal(externalUserId: Long, goalMl: Int) {
+    override fun changeDailyGoal(
+        externalUserId: Long,
+        goalMl: Int,
+    ) {
         logger.info("Changing daily goal for telegram user [$externalUserId] to [$goalMl] ml")
         require(goalMl in TelegramDailyGoalConstants.ALLOWED_VALUES_ML) {
             "Daily goal must be one of ${TelegramDailyGoalConstants.ALLOWED_VALUES_ML} ml, got: $goalMl"
@@ -138,12 +160,13 @@ class NotificationSettingsServiceImpl(
         logger.info("Getting pause state for telegram user [$externalUserId]")
         val settings = notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
         val now = LocalDateTime.now(clock)
-        val activePauseUntil = settings.pauseUntil
-            ?.takeIf { it.isAfter(now) }
-            ?.toUtcInstant()
+        val activePauseUntil =
+            settings.pauseUntil
+                ?.takeIf { it.isAfter(now) }
+                ?.toUtcInstant()
         return PauseStateResponse(
             paused = activePauseUntil != null,
-            pauseUntil = activePauseUntil
+            pauseUntil = activePauseUntil,
         )
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSettingsServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSettingsServiceImpl.kt
@@ -23,28 +23,28 @@ class NotificationSettingsServiceImpl(
 
     private val logger = LoggerFactory.getLogger("SERVICE")
 
-    override fun getNextNotificationAt(telegramUserId: Long): Instant {
-        logger.info("Getting next notification time for telegram user [$telegramUserId]")
-        val settings = notificationAccessService.findNotificationSettingByTelegramUserId(telegramUserId)
+    override fun getNextNotificationAt(externalUserId: Long): Instant {
+        logger.info("Getting next notification time for telegram user [$externalUserId]")
+        val settings = notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
         return notificationTimeService.calculateNextNotificationAt(settings)
     }
 
-    override fun getAllSettings(telegramUserId: Long): SettingDto {
-        logger.info("Getting all notification settings for telegram user [$telegramUserId]")
+    override fun getAllSettings(externalUserId: Long): SettingDto {
+        logger.info("Getting all notification settings for telegram user [$externalUserId]")
 
-        val active = notificationAccessService.isEnabledNotifications(telegramUserId)
+        val active = notificationAccessService.isEnabledNotifications(externalUserId)
         if (!active) {
-            logger.debug("Not enabled notifications for telegramUserId [$telegramUserId], returning empty settings")
+            logger.debug("Not enabled notifications for externalUserId [$externalUserId], returning empty settings")
             return SettingDto(notificationActive = false)
         }
 
-        logger.debug("Settings for telegramUserId [$telegramUserId] has been enabled")
-        return getNotificationSettings(telegramUserId).let { SettingBuilder.toDto(it) }
+        logger.debug("Settings for externalUserId [$externalUserId] has been enabled")
+        return getNotificationSettings(externalUserId).let { SettingBuilder.toDto(it) }
     }
 
-    override fun getNotificationSettings(telegramUserId: Long): NotificationSettingDto {
-        logger.info("Getting notification settings for telegram user [$telegramUserId]")
-        return notificationAccessService.findNotificationSettingByTelegramUserId(telegramUserId)
+    override fun getNotificationSettings(externalUserId: Long): NotificationSettingDto {
+        logger.info("Getting notification settings for telegram user [$externalUserId]")
+        return notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
     }
 
     override fun getAllNotificationSettings(): Collection<NotificationSettingDto> {
@@ -52,91 +52,91 @@ class NotificationSettingsServiceImpl(
         return notificationAccessService.findAllNotificationSettings()
     }
 
-    override fun getQuietMode(telegramUserId: Long): Pair<LocalTime, LocalTime> {
-        logger.info("Getting quiet mode for telegram user [$telegramUserId]")
-        val settings = notificationAccessService.findNotificationSettingByTelegramUserId(telegramUserId)
+    override fun getQuietMode(externalUserId: Long): Pair<LocalTime, LocalTime> {
+        logger.info("Getting quiet mode for telegram user [$externalUserId]")
+        val settings = notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
         val start =
             checkNotNull(settings.quietModeStart) {
-                "Quiet mode start is not configured for user [$telegramUserId]"
+                "Quiet mode start is not configured for user [$externalUserId]"
             }
         val end =
             checkNotNull(settings.quietModeEnd) {
-                "Quiet mode end is not configured for user [$telegramUserId]"
+                "Quiet mode end is not configured for user [$externalUserId]"
             }
         return start to end
     }
 
-    override fun resetNotificationTimer(telegramUserId: Long, time: LocalDateTime): NotificationSettingDto {
-        logger.info("Resetting notification timer for telegram user [$telegramUserId] to [$time]")
-        return notificationAccessService.updateTimeOfLastNotification(telegramUserId, time)
+    override fun resetNotificationTimer(externalUserId: Long, time: LocalDateTime): NotificationSettingDto {
+        logger.info("Resetting notification timer for telegram user [$externalUserId] to [$time]")
+        return notificationAccessService.updateTimeOfLastNotification(externalUserId, time)
     }
 
     override fun changeInterval(
-        telegramUserId: Long,
+        externalUserId: Long,
         notificationInterval: IntervalNotificationType
     ): NotificationSettingDto {
-        logger.info("Changing notification interval for telegram user [$telegramUserId] to [$notificationInterval]")
-        return notificationAccessService.updateNotificationSettings(telegramUserId, notificationInterval)
+        logger.info("Changing notification interval for telegram user [$externalUserId] to [$notificationInterval]")
+        return notificationAccessService.updateNotificationSettings(externalUserId, notificationInterval)
     }
 
-    override fun changeQuietMode(userId: Long, start: LocalTime, end: LocalTime) {
-        logger.info("Change time of quiet mode for telegram user [$userId], start: [$start], end: [$end]")
+    override fun changeQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime) {
+        logger.info("Change time of quiet mode for telegram user [$externalUserId], start: [$start], end: [$end]")
         require(start != end) { "Start must be before end" }
-        notificationAccessService.changeQuietMode(userId, start, end)
+        notificationAccessService.changeQuietMode(externalUserId, start, end)
     }
 
-    override fun disableQuietMode(userId: Long) {
-        logger.info("Disabling quiet mode for user [$userId]")
-        notificationAccessService.disableQuietMode(userId)
+    override fun disableQuietMode(externalUserId: Long) {
+        logger.info("Disabling quiet mode for user [$externalUserId]")
+        notificationAccessService.disableQuietMode(externalUserId)
     }
 
-    override fun isEnabledNotifications(telegramUserId: Long): Boolean {
-        logger.info("Checking if notifications are enabled for telegram user [$telegramUserId]")
-        return notificationAccessService.isEnabledNotifications(telegramUserId)
+    override fun isEnabledNotifications(externalUserId: Long): Boolean {
+        logger.info("Checking if notifications are enabled for telegram user [$externalUserId]")
+        return notificationAccessService.isEnabledNotifications(externalUserId)
     }
 
-    override fun changeNotificationStatus(telegramUserId: Long, active: Boolean) {
-        logger.info("Changing notification status for telegram user [$telegramUserId] to [$active]")
+    override fun changeNotificationStatus(externalUserId: Long, active: Boolean) {
+        logger.info("Changing notification status for telegram user [$externalUserId] to [$active]")
         if (active) {
-            notificationAccessService.enableNotifications(telegramUserId)
+            notificationAccessService.enableNotifications(externalUserId)
         } else {
-            notificationAccessService.disableNotifications(telegramUserId)
+            notificationAccessService.disableNotifications(externalUserId)
         }
     }
 
-    override fun changeTimezone(telegramUserId: Long, timezone: String) {
-        logger.info("Changing timezone for telegram user [$telegramUserId] to [$timezone]")
+    override fun changeTimezone(externalUserId: Long, timezone: String) {
+        logger.info("Changing timezone for telegram user [$externalUserId] to [$timezone]")
         try {
             ZoneId.of(timezone)
         } catch (e: Exception) {
             throw IllegalArgumentException("Invalid timezone: $timezone", e)
         }
-        notificationAccessService.changeTimezone(telegramUserId, timezone)
+        notificationAccessService.changeTimezone(externalUserId, timezone)
     }
 
-    override fun pauseNotifications(telegramUserId: Long, minutes: Long) {
-        logger.info("Pausing notifications for telegram user [$telegramUserId] for [$minutes] minutes")
+    override fun pauseNotifications(externalUserId: Long, minutes: Long) {
+        logger.info("Pausing notifications for telegram user [$externalUserId] for [$minutes] minutes")
         require(minutes > 0) { "Pause duration must be positive: $minutes" }
         val pauseUntil = LocalDateTime.now(clock).plusMinutes(minutes)
-        notificationAccessService.setPause(telegramUserId, pauseUntil)
+        notificationAccessService.setPause(externalUserId, pauseUntil)
     }
 
-    override fun cancelPause(telegramUserId: Long) {
-        logger.info("Cancelling pause for telegram user [$telegramUserId]")
-        notificationAccessService.setPause(telegramUserId, null)
+    override fun cancelPause(externalUserId: Long) {
+        logger.info("Cancelling pause for telegram user [$externalUserId]")
+        notificationAccessService.setPause(externalUserId, null)
     }
 
-    override fun changeDailyGoal(telegramUserId: Long, goalMl: Int) {
-        logger.info("Changing daily goal for telegram user [$telegramUserId] to [$goalMl] ml")
+    override fun changeDailyGoal(externalUserId: Long, goalMl: Int) {
+        logger.info("Changing daily goal for telegram user [$externalUserId] to [$goalMl] ml")
         require(goalMl in TelegramDailyGoalConstants.ALLOWED_VALUES_ML) {
             "Daily goal must be one of ${TelegramDailyGoalConstants.ALLOWED_VALUES_ML} ml, got: $goalMl"
         }
-        notificationAccessService.updateDailyGoal(telegramUserId, goalMl)
+        notificationAccessService.updateDailyGoal(externalUserId, goalMl)
     }
 
-    override fun getPauseState(telegramUserId: Long): PauseStateResponse {
-        logger.info("Getting pause state for telegram user [$telegramUserId]")
-        val settings = notificationAccessService.findNotificationSettingByTelegramUserId(telegramUserId)
+    override fun getPauseState(externalUserId: Long): PauseStateResponse {
+        logger.info("Getting pause state for telegram user [$externalUserId]")
+        val settings = notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
         val now = LocalDateTime.now(clock)
         val activePauseUntil = settings.pauseUntil
             ?.takeIf { it.isAfter(now) }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSettingsServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSettingsServiceImpl.kt
@@ -32,7 +32,7 @@ class NotificationSettingsServiceImpl(
     override fun getAllSettings(externalUserId: Long): SettingDto {
         logger.info("Getting all notification settings for telegram user [$externalUserId]")
 
-        val active = notificationAccessService.isEnabledNotifications(externalUserId)
+        val active = notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)
         if (!active) {
             logger.debug("Not enabled notifications for externalUserId [$externalUserId], returning empty settings")
             return SettingDto(notificationActive = false)
@@ -82,25 +82,25 @@ class NotificationSettingsServiceImpl(
     override fun changeQuietMode(externalUserId: Long, start: LocalTime, end: LocalTime) {
         logger.info("Change time of quiet mode for telegram user [$externalUserId], start: [$start], end: [$end]")
         require(start != end) { "Start must be before end" }
-        notificationAccessService.changeQuietMode(externalUserId, start, end)
+        notificationAccessService.updateQuietMode(externalUserId, start, end)
     }
 
     override fun disableQuietMode(externalUserId: Long) {
         logger.info("Disabling quiet mode for user [$externalUserId]")
-        notificationAccessService.disableQuietMode(externalUserId)
+        notificationAccessService.updateQuietModeDisabled(externalUserId)
     }
 
     override fun isEnabledNotifications(externalUserId: Long): Boolean {
         logger.info("Checking if notifications are enabled for telegram user [$externalUserId]")
-        return notificationAccessService.isEnabledNotifications(externalUserId)
+        return notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)
     }
 
     override fun changeNotificationStatus(externalUserId: Long, active: Boolean) {
         logger.info("Changing notification status for telegram user [$externalUserId] to [$active]")
         if (active) {
-            notificationAccessService.enableNotifications(externalUserId)
+            notificationAccessService.updateNotificationsEnabled(externalUserId)
         } else {
-            notificationAccessService.disableNotifications(externalUserId)
+            notificationAccessService.updateNotificationsDisabled(externalUserId)
         }
     }
 
@@ -111,19 +111,19 @@ class NotificationSettingsServiceImpl(
         } catch (e: Exception) {
             throw IllegalArgumentException("Invalid timezone: $timezone", e)
         }
-        notificationAccessService.changeTimezone(externalUserId, timezone)
+        notificationAccessService.updateTimezone(externalUserId, timezone)
     }
 
     override fun pauseNotifications(externalUserId: Long, minutes: Long) {
         logger.info("Pausing notifications for telegram user [$externalUserId] for [$minutes] minutes")
         require(minutes > 0) { "Pause duration must be positive: $minutes" }
         val pauseUntil = LocalDateTime.now(clock).plusMinutes(minutes)
-        notificationAccessService.setPause(externalUserId, pauseUntil)
+        notificationAccessService.updatePause(externalUserId, pauseUntil)
     }
 
     override fun cancelPause(externalUserId: Long) {
         logger.info("Cancelling pause for telegram user [$externalUserId]")
-        notificationAccessService.setPause(externalUserId, null)
+        notificationAccessService.updatePause(externalUserId, null)
     }
 
     override fun changeDailyGoal(externalUserId: Long, goalMl: Int) {

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationTimeServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationTimeServiceImpl.kt
@@ -5,18 +5,25 @@ import org.springframework.stereotype.Service
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.service.notification.NotificationTimeService
 import ru.illine.drinking.ponies.util.statistics.toUtcInstant
-import java.time.*
+import java.time.Clock
+import java.time.DateTimeException
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 
 @Suppress("IDENTITY_SENSITIVE_OPERATIONS_WITH_VALUE_TYPE")
 @Service
-class NotificationTimeServiceImpl(private val clock: Clock) : NotificationTimeService {
-
+class NotificationTimeServiceImpl(
+    private val clock: Clock,
+) : NotificationTimeService {
     companion object {
         private const val NEXT_DAY_OFFSET = 1L
     }
-    
+
     private val logger = LoggerFactory.getLogger("SERVICE")
-    
+
     override fun isOutsideQuietTime(dto: NotificationSettingDto): Boolean {
         logger.debug("Checking quiet mode for user id: [{}]", dto.id)
 
@@ -51,7 +58,7 @@ class NotificationTimeServiceImpl(private val clock: Clock) : NotificationTimeSe
         val nextNotificationTime = dto.timeOfLastNotification.plusMinutes(dto.notificationInterval.minutes)
         logger.debug("Next scheduled notification (UTC): [{}]", nextNotificationTime)
 
-        val isDue =  nextNotificationTime <= now
+        val isDue = nextNotificationTime <= now
         logger.debug("Notification due: [{}]", isDue)
 
         return isDue
@@ -79,11 +86,12 @@ class NotificationTimeServiceImpl(private val clock: Clock) : NotificationTimeSe
         val isAtOrAfterStart = !rawNextUserTime.isBefore(quietStart)
         val isAtOrBeforeEnd = !rawNextUserTime.isAfter(quietEnd)
 
-        val isInQuietMode = if (quietStart.isBefore(quietEnd)) {
-            isAtOrAfterStart && isAtOrBeforeEnd
-        } else {
-            isAtOrAfterStart || isAtOrBeforeEnd
-        }
+        val isInQuietMode =
+            if (quietStart.isBefore(quietEnd)) {
+                isAtOrAfterStart && isAtOrBeforeEnd
+            } else {
+                isAtOrAfterStart || isAtOrBeforeEnd
+            }
         logger.debug("Quiet mode [{} - {}], in quiet mode: [{}]", quietStart, quietEnd, isInQuietMode)
 
         if (!isInQuietMode) {
@@ -109,16 +117,17 @@ class NotificationTimeServiceImpl(private val clock: Clock) : NotificationTimeSe
 
         return userTime
     }
-    
-    private fun resolveZoneId(dto: NotificationSettingDto): ZoneId {
-        return try {
+
+    private fun resolveZoneId(dto: NotificationSettingDto): ZoneId =
+        try {
             ZoneId.of(dto.telegramUser.userTimeZone)
         } catch (e: DateTimeException) {
             logger.error(
                 "Invalid timezone for user [{}]: [{}], error: {}. Fallback to UTC.",
-                dto.id, dto.telegramUser.userTimeZone, e.message
+                dto.id,
+                dto.telegramUser.userTimeZone,
+                e.message,
             )
             ZoneId.of("UTC")
         }
-    }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsService.kt
@@ -6,8 +6,8 @@ import java.time.LocalDate
 
 interface StatisticsService {
 
-    fun getToday(telegramUserId: Long): List<WaterStatisticDto>
+    fun getToday(externalUserId: Long): List<WaterStatisticDto>
 
-    fun getStatistics(telegramUserId: Long, from: LocalDate, to: LocalDate): StatisticsDto
+    fun getStatistics(externalUserId: Long, from: LocalDate, to: LocalDate): StatisticsDto
 
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsService.kt
@@ -5,9 +5,11 @@ import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import java.time.LocalDate
 
 interface StatisticsService {
-
     fun getToday(externalUserId: Long): List<WaterStatisticDto>
 
-    fun getStatistics(externalUserId: Long, from: LocalDate, to: LocalDate): StatisticsDto
-
+    fun getStatistics(
+        externalUserId: Long,
+        from: LocalDate,
+        to: LocalDate,
+    ): StatisticsDto
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticService.kt
@@ -5,11 +5,20 @@ import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
 import java.time.Instant
 
 interface WaterStatisticService {
+    fun recordEvent(
+        telegramUser: TelegramUserDto,
+        eventType: AnswerNotificationType,
+        waterAmountMl: Int = 0,
+    )
 
-    fun recordEvent(telegramUser: TelegramUserDto, eventType: AnswerNotificationType, waterAmountMl: Int = 0)
+    fun recordEvents(
+        telegramUsers: Collection<TelegramUserDto>,
+        eventType: AnswerNotificationType,
+    )
 
-    fun recordEvents(telegramUsers: Collection<TelegramUserDto>, eventType: AnswerNotificationType)
-
-    fun manualRecordEvent(externalUserId: Long, consumedAt: Instant?, amountMl: Int)
-
+    fun manualRecordEvent(
+        externalUserId: Long,
+        consumedAt: Instant?,
+        amountMl: Int,
+    )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/impl/StatisticsServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/impl/StatisticsServiceImpl.kt
@@ -27,7 +27,6 @@ class StatisticsServiceImpl(
     private val messageProvider: MessageProvider,
     private val clock: Clock,
 ) : StatisticsService {
-
     private val logger = LoggerFactory.getLogger("SERVICE")
 
     // Returns RAW events (unfiltered by YES) for the home widget's per-event diary.
@@ -41,7 +40,11 @@ class StatisticsServiceImpl(
         return waterStatisticAccessService.findByUserAndEventTimeBetween(externalUserId, startInclusive, endExclusive)
     }
 
-    override fun getStatistics(externalUserId: Long, from: LocalDate, to: LocalDate): StatisticsDto {
+    override fun getStatistics(
+        externalUserId: Long,
+        from: LocalDate,
+        to: LocalDate,
+    ): StatisticsDto {
         logger.debug("Getting [{} - {}] statistics for telegram user [{}]", from, to, externalUserId)
 
         require(from <= to) { "Invalid parameter: 'from' must be before or equal to 'to'" }
@@ -64,29 +67,32 @@ class StatisticsServiceImpl(
         val byDate = StatisticsAggregator.sumByLocalDate(allEvents, ctx.zone)
 
         // Points are built from events in the requested [from..to] window only.
-        val rangeEvents = allEvents.filter {
-            val date = StatisticsPeriodHelper.toLocal(it.eventTime, ctx.zone).toLocalDate()
-            !date.isBefore(from) && !date.isAfter(to)
-        }
-        val points = if (from == to) {
-            StatisticsAggregator.aggregateByHour(rangeEvents, ctx.zone)
-        } else {
-            StatisticsAggregator.aggregateByDay(byDate, from, days)
-        }
+        val rangeEvents =
+            allEvents.filter {
+                val date = StatisticsPeriodHelper.toLocal(it.eventTime, ctx.zone).toLocalDate()
+                !date.isBefore(from) && !date.isAfter(to)
+            }
+        val points =
+            if (from == to) {
+                StatisticsAggregator.aggregateByHour(rangeEvents, ctx.zone)
+            } else {
+                StatisticsAggregator.aggregateByDay(byDate, from, days)
+            }
 
         val bestDay = StatisticsAggregator.bestDay(days, byDate.filterKeys { !it.isBefore(from) && !it.isAfter(to) })
         val averageMlPerDay = StatisticsAggregator.averageMlPerDay(days, points)
         val currentStreakDays = StatisticsAggregator.calculateStreak(byDate, ctx.today, ctx.settings.dailyGoalMl)
 
-        val insight = messageProvider.getMessage(
-            MessageSpec.InsightStats,
-            InsightStatsContext(
-                averageMlPerDay,
-                bestDay,
-                currentStreakDays,
-                ctx.settings.dailyGoalMl
+        val insight =
+            messageProvider.getMessage(
+                MessageSpec.InsightStats,
+                InsightStatsContext(
+                    averageMlPerDay,
+                    bestDay,
+                    currentStreakDays,
+                    ctx.settings.dailyGoalMl,
+                ),
             )
-        )
         val firstEntryAt = waterStatisticAccessService.findEarliestEventTimeByUser(externalUserId)?.toUtcInstant()
 
         return StatisticsDto(
@@ -96,7 +102,7 @@ class StatisticsServiceImpl(
             bestDay = bestDay,
             currentStreakDays = currentStreakDays,
             insightText = insight.text,
-            firstEntryAt = firstEntryAt
+            firstEntryAt = firstEntryAt,
         )
     }
 
@@ -104,10 +110,11 @@ class StatisticsServiceImpl(
         externalUserId: Long,
         startLocal: LocalDate,
         endLocalExclusive: LocalDate,
-        zone: ZoneId
+        zone: ZoneId,
     ): List<WaterStatisticDto> {
         val (startUtc, endUtc) = StatisticsPeriodHelper.localDayBoundsToUtc(startLocal, endLocalExclusive, zone)
-        return waterStatisticAccessService.findByUserAndEventTimeBetween(externalUserId, startUtc, endUtc)
+        return waterStatisticAccessService
+            .findByUserAndEventTimeBetween(externalUserId, startUtc, endUtc)
             .filter { it.eventType == AnswerNotificationType.YES }
     }
 
@@ -121,7 +128,6 @@ class StatisticsServiceImpl(
     private data class UserTimeContext(
         val settings: NotificationSettingDto,
         val zone: ZoneId,
-        val today: LocalDate
+        val today: LocalDate,
     )
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/impl/StatisticsServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/impl/StatisticsServiceImpl.kt
@@ -31,22 +31,22 @@ class StatisticsServiceImpl(
     private val logger = LoggerFactory.getLogger("SERVICE")
 
     // Returns RAW events (unfiltered by YES) for the home widget's per-event diary.
-    override fun getToday(telegramUserId: Long): List<WaterStatisticDto> {
-        logger.debug("Getting today entries for telegram user [{}]", telegramUserId)
+    override fun getToday(externalUserId: Long): List<WaterStatisticDto> {
+        logger.debug("Getting today entries for telegram user [{}]", externalUserId)
 
-        val ctx = userTimeContext(telegramUserId)
+        val ctx = userTimeContext(externalUserId)
         val (startInclusive, endExclusive) =
             StatisticsPeriodHelper.localDayBoundsToUtc(ctx.today, ctx.today.plusDays(1), ctx.zone)
 
-        return waterStatisticAccessService.findByUserAndEventTimeBetween(telegramUserId, startInclusive, endExclusive)
+        return waterStatisticAccessService.findByUserAndEventTimeBetween(externalUserId, startInclusive, endExclusive)
     }
 
-    override fun getStatistics(telegramUserId: Long, from: LocalDate, to: LocalDate): StatisticsDto {
-        logger.debug("Getting [{} - {}] statistics for telegram user [{}]", from, to, telegramUserId)
+    override fun getStatistics(externalUserId: Long, from: LocalDate, to: LocalDate): StatisticsDto {
+        logger.debug("Getting [{} - {}] statistics for telegram user [{}]", from, to, externalUserId)
 
         require(from <= to) { "Invalid parameter: 'from' must be before or equal to 'to'" }
 
-        val ctx = userTimeContext(telegramUserId)
+        val ctx = userTimeContext(externalUserId)
 
         require(from <= ctx.today) { "Invalid parameter: 'from' must not be in the future" }
 
@@ -60,7 +60,7 @@ class StatisticsServiceImpl(
         val fetchStart = minOf(from, streakWindowStart)
         val fetchEndExclusive = maxOf(to, ctx.today).plusDays(1)
 
-        val allEvents = fetchYesEvents(telegramUserId, fetchStart, fetchEndExclusive, ctx.zone)
+        val allEvents = fetchYesEvents(externalUserId, fetchStart, fetchEndExclusive, ctx.zone)
         val byDate = StatisticsAggregator.sumByLocalDate(allEvents, ctx.zone)
 
         // Points are built from events in the requested [from..to] window only.
@@ -87,7 +87,7 @@ class StatisticsServiceImpl(
                 ctx.settings.dailyGoalMl
             )
         )
-        val firstEntryAt = waterStatisticAccessService.findEarliestEventTimeByUser(telegramUserId)?.toUtcInstant()
+        val firstEntryAt = waterStatisticAccessService.findEarliestEventTimeByUser(externalUserId)?.toUtcInstant()
 
         return StatisticsDto(
             points = points,
@@ -101,18 +101,18 @@ class StatisticsServiceImpl(
     }
 
     private fun fetchYesEvents(
-        telegramUserId: Long,
+        externalUserId: Long,
         startLocal: LocalDate,
         endLocalExclusive: LocalDate,
         zone: ZoneId
     ): List<WaterStatisticDto> {
         val (startUtc, endUtc) = StatisticsPeriodHelper.localDayBoundsToUtc(startLocal, endLocalExclusive, zone)
-        return waterStatisticAccessService.findByUserAndEventTimeBetween(telegramUserId, startUtc, endUtc)
+        return waterStatisticAccessService.findByUserAndEventTimeBetween(externalUserId, startUtc, endUtc)
             .filter { it.eventType == AnswerNotificationType.YES }
     }
 
-    private fun userTimeContext(telegramUserId: Long): UserTimeContext {
-        val settings = notificationAccessService.findNotificationSettingByTelegramUserId(telegramUserId)
+    private fun userTimeContext(externalUserId: Long): UserTimeContext {
+        val settings = notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
         val zone = ZoneId.of(settings.telegramUser.userTimeZone)
         val today = LocalDate.now(clock.withZone(zone))
         return UserTimeContext(settings, zone, today)

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/impl/WaterStatisticServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/impl/WaterStatisticServiceImpl.kt
@@ -18,17 +18,20 @@ import java.time.temporal.ChronoUnit
 @Service
 class WaterStatisticServiceImpl(
     private val waterStatisticAccessService: WaterStatisticAccessService,
-    private val clock: Clock
+    private val clock: Clock,
 ) : WaterStatisticService {
-
     private val logger = LoggerFactory.getLogger("SERVICE")
 
-    override fun recordEvent(telegramUser: TelegramUserDto, eventType: AnswerNotificationType, waterAmountMl: Int) {
+    override fun recordEvent(
+        telegramUser: TelegramUserDto,
+        eventType: AnswerNotificationType,
+        waterAmountMl: Int,
+    ) {
         logger.info(
             "Recording water statistic event [{}] for user [{}], amount [{}] ml",
             eventType,
             telegramUser.externalUserId,
-            waterAmountMl
+            waterAmountMl,
         )
 
         waterStatisticAccessService.save(
@@ -36,12 +39,15 @@ class WaterStatisticServiceImpl(
                 telegramUser = telegramUser,
                 eventTime = LocalDateTime.now(clock),
                 eventType = eventType,
-                waterAmountMl = waterAmountMl
-            )
+                waterAmountMl = waterAmountMl,
+            ),
         )
     }
 
-    override fun recordEvents(telegramUsers: Collection<TelegramUserDto>, eventType: AnswerNotificationType) {
+    override fun recordEvents(
+        telegramUsers: Collection<TelegramUserDto>,
+        eventType: AnswerNotificationType,
+    ) {
         logger.info("Recording [{}] water statistic events with type [{}]", telegramUsers.size, eventType)
 
         waterStatisticAccessService.saveAll(
@@ -49,36 +55,41 @@ class WaterStatisticServiceImpl(
                 WaterStatisticDto(
                     telegramUser = it,
                     eventTime = LocalDateTime.now(clock),
-                    eventType = eventType
+                    eventType = eventType,
                 )
-            }
+            },
         )
     }
 
-    override fun manualRecordEvent(externalUserId: Long, consumedAt: Instant?, amountMl: Int) {
+    override fun manualRecordEvent(
+        externalUserId: Long,
+        consumedAt: Instant?,
+        amountMl: Int,
+    ) {
         require(amountMl.toLong() in WaterEntryConstants.MIN_ML..WaterEntryConstants.MAX_ML) {
             "Water amount must be between ${WaterEntryConstants.MIN_ML} and ${WaterEntryConstants.MAX_ML} ml, got: $amountMl"
         }
 
         val now = Instant.now(clock)
-        val eventInstant = consumedAt?.also {
-            require(!it.isAfter(now)) {
-                "consumedAt must not be in the future, got: $it (now: $now)"
-            }
-            require(
-                !it.isBefore(
-                    now.minus(WaterEntryConstants.MAX_DAYS_AGO, ChronoUnit.DAYS)
-                )
-            ) {
-                "consumedAt must not be older than ${WaterEntryConstants.MAX_DAYS_AGO} days, got: $it"
-            }
-        } ?: now.also { logger.debug("consumedAt not passed, now will be used") }
+        val eventInstant =
+            consumedAt?.also {
+                require(!it.isAfter(now)) {
+                    "consumedAt must not be in the future, got: $it (now: $now)"
+                }
+                require(
+                    !it.isBefore(
+                        now.minus(WaterEntryConstants.MAX_DAYS_AGO, ChronoUnit.DAYS),
+                    ),
+                ) {
+                    "consumedAt must not be older than ${WaterEntryConstants.MAX_DAYS_AGO} days, got: $it"
+                }
+            } ?: now.also { logger.debug("consumedAt not passed, now will be used") }
 
         logger.info(
             "Recording manual water entry for user [{}], amount [{}] ml at [{}]",
             externalUserId,
             amountMl,
-            eventInstant
+            eventInstant,
         )
 
         waterStatisticAccessService.save(
@@ -87,9 +98,8 @@ class WaterStatisticServiceImpl(
                 eventTime = LocalDateTime.ofInstant(eventInstant, ZoneOffset.UTC),
                 eventType = AnswerNotificationType.YES,
                 waterAmountMl = amountMl,
-                source = WaterEntrySourceType.MANUAL
-            )
+                source = WaterEntrySourceType.MANUAL,
+            ),
         )
     }
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/telegram/MessageEditorService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/telegram/MessageEditorService.kt
@@ -3,18 +3,23 @@ package ru.illine.drinking.ponies.service.telegram
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup
 
 interface MessageEditorService {
-
-    fun deleteReplyMarkup(chatId: Long, messageId: Int)
+    fun deleteReplyMarkup(
+        chatId: Long,
+        messageId: Int,
+    )
 
     fun editReplyMarkup(
         newText: String,
         chatId: Long,
         messageId: Int,
         enableMarkDown: Boolean = false,
-        replyKeyboard: InlineKeyboardMarkup? = null
+        replyKeyboard: InlineKeyboardMarkup? = null,
     )
 
-    fun deleteMessage(chatId: Long, messageId: Int)
+    fun deleteMessage(
+        chatId: Long,
+        messageId: Int,
+    )
 
     fun deleteMessage(messageInfo: Pair<Long, Int>)
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/telegram/TelegramValidatorService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/telegram/TelegramValidatorService.kt
@@ -3,9 +3,7 @@ package ru.illine.drinking.ponies.service.telegram
 import ru.illine.drinking.ponies.model.dto.TelegramUserDto
 
 interface TelegramValidatorService {
-
     fun verifySignature(initData: String): Boolean
 
     fun map(initData: String): TelegramUserDto
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/telegram/impl/MessageEditorServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/telegram/impl/MessageEditorServiceImpl.kt
@@ -12,18 +12,19 @@ import ru.illine.drinking.ponies.util.FunctionHelper
 
 @Service
 class MessageEditorServiceImpl(
-    private val sender: TelegramClient
+    private val sender: TelegramClient,
 ) : MessageEditorService {
-
     private val logger = LoggerFactory.getLogger("SERVICE")
 
-    override fun deleteReplyMarkup(chatId: Long, messageId: Int) {
+    override fun deleteReplyMarkup(
+        chatId: Long,
+        messageId: Int,
+    ) {
         EditMessageReplyMarkup()
             .apply {
                 setChatId(chatId)
                 setMessageId(messageId)
-            }
-            .apply { sender.execute(this) }
+            }.apply { sender.execute(this) }
     }
 
     override fun editReplyMarkup(
@@ -31,40 +32,42 @@ class MessageEditorServiceImpl(
         chatId: Long,
         messageId: Int,
         enableMarkDown: Boolean,
-        replyKeyboard: InlineKeyboardMarkup?
+        replyKeyboard: InlineKeyboardMarkup?,
     ) {
         deleteReplyMarkup(chatId, messageId)
 
         EditMessageText(
-            newText
+            newText,
         ).apply {
-                setChatId(chatId)
-                setMessageId(messageId)
-                enableMarkdown(enableMarkDown)
-                setReplyMarkup(replyKeyboard)
+            setChatId(chatId)
+            setMessageId(messageId)
+            enableMarkdown(enableMarkDown)
+            setReplyMarkup(replyKeyboard)
         }.apply { sender.execute(this) }
-
     }
 
-    override fun deleteMessage(chatId: Long, messageId: Int) {
+    override fun deleteMessage(
+        chatId: Long,
+        messageId: Int,
+    ) {
         deleteMessage(Pair(chatId, messageId))
     }
 
     override fun deleteMessage(messageInfo: Pair<Long, Int>) {
         DeleteMessage(
             messageInfo.first.toString(),
-            messageInfo.second
+            messageInfo.second,
         ).apply {
-                FunctionHelper.catchAny(
-                    action = { sender.execute(this) },
-                    errorLogging = {
-                        logger.error(
-                            "A previous message can't be deleted! A chatId: [${this.chatId}], messageId: [${this.messageId}]",
-                            it
-                        )
-                    }
-                )
-            }
+            FunctionHelper.catchAny(
+                action = { sender.execute(this) },
+                errorLogging = {
+                    logger.error(
+                        "A previous message can't be deleted! A chatId: [${this.chatId}], messageId: [${this.messageId}]",
+                        it,
+                    )
+                },
+            )
+        }
     }
 
     override fun deleteMessages(messageInfo: Collection<Pair<Long, Int>>) {

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/telegram/impl/TelegramValidatorServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/telegram/impl/TelegramValidatorServiceImpl.kt
@@ -17,9 +17,8 @@ import java.time.Duration
 
 @Service
 class TelegramValidatorServiceImpl(
-    private val telegramBotProperties: TelegramBotProperties
+    private val telegramBotProperties: TelegramBotProperties,
 ) : TelegramValidatorService {
-
     private val logger = LoggerFactory.getLogger("SERVICE")
 
     private val objectMapper = jacksonObjectMapper()

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/FunctionHelper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/FunctionHelper.kt
@@ -1,10 +1,9 @@
 package ru.illine.drinking.ponies.util
 
 object FunctionHelper {
-
     inline fun <T> Boolean.check(
         ifTrue: Boolean.() -> T,
-        ifFalse: Boolean.() -> T
+        ifFalse: Boolean.() -> T,
     ) = when (this) {
         true -> ifTrue()
         false -> ifFalse()
@@ -13,7 +12,7 @@ object FunctionHelper {
     inline fun catchAny(
         action: () -> Unit,
         ifException: (Exception) -> Unit = {},
-        errorLogging: (Exception) -> Unit = {}
+        errorLogging: (Exception) -> Unit = {},
     ) {
         try {
             action()
@@ -26,13 +25,12 @@ object FunctionHelper {
     inline fun <T> catchAnyWithReturn(
         action: () -> T,
         noinline ifException: ((Exception) -> T?)? = null,
-        errorLogging: (Exception) -> Unit = {}
-    ): T? {
-        return try {
+        errorLogging: (Exception) -> Unit = {},
+    ): T? =
+        try {
             action()
         } catch (e: Exception) {
             errorLogging(e)
             ifException?.invoke(e)
         }
-    }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/PluralizationHelper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/PluralizationHelper.kt
@@ -1,7 +1,6 @@
 package ru.illine.drinking.ponies.util
 
 object PluralizationHelper {
-
     fun pluralizeDays(n: Int): String {
         val abs = if (n < 0) -n else n
         val mod100 = abs % 100

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/TimeHelper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/TimeHelper.kt
@@ -6,7 +6,6 @@ import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
 object TimeHelper {
-
     const val DEFAULT_TIME_PATTERN = "HH:mm"
 
     val DEFAULT_TIME_FORMATTER = DateTimeFormatter.ofPattern(DEFAULT_TIME_PATTERN)
@@ -19,7 +18,11 @@ object TimeHelper {
     // To make the next notification fire exactly snoozeMinutes from now:
     //   timeOfLastNotification + interval = now + snoozeMinutes
     //   timeOfLastNotification = now - interval + snoozeMinutes
-    fun nextNotificationTimeByNow(clock: Clock, intervalMinutes: Long, snoozeMinutes: Long): LocalDateTime {
+    fun nextNotificationTimeByNow(
+        clock: Clock,
+        intervalMinutes: Long,
+        snoozeMinutes: Long,
+    ): LocalDateTime {
         val now = LocalDateTime.now(clock)
         return now.minusMinutes(intervalMinutes).plusMinutes(snoozeMinutes)
     }

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/message/MessageSpec.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/message/MessageSpec.kt
@@ -4,9 +4,7 @@ import ru.illine.drinking.ponies.model.dto.message.InsightStatsContext
 import ru.illine.drinking.ponies.model.dto.message.MessageContext
 
 sealed class MessageSpec<C : MessageContext>(
-    val id: String
+    val id: String,
 ) {
-
     object InsightStats : MessageSpec<InsightStatsContext>(id = "insight_stats")
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/message/TemplateRule.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/message/TemplateRule.kt
@@ -7,11 +7,9 @@ typealias RuleBucket<C> = List<TemplateRule<C>>
 
 data class TemplateRule<C : MessageContext>(
     val predicate: (C) -> Boolean,
-    val templates: List<(C) -> String>
+    val templates: List<(C) -> String>,
 ) {
-
     init {
         require(templates.isNotEmpty()) { "TemplateRule must have at least one template" }
     }
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalInsightStats.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalInsightStats.kt
@@ -6,69 +6,83 @@ import ru.illine.drinking.ponies.util.message.RuleBucket
 import ru.illine.drinking.ponies.util.message.TemplateRule
 
 object LocalInsightStats {
-
-    val PHRASES: List<RuleBucket<InsightStatsContext>> = listOf(
-        // Specific signals
+    val PHRASES: List<RuleBucket<InsightStatsContext>> =
         listOf(
-            TemplateRule(
-                predicate = { it.currentStreakDays in 2..6 },
-                templates = listOf(
-                    { "${it.currentStreakDays} ${pluralizeDays(it.currentStreakDays)} подряд - поняши заметили!" },
-                    { "${it.currentStreakDays} ${pluralizeDays(it.currentStreakDays)} - и ритм пошёл!" },
-                )
+            // Specific signals
+            listOf(
+                TemplateRule(
+                    predicate = { it.currentStreakDays in 2..6 },
+                    templates =
+                        listOf(
+                            {
+                                "${it.currentStreakDays} ${pluralizeDays(
+                                    it.currentStreakDays,
+                                )} подряд - поняши заметили!"
+                            },
+                            { "${it.currentStreakDays} ${pluralizeDays(it.currentStreakDays)} - и ритм пошёл!" },
+                        ),
+                ),
+                TemplateRule(
+                    predicate = { it.currentStreakDays in 7..13 },
+                    templates =
+                        listOf(
+                            {
+                                "${it.currentStreakDays} ${pluralizeDays(
+                                    it.currentStreakDays,
+                                )} - это уже не случайность!"
+                            },
+                            { "Столько дней выпивать норму подряд - чувствуешь как вырабатывается привычка?" },
+                        ),
+                ),
+                TemplateRule(
+                    predicate = { it.currentStreakDays >= 14 },
+                    templates =
+                        listOf(
+                            { "${it.currentStreakDays} ${pluralizeDays(it.currentStreakDays)} - это уже ритуал :)" },
+                            {
+                                "${it.currentStreakDays} ${pluralizeDays(
+                                    it.currentStreakDays,
+                                )} подряд - поняши аплодируют тебе!"
+                            },
+                            { "${it.currentStreakDays} ${pluralizeDays(it.currentStreakDays)} - ого!" },
+                        ),
+                ),
+                TemplateRule(
+                    predicate = { it.avgMlPerDay >= it.dailyGoalMl && it.dailyGoalMl > 0 },
+                    templates =
+                        listOf(
+                            { "В среднем выше цели - поняши шепчутся, что ты самое гидрированное солнышко!" },
+                            { "Среднее перебирает план - ты молодец, но перепей :)" },
+                        ),
+                ),
+                TemplateRule(
+                    predicate = { it.bestDay != null },
+                    templates =
+                        listOf(
+                            { "Лучший день - ${it.bestDay!!.valueMl} мл, помнишь как это было?" },
+                            { "День с ${it.bestDay!!.valueMl} мл воды - вот это размах :)" },
+                        ),
+                ),
+                // Generic fallback - used only if nothing specific matched
+                TemplateRule(
+                    predicate = { true },
+                    templates =
+                        listOf(
+                            { "Поняши тобой довольны!" },
+                            { "Поняши машут хвостами в твою честь" },
+                            { "Твой внутренний пони в восторге!" },
+                            { "Кто-то тут молодец, и это ты" },
+                            { "Маленькая пони тебе кивает" },
+                            { "Кактусы тебе завидуют" },
+                            { "Радуга где-то поднялась в твою честь" },
+                            { "Твои почки шлют сердечко" },
+                            { "Тело тебя слышит, и это редко" },
+                            { "Без громких слов - ты просто молодец!" },
+                            { "Заметно, что ты стараешься!" },
+                            { "Тихий прогресс - самый честный" },
+                            { "Самое важное - не останавливаться!" },
+                        ),
+                ),
             ),
-            TemplateRule(
-                predicate = { it.currentStreakDays in 7..13 },
-                templates = listOf(
-                    { "${it.currentStreakDays} ${pluralizeDays(it.currentStreakDays)} - это уже не случайность!" },
-                    { "Столько дней выпивать норму подряд - чувствуешь как вырабатывается привычка?" },
-                )
-            ),
-            TemplateRule(
-                predicate = { it.currentStreakDays >= 14 },
-                templates = listOf(
-                    { "${it.currentStreakDays} ${pluralizeDays(it.currentStreakDays)} - это уже ритуал :)" },
-                    { "${it.currentStreakDays} ${pluralizeDays(it.currentStreakDays)} подряд - поняши аплодируют тебе!" },
-                    { "${it.currentStreakDays} ${pluralizeDays(it.currentStreakDays)} - ого!" },
-                )
-            ),
-
-            TemplateRule(
-                predicate = { it.avgMlPerDay >= it.dailyGoalMl && it.dailyGoalMl > 0 },
-                templates = listOf(
-                    { "В среднем выше цели - поняши шепчутся, что ты самое гидрированное солнышко!" },
-                    { "Среднее перебирает план - ты молодец, но перепей :)" },
-                )
-            ),
-
-            TemplateRule(
-                predicate = { it.bestDay != null },
-                templates = listOf(
-                    { "Лучший день - ${it.bestDay!!.valueMl} мл, помнишь как это было?" },
-                    { "День с ${it.bestDay!!.valueMl} мл воды - вот это размах :)" },
-                )
-            ),
-
-            // Generic fallback - used only if nothing specific matched
-            TemplateRule(
-                predicate = { true },
-                templates = listOf(
-                    { "Поняши тобой довольны!" },
-                    { "Поняши машут хвостами в твою честь" },
-                    { "Твой внутренний пони в восторге!" },
-                    { "Кто-то тут молодец, и это ты" },
-                    { "Маленькая пони тебе кивает" },
-                    { "Кактусы тебе завидуют" },
-                    { "Радуга где-то поднялась в твою честь" },
-                    { "Твои почки шлют сердечко" },
-                    { "Тело тебя слышит, и это редко" },
-                    { "Без громких слов - ты просто молодец!" },
-                    { "Заметно, что ты стараешься!" },
-                    { "Тихий прогресс - самый честный" },
-                    { "Самое важное - не останавливаться!" },
-                )
-            )
         )
-    )
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/sql/CustomP6SpyLogger.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/sql/CustomP6SpyLogger.kt
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.util.ReflectionUtils
 
 class CustomP6SpyLogger : Slf4JLogger() {
-
     companion object {
         private const val SLF4J_LOGGER_NAME = "logger"
         private val LOGGER = LoggerFactory.getLogger("SQL")
@@ -16,7 +15,8 @@ class CustomP6SpyLogger : Slf4JLogger() {
     }
 
     private fun overrideDefaultLoggerViaReflection() {
-        ReflectionUtils.findField(this.javaClass, SLF4J_LOGGER_NAME)
+        ReflectionUtils
+            .findField(this.javaClass, SLF4J_LOGGER_NAME)
             ?.let {
                 ReflectionUtils.makeAccessible(it)
                 ReflectionUtils.setField(it, this, LOGGER)

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsAggregator.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsAggregator.kt
@@ -71,11 +71,11 @@ object StatisticsAggregator {
         today: LocalDate,
         dailyGoalMl: Int,
     ): Int {
-        // Active streak: if today's goal isn't met, the chain is broken right now, regardless of past days.
-        if ((byDate[today] ?: 0) < dailyGoalMl) return 0
-        var streak = 1
-        var cursor = today.minusDays(1)
+        // Hanging streak: an unfinished today does NOT break the chain - we start counting from
+        // yesterday in that case. The streak only resets to 0 on a real gap (yesterday below goal too).
+        var cursor = if ((byDate[today] ?: 0) >= dailyGoalMl) today else today.minusDays(1)
         val earliest = today.minusDays(STREAK_LIMIT_DAYS)
+        var streak = 0
         while (!cursor.isBefore(earliest)) {
             if ((byDate[cursor] ?: 0) < dailyGoalMl) break
             streak++

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsAggregator.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsAggregator.kt
@@ -7,18 +7,24 @@ import java.time.LocalDate
 import java.time.ZoneId
 
 object StatisticsAggregator {
-
     private const val HOURS_IN_DAY = 24
     private const val HOUR_LABEL_FORMAT = "%02d:00"
 
     // 366 (not 365) covers a leap year, so a full year of streak isn't off by one
     const val STREAK_LIMIT_DAYS = 366L
 
-    fun sumByLocalDate(events: List<WaterStatisticDto>, zone: ZoneId): Map<LocalDate, Int> =
-        events.groupBy { StatisticsPeriodHelper.toLocal(it.eventTime, zone).toLocalDate() }
+    fun sumByLocalDate(
+        events: List<WaterStatisticDto>,
+        zone: ZoneId,
+    ): Map<LocalDate, Int> =
+        events
+            .groupBy { StatisticsPeriodHelper.toLocal(it.eventTime, zone).toLocalDate() }
             .mapValues { entry -> entry.value.sumOf { it.waterAmountMl } }
 
-    fun aggregateByHour(events: List<WaterStatisticDto>, zone: ZoneId): List<StatisticsPointDto> {
+    fun aggregateByHour(
+        events: List<WaterStatisticDto>,
+        zone: ZoneId,
+    ): List<StatisticsPointDto> {
         val byHour = IntArray(HOURS_IN_DAY)
         for (event in events) {
             val localHour = StatisticsPeriodHelper.toLocal(event.eventTime, zone).hour
@@ -32,31 +38,38 @@ object StatisticsAggregator {
     fun aggregateByDay(
         byDate: Map<LocalDate, Int>,
         startLocal: LocalDate,
-        days: Int
+        days: Int,
     ): List<StatisticsPointDto> =
         (0 until days).map { offset ->
             val date = startLocal.plusDays(offset.toLong())
             StatisticsPointDto(label = date.toString(), valueMl = byDate[date] ?: 0)
         }
 
-    fun averageMlPerDay(days: Int, points: List<StatisticsPointDto>): Int {
+    fun averageMlPerDay(
+        days: Int,
+        points: List<StatisticsPointDto>,
+    ): Int {
         val total = points.sumOf { it.valueMl }
         return total / days
     }
 
-    fun bestDay(days: Int, byDate: Map<LocalDate, Int>): BestDayDto? {
+    fun bestDay(
+        days: Int,
+        byDate: Map<LocalDate, Int>,
+    ): BestDayDto? {
         if (days == 1) return null
-        val best = byDate.entries
-            .filter { it.value > 0 }
-            .sortedBy { it.key }
-            .maxByOrNull { it.value } ?: return null
+        val best =
+            byDate.entries
+                .filter { it.value > 0 }
+                .sortedBy { it.key }
+                .maxByOrNull { it.value } ?: return null
         return BestDayDto(date = best.key, valueMl = best.value, weekday = best.key.dayOfWeek)
     }
 
     fun calculateStreak(
         byDate: Map<LocalDate, Int>,
         today: LocalDate,
-        dailyGoalMl: Int
+        dailyGoalMl: Int,
     ): Int {
         // Active streak: if today's goal isn't met, the chain is broken right now, regardless of past days.
         if ((byDate[today] ?: 0) < dailyGoalMl) return 0

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsPeriodHelper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsPeriodHelper.kt
@@ -1,22 +1,26 @@
 package ru.illine.drinking.ponies.util.statistics
 
-import java.time.*
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
 
 fun LocalDateTime.toUtcInstant(): Instant = this.toInstant(ZoneOffset.UTC)
 
 object StatisticsPeriodHelper {
-
-    fun toLocal(eventTimeUtc: LocalDateTime, zone: ZoneId): LocalDateTime =
-        eventTimeUtc.atZone(ZoneOffset.UTC).withZoneSameInstant(zone).toLocalDateTime()
+    fun toLocal(
+        eventTimeUtc: LocalDateTime,
+        zone: ZoneId,
+    ): LocalDateTime = eventTimeUtc.atZone(ZoneOffset.UTC).withZoneSameInstant(zone).toLocalDateTime()
 
     fun localDayBoundsToUtc(
         startLocal: LocalDate,
         endLocalExclusive: LocalDate,
-        zone: ZoneId
+        zone: ZoneId,
     ): Pair<LocalDateTime, LocalDateTime> {
         val startUtc = startLocal.atStartOfDay(zone).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime()
         val endUtc = endLocalExclusive.atStartOfDay(zone).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime()
         return startUtc to endUtc
     }
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramBotKeyboardHelper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramBotKeyboardHelper.kt
@@ -7,57 +7,56 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKe
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
 import ru.illine.drinking.ponies.model.base.WaterAmountType
-import java.util.*
+import java.util.UUID
 
 object TelegramBotKeyboardHelper {
-
-    fun snoozeTimeButtons(): ReplyKeyboard {
-        return buildInlineKeyboard(
+    fun snoozeTimeButtons(): ReplyKeyboard =
+        buildInlineKeyboard(
             SnoozeNotificationType.entries,
             SnoozeNotificationType::displayName,
-            SnoozeNotificationType::queryData
+            SnoozeNotificationType::queryData,
         )
-    }
 
-    fun waterAmountButtons(): ReplyKeyboard {
-        return buildInlineKeyboard(
+    fun waterAmountButtons(): ReplyKeyboard =
+        buildInlineKeyboard(
             WaterAmountType.entries,
             WaterAmountType::displayName,
-            WaterAmountType::queryData
+            WaterAmountType::queryData,
         )
-    }
 
-    fun notifyButtons(): ReplyKeyboard {
-        return buildInlineKeyboard(
+    fun notifyButtons(): ReplyKeyboard =
+        buildInlineKeyboard(
             AnswerNotificationType.entries,
             AnswerNotificationType::displayName,
             AnswerNotificationType::queryData,
-            singleRow = true
+            singleRow = true,
         )
-    }
 
     private fun <T> buildInlineKeyboard(
         entries: List<T>,
         displayName: (T) -> String,
         queryData: (T) -> UUID,
-        singleRow: Boolean = false
+        singleRow: Boolean = false,
     ): ReplyKeyboard {
-        val buttons = entries.map {
-            InlineKeyboardButton.builder()
-                .text(displayName(it))
-                .callbackData(queryData(it).toString())
-                .build()
-        }
+        val buttons =
+            entries.map {
+                InlineKeyboardButton
+                    .builder()
+                    .text(displayName(it))
+                    .callbackData(queryData(it).toString())
+                    .build()
+            }
 
-        val keyboard = if (singleRow) {
-            listOf(InlineKeyboardRow(buttons))
-        } else {
-            buttons.map { InlineKeyboardRow(it) }
-        }
+        val keyboard =
+            if (singleRow) {
+                listOf(InlineKeyboardRow(buttons))
+            } else {
+                buttons.map { InlineKeyboardRow(it) }
+            }
 
-        return InlineKeyboardMarkup.builder()
+        return InlineKeyboardMarkup
+            .builder()
             .keyboard(keyboard)
             .build()
     }
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramDailyGoalConstants.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramDailyGoalConstants.kt
@@ -1,7 +1,5 @@
 package ru.illine.drinking.ponies.util.telegram
 
 object TelegramDailyGoalConstants {
-
     val ALLOWED_VALUES_ML: Set<Int> = setOf(2000, 2250, 2500, 2750, 3000)
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramGeneralConstants.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramGeneralConstants.kt
@@ -1,7 +1,5 @@
 package ru.illine.drinking.ponies.util.telegram
 
 object TelegramGeneralConstants {
-
     const val TELEGRAM_USER_ATTRIBUTE = "telegramUser"
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramMenuConstants.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramMenuConstants.kt
@@ -1,7 +1,5 @@
 package ru.illine.drinking.ponies.util.telegram
 
 object TelegramMenuConstants {
-
     const val MENU_BUTTON_TEXT = "Меню"
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramMessageConstants.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramMessageConstants.kt
@@ -1,20 +1,19 @@
 package ru.illine.drinking.ponies.util.telegram
 
 object TelegramMessageConstants {
-
     val START_GREETING_MESSAGE =
         """
-                Здравствуй, %s! 
-                Я бот Пьющие Поняшки. Я полностью понимающий и знаю, что всем нужно пить!
-            """.trimIndent()
+        Здравствуй, %s! 
+        Я бот Пьющие Поняшки. Я полностью понимающий и знаю, что всем нужно пить!
+        """.trimIndent()
 
     val START_DEFAULT_SETTINGS_MESSAGE =
         """
-               Установлены настройки по-умолчанию:
-               Периодичность уведомлений: %s
-               Часовой пояс: Москва
-               Время тихого режима: с 23:00 до 11:00
-            """.trimIndent()
+        Установлены настройки по-умолчанию:
+        Периодичность уведомлений: %s
+        Часовой пояс: Москва
+        Время тихого режима: с 23:00 до 11:00
+        """.trimIndent()
 
     val NOTIFICATION_QUESTION_MESSAGE = "Водица выпита?"
 
@@ -22,9 +21,9 @@ object TelegramMessageConstants {
 
     val NOTIFICATION_SUSPEND_MESSAGE =
         """
-                Котик, твое уведомление отложено! 
-                Через %s я тебя снова побеспокою, жди!
-            """.trimIndent()
+        Котик, твое уведомление отложено! 
+        Через %s я тебя снова побеспокою, жди!
+        """.trimIndent()
 
     val NOTIFICATION_ANSWER_YES_MESSAGE = "Ты - солнышко! Так держать!"
 
@@ -33,5 +32,4 @@ object TelegramMessageConstants {
     val NOTIFICATION_SNOOZE_MENU_MESSAGE = "Выбери, на сколько хочешь отложить уведомление"
 
     val NOTIFICATION_WATER_AMOUNT_MENU_MESSAGE = "Сколько водицы выпито?"
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramTimeConstants.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramTimeConstants.kt
@@ -1,7 +1,6 @@
 package ru.illine.drinking.ponies.util.telegram
 
 object TelegramTimeConstants {
-
     const val FIVE_MINS = "5 минут"
     const val TEN_MINS = "10 минут"
     const val FIFTEEN_MINS = "15 минут"
@@ -13,5 +12,4 @@ object TelegramTimeConstants {
     const val THREE_HOURS = "3 часа"
     const val FOUR_HOURS = "4 часа"
     const val FIVE_HOURS = "5 часов"
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramWaterAmountConstants.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramWaterAmountConstants.kt
@@ -1,11 +1,9 @@
 package ru.illine.drinking.ponies.util.telegram
 
 object TelegramWaterAmountConstants {
-
     const val ML_50 = "50 мл"
     const val ML_100 = "100 мл"
     const val ML_150 = "150 мл"
     const val ML_250 = "250 мл"
     const val ML_450 = "450 мл"
-
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramWebAppDataHelper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramWebAppDataHelper.kt
@@ -10,7 +10,6 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 
 object TelegramWebAppDataHelper {
-
     private val logger = LoggerFactory.getLogger("HELPER")
 
     private val ALGORITHM_NAME = "HmacSHA256"
@@ -21,7 +20,10 @@ object TelegramWebAppDataHelper {
     val QUERY_ID_FIELD_NAME = "query_id"
     val USER_FIELD_NAME = "user"
 
-    fun validateAuthDate(decodedData: Map<String, String>, expirationTime: Duration): Boolean {
+    fun validateAuthDate(
+        decodedData: Map<String, String>,
+        expirationTime: Duration,
+    ): Boolean {
         val hashTimestamp = decodedData[AUTH_DATE_FIELD_NAME]?.toLongOrNull()
 
         if (hashTimestamp == null) {
@@ -41,7 +43,10 @@ object TelegramWebAppDataHelper {
         return true
     }
 
-    fun validateHash(decodedData: Map<String, String>, token: String): Boolean {
+    fun validateHash(
+        decodedData: Map<String, String>,
+        token: String,
+    ): Boolean {
         val receivedHash = decodedData[HASH_FIELD_NAME]
         if (receivedHash == null) {
             logger.warn("Field 'hash' hasn't been received!")
@@ -49,11 +54,12 @@ object TelegramWebAppDataHelper {
         }
         logger.debug("Received hash: {}", receivedHash)
 
-        val dataCheckString = decodedData
-            .filter { it.key != HASH_FIELD_NAME }
-            .toSortedMap()
-            .map { "${it.key}=${it.value}" }
-            .joinToString("\n")
+        val dataCheckString =
+            decodedData
+                .filter { it.key != HASH_FIELD_NAME }
+                .toSortedMap()
+                .map { "${it.key}=${it.value}" }
+                .joinToString("\n")
         logger.debug("Data string for HMAC: \n{}", dataCheckString)
 
         val secretKey = HmacUtils(ALGORITHM_NAME, ALGORITHM_HASH_KEY).hmac(token)

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/water/WaterEntryConstants.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/water/WaterEntryConstants.kt
@@ -1,9 +1,7 @@
 package ru.illine.drinking.ponies.util.water
 
 object WaterEntryConstants {
-
     const val MIN_ML: Long = 50
     const val MAX_ML: Long = 1000
     const val MAX_DAYS_AGO: Long = 30
-
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/bot/InMemoryDBContextTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/bot/InMemoryDBContextTest.kt
@@ -1,0 +1,105 @@
+package ru.illine.drinking.ponies.bot
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import ru.illine.drinking.ponies.test.tag.UnitTest
+
+@UnitTest
+@DisplayName("InMemoryDBContext Unit Test")
+class InMemoryDBContextTest {
+    private lateinit var db: InMemoryDBContext
+
+    @BeforeEach
+    fun setUp() {
+        db = InMemoryDBContext()
+    }
+
+    @Test
+    @DisplayName("getMap(): returns the same live map for the same name")
+    fun `getMap returns same instance`() {
+        val first = db.getMap<String, Int>("counters")
+        first["a"] = 1
+        val second = db.getMap<String, Int>("counters")
+
+        assertSame(first, second)
+        assertEquals(1, second["a"])
+    }
+
+    @Test
+    @DisplayName("getSet(): returns the same live set for the same name")
+    fun `getSet returns same instance`() {
+        val first = db.getSet<Long>("admins")
+        first.add(42L)
+        val second = db.getSet<Long>("admins")
+
+        assertSame(first, second)
+        assertTrue(second.contains(42L))
+    }
+
+    @Test
+    @DisplayName("getList(): returns the same live list for the same name")
+    fun `getList returns same instance`() {
+        val first = db.getList<String>("events")
+        first.add("started")
+        val second = db.getList<String>("events")
+
+        assertSame(first, second)
+        assertEquals(listOf("started"), second.toList())
+    }
+
+    @Test
+    @DisplayName("getVar(): persists the value across lookups")
+    fun `getVar persists value`() {
+        db.getVar<String>("token").set("secret")
+
+        assertEquals("secret", db.getVar<String>("token").get())
+    }
+
+    @Test
+    @DisplayName("contains(): true only after a structure is created")
+    fun `contains reflects created structures`() {
+        assertFalse(db.contains("users"))
+
+        db.getMap<Long, String>("users")
+
+        assertTrue(db.contains("users"))
+    }
+
+    @Test
+    @DisplayName("clear(): empties structures but keeps them registered")
+    fun `clear empties structures but keeps them registered`() {
+        db.getMap<String, Int>("counters")["a"] = 1
+        db.getSet<Long>("admins").add(42L)
+
+        db.clear()
+
+        assertTrue(db.getMap<String, Int>("counters").isEmpty())
+        assertTrue(db.getSet<Long>("admins").isEmpty())
+        assertTrue(db.contains("counters"))
+    }
+
+    @Test
+    @DisplayName("backup()/recover(): round-trips the stored structures")
+    fun `backup and recover round-trip`() {
+        db.getMap<String, Int>("counters")["a"] = 1
+
+        val restored = InMemoryDBContext()
+        val recovered = restored.recover(db.backup())
+
+        assertTrue(recovered)
+        assertEquals(1, restored.getMap<String, Int>("counters")["a"])
+    }
+
+    @Test
+    @DisplayName("info(): reports type and size of a structure")
+    fun `info reports structure type and size`() {
+        db.getSet<Long>("admins").add(42L)
+
+        assertEquals("admins - Set - 1", db.info("admins"))
+    }
+}

--- a/src/test/kotlin/ru/illine/drinking/ponies/builder/StatisticsBuilderTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/builder/StatisticsBuilderTest.kt
@@ -43,9 +43,10 @@ class StatisticsBuilderTest {
         assertEquals(2000, response.dailyGoalMl)
         assertEquals(1950, response.averageMlPerDay)
         assertNotNull(response.bestDay)
-        assertEquals(LocalDate.of(2026, 5, 5), response.bestDay!!.date)
-        assertEquals(2100, response.bestDay!!.valueMl)
-        assertEquals(DayOfWeek.TUESDAY, response.bestDay!!.weekday)
+        val bestDay = response.bestDay!!
+        assertEquals(LocalDate.of(2026, 5, 5), bestDay.date)
+        assertEquals(2100, bestDay.valueMl)
+        assertEquals(DayOfWeek.TUESDAY, bestDay.weekday)
         assertEquals(3, response.currentStreakDays)
         assertEquals("Котик, ты пьёшь водицу 3 дней подряд - так держать!", response.insight.text)
         assertEquals(Instant.parse("2026-04-15T10:30:00Z"), response.firstEntryAt)

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/cache/CacheConfigTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/cache/CacheConfigTest.kt
@@ -1,6 +1,8 @@
 package ru.illine.drinking.ponies.config.cache
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.cache.transaction.TransactionAwareCacheManagerProxy
@@ -13,14 +15,14 @@ import java.time.Duration
 @UnitTest
 @DisplayName("CacheConfig Unit Test")
 class CacheConfigTest {
-
     @Test
     @DisplayName("cacheManager(): registers all caches when no overrides are provided")
     fun `cacheManager registers all caches`() {
-        val properties = CacheProperties(
-            default = CacheEntry(ttl = Duration.ofMinutes(7), maximumSize = 50),
-            overrides = emptyMap()
-        )
+        val properties =
+            CacheProperties(
+                default = CacheEntry(ttl = Duration.ofMinutes(7), maximumSize = 50),
+                overrides = emptyMap(),
+            )
 
         val manager = CacheConfig(properties).cacheManager()
 
@@ -36,31 +38,35 @@ class CacheConfigTest {
     fun `cacheManager wraps caffeine in transaction aware proxy`() {
         // Without this proxy, @CacheEvict happens before the @Transactional method commits,
         // and a concurrent reader can re-cache the stale value. The proxy is load-bearing.
-        val properties = CacheProperties(
-            default = CacheEntry(ttl = Duration.ofMinutes(7), maximumSize = 50),
-            overrides = emptyMap()
-        )
+        val properties =
+            CacheProperties(
+                default = CacheEntry(ttl = Duration.ofMinutes(7), maximumSize = 50),
+                overrides = emptyMap(),
+            )
 
         val manager = CacheConfig(properties).cacheManager()
 
         assertTrue(
             manager is TransactionAwareCacheManagerProxy,
-            "Expected TransactionAwareCacheManagerProxy, got ${manager::class}"
+            "Expected TransactionAwareCacheManagerProxy, got ${manager::class}",
         )
     }
 
     @Test
     @DisplayName("cacheManager(): applies override values for ttl and maximumSize when both are set")
     fun `cacheManager applies override ttl and maximumSize`() {
-        val properties = CacheProperties(
-            default = CacheEntry(ttl = Duration.ofMinutes(7), maximumSize = 50),
-            overrides = mapOf(
-                CacheConfig.USER_IS_ADMIN to CacheEntryOverride(
-                    ttl = Duration.ofMinutes(15),
-                    maximumSize = 200
-                )
+        val properties =
+            CacheProperties(
+                default = CacheEntry(ttl = Duration.ofMinutes(7), maximumSize = 50),
+                overrides =
+                    mapOf(
+                        CacheConfig.USER_IS_ADMIN to
+                            CacheEntryOverride(
+                                ttl = Duration.ofMinutes(15),
+                                maximumSize = 200,
+                            ),
+                    ),
             )
-        )
 
         val manager = CacheConfig(properties).cacheManager()
 
@@ -72,15 +78,18 @@ class CacheConfigTest {
     @Test
     @DisplayName("cacheManager(): falls back to default ttl and maximumSize when override fields are null")
     fun `cacheManager falls back to default when override fields are null`() {
-        val properties = CacheProperties(
-            default = CacheEntry(ttl = Duration.ofMinutes(7), maximumSize = 50),
-            overrides = mapOf(
-                CacheConfig.USER_IS_ADMIN to CacheEntryOverride(
-                    ttl = null,
-                    maximumSize = null
-                )
+        val properties =
+            CacheProperties(
+                default = CacheEntry(ttl = Duration.ofMinutes(7), maximumSize = 50),
+                overrides =
+                    mapOf(
+                        CacheConfig.USER_IS_ADMIN to
+                            CacheEntryOverride(
+                                ttl = null,
+                                maximumSize = null,
+                            ),
+                    ),
             )
-        )
 
         val manager = CacheConfig(properties).cacheManager()
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/DefaultExceptionHandlerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/DefaultExceptionHandlerTest.kt
@@ -20,7 +20,6 @@ import ru.illine.drinking.ponies.test.tag.UnitTest
 @UnitTest
 @DisplayName("DefaultExceptionHandler Unit Test")
 class DefaultExceptionHandlerTest {
-
     private lateinit var handler: DefaultExceptionHandler
 
     @BeforeEach
@@ -78,7 +77,9 @@ class DefaultExceptionHandlerTest {
     }
 
     @Test
-    @DisplayName("handleValidationException(): MethodArgumentTypeMismatchException - returns 400 with 'validation failed'")
+    @DisplayName(
+        "handleValidationException(): MethodArgumentTypeMismatchException - returns 400 with 'validation failed'",
+    )
     fun `handleValidationException with MethodArgumentTypeMismatchException returns 400`() {
         val exception = mock<MethodArgumentTypeMismatchException>()
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/DefaultExceptionHandlerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/DefaultExceptionHandlerTest.kt
@@ -4,8 +4,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.converter.HttpMessageNotReadableException
@@ -43,11 +43,11 @@ class DefaultExceptionHandlerTest {
     @Test
     @DisplayName("handleValidationException(): MethodArgumentNotValidException - returns 400 with 'validation failed'")
     fun `handleValidationException with MethodArgumentNotValidException returns 400`() {
-        val bindingResult = mock(BindingResult::class.java)
+        val bindingResult = mock<BindingResult>()
         val fieldError = FieldError("obj", "field", "must not be null")
-        `when`(bindingResult.fieldErrors).thenReturn(listOf(fieldError))
-        val exception = mock(MethodArgumentNotValidException::class.java)
-        `when`(exception.bindingResult).thenReturn(bindingResult)
+        whenever(bindingResult.fieldErrors).thenReturn(listOf(fieldError))
+        val exception = mock<MethodArgumentNotValidException>()
+        whenever(exception.bindingResult).thenReturn(bindingResult)
 
         val response = handler.handleValidationException(exception)
 
@@ -69,7 +69,7 @@ class DefaultExceptionHandlerTest {
     @Test
     @DisplayName("handleValidationException(): HttpMessageNotReadableException - returns 400 with 'validation failed'")
     fun `handleValidationException with HttpMessageNotReadableException returns 400`() {
-        val exception = mock(HttpMessageNotReadableException::class.java)
+        val exception = mock<HttpMessageNotReadableException>()
 
         val response = handler.handleValidationException(exception)
 
@@ -80,7 +80,7 @@ class DefaultExceptionHandlerTest {
     @Test
     @DisplayName("handleValidationException(): MethodArgumentTypeMismatchException - returns 400 with 'validation failed'")
     fun `handleValidationException with MethodArgumentTypeMismatchException returns 400`() {
-        val exception = mock(MethodArgumentTypeMismatchException::class.java)
+        val exception = mock<MethodArgumentTypeMismatchException>()
 
         val response = handler.handleValidationException(exception)
 
@@ -91,8 +91,8 @@ class DefaultExceptionHandlerTest {
     @Test
     @DisplayName("handleNoResourceFound(): returns 404 with 'resource not found'")
     fun `handleNoResourceFound returns 404`() {
-        val exception = mock(NoResourceFoundException::class.java)
-        `when`(exception.resourcePath).thenReturn("/unknown/path")
+        val exception = mock<NoResourceFoundException>()
+        whenever(exception.resourcePath).thenReturn("/unknown/path")
 
         val response = handler.handleNoResourceFound(exception)
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigAuthInterceptorIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigAuthInterceptorIntegrationTest.kt
@@ -1,0 +1,138 @@
+package ru.illine.drinking.ponies.config.web
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.context.jdbc.SqlConfig
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import ru.illine.drinking.ponies.config.web.WebConfigAuthInterceptorIntegrationTest.DefaultSecureTestConfig
+import ru.illine.drinking.ponies.config.web.security.AuthErrorType
+import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
+import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
+
+@SpringIntegrationTest
+@DisplayName("WebConfig default-secure interceptor Spring Integration Test")
+@Import(DefaultSecureTestConfig::class)
+@Sql(
+    scripts = ["classpath:sql/access/TelegramUserAccessService.sql"],
+    config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+)
+@Sql(
+    scripts = ["classpath:sql/clear.sql"],
+    config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD
+)
+class WebConfigAuthInterceptorIntegrationTest @Autowired constructor(
+    private val restTemplate: TestRestTemplate,
+) {
+
+    @MockitoBean
+    private lateinit var telegramValidatorService: TelegramValidatorService
+
+    private val telegramUser = TelegramUserDto(
+        externalUserId = 1L,
+        firstName = "First Name",
+        lastName = null,
+        username = "username"
+    )
+
+    @BeforeEach
+    fun setUp() {
+        `when`(telegramValidatorService.verifySignature(any())).thenReturn(true)
+        `when`(telegramValidatorService.map(any())).thenReturn(telegramUser)
+    }
+
+    private fun buildHeaders(): HttpHeaders {
+        return HttpHeaders().apply {
+            set("X-Authorization-Telegram-Data", "test-init-data")
+        }
+    }
+
+    @Nested
+    @DisplayName("default-secure: endpoint outside any exclude pattern is protected by default")
+    inner class DefaultSecureEndpoint {
+
+        private val url = "/test-default-secure"
+
+        @Test
+        @DisplayName("missing auth header - returns 401 with X-Auth-Error-Code invalid_auth_signature")
+        fun `missing auth header returns 401 with invalid_auth_signature header`() {
+            val response = restTemplate.exchange(
+                url, HttpMethod.GET, HttpEntity<Void>(HttpHeaders()), Void::class.java
+            )
+
+            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+            assertEquals(
+                AuthErrorType.INVALID_AUTH_SIGNATURE.value,
+                response.headers.getFirst(AuthErrorType.HEADER_NAME)
+            )
+            verify(telegramValidatorService, never()).verifySignature(any())
+            verify(telegramValidatorService, never()).map(any())
+        }
+
+        @Test
+        @DisplayName("valid auth header - returns 200")
+        fun `valid auth header returns 200`() {
+            val response = restTemplate.exchange(
+                url, HttpMethod.GET, HttpEntity<Void>(buildHeaders()), String::class.java
+            )
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            verify(telegramValidatorService).verifySignature("test-init-data")
+            verify(telegramValidatorService).map("test-init-data")
+        }
+    }
+
+    @Nested
+    @DisplayName("excluded public path: /v3/api-docs is reachable without auth header")
+    inner class ExcludedPublicPath {
+
+        @Test
+        @DisplayName("GET /v3/api-docs without auth header - returns 200 and is not blocked by auth")
+        fun `api docs without auth header returns 200`() {
+            val response = restTemplate.exchange(
+                "/v3/api-docs", HttpMethod.GET, HttpEntity<Void>(HttpHeaders()), String::class.java
+            )
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertNotEquals(
+                AuthErrorType.INVALID_AUTH_SIGNATURE.value,
+                response.headers.getFirst(AuthErrorType.HEADER_NAME)
+            )
+            verify(telegramValidatorService, never()).verifySignature(any())
+        }
+    }
+
+    @TestConfiguration
+    class DefaultSecureTestConfig {
+
+        @RestController
+        @RequestMapping("/test-default-secure")
+        class DefaultSecureTestController {
+
+            @GetMapping
+            fun defaultSecure(): String = "ok"
+        }
+    }
+}

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigAuthInterceptorIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigAuthInterceptorIntegrationTest.kt
@@ -36,103 +36,112 @@ import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
 @Sql(
     scripts = ["classpath:sql/access/TelegramUserAccessService.sql"],
     config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
-    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
 )
 @Sql(
     scripts = ["classpath:sql/clear.sql"],
     config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
-    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
 )
-class WebConfigAuthInterceptorIntegrationTest @Autowired constructor(
-    private val restTemplate: TestRestTemplate,
-) {
+class WebConfigAuthInterceptorIntegrationTest
+    @Autowired
+    constructor(
+        private val restTemplate: TestRestTemplate,
+    ) {
+        @MockitoBean
+        private lateinit var telegramValidatorService: TelegramValidatorService
 
-    @MockitoBean
-    private lateinit var telegramValidatorService: TelegramValidatorService
-
-    private val telegramUser = TelegramUserDto(
-        externalUserId = 1L,
-        firstName = "First Name",
-        lastName = null,
-        username = "username"
-    )
-
-    @BeforeEach
-    fun setUp() {
-        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
-    }
-
-    private fun buildHeaders(): HttpHeaders {
-        return HttpHeaders().apply {
-            set("X-Authorization-Telegram-Data", "test-init-data")
-        }
-    }
-
-    @Nested
-    @DisplayName("default-secure: endpoint outside any exclude pattern is protected by default")
-    inner class DefaultSecureEndpoint {
-
-        private val url = "/test-default-secure"
-
-        @Test
-        @DisplayName("missing auth header - returns 401 with X-Auth-Error-Code invalid_auth_signature")
-        fun `missing auth header returns 401 with invalid_auth_signature header`() {
-            val response = restTemplate.exchange(
-                url, HttpMethod.GET, HttpEntity<Void>(HttpHeaders()), Void::class.java
+        private val telegramUser =
+            TelegramUserDto(
+                externalUserId = 1L,
+                firstName = "First Name",
+                lastName = null,
+                username = "username",
             )
 
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-            assertEquals(
-                AuthErrorType.INVALID_AUTH_SIGNATURE.value,
-                response.headers.getFirst(AuthErrorType.HEADER_NAME)
-            )
-            verify(telegramValidatorService, never()).verifySignature(any())
-            verify(telegramValidatorService, never()).map(any())
+        @BeforeEach
+        fun setUp() {
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+            whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
         }
 
-        @Test
-        @DisplayName("valid auth header - returns 200")
-        fun `valid auth header returns 200`() {
-            val response = restTemplate.exchange(
-                url, HttpMethod.GET, HttpEntity<Void>(buildHeaders()), String::class.java
-            )
+        private fun buildHeaders(): HttpHeaders =
+            HttpHeaders().apply {
+                set("X-Authorization-Telegram-Data", "test-init-data")
+            }
 
-            assertEquals(HttpStatus.OK, response.statusCode)
-            verify(telegramValidatorService).verifySignature("test-init-data")
-            verify(telegramValidatorService).map("test-init-data")
+        @Nested
+        @DisplayName("default-secure: endpoint outside any exclude pattern is protected by default")
+        inner class DefaultSecureEndpoint {
+            private val url = "/test-default-secure"
+
+            @Test
+            @DisplayName("missing auth header - returns 401 with X-Auth-Error-Code invalid_auth_signature")
+            fun `missing auth header returns 401 with invalid_auth_signature header`() {
+                val response =
+                    restTemplate.exchange(
+                        url,
+                        HttpMethod.GET,
+                        HttpEntity<Void>(HttpHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                assertEquals(
+                    AuthErrorType.INVALID_AUTH_SIGNATURE.value,
+                    response.headers.getFirst(AuthErrorType.HEADER_NAME),
+                )
+                verify(telegramValidatorService, never()).verifySignature(any())
+                verify(telegramValidatorService, never()).map(any())
+            }
+
+            @Test
+            @DisplayName("valid auth header - returns 200")
+            fun `valid auth header returns 200`() {
+                val response =
+                    restTemplate.exchange(
+                        url,
+                        HttpMethod.GET,
+                        HttpEntity<Void>(buildHeaders()),
+                        String::class.java,
+                    )
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                verify(telegramValidatorService).verifySignature("test-init-data")
+                verify(telegramValidatorService).map("test-init-data")
+            }
+        }
+
+        @Nested
+        @DisplayName("excluded public path: /v3/api-docs is reachable without auth header")
+        inner class ExcludedPublicPath {
+            @Test
+            @DisplayName("GET /v3/api-docs without auth header - returns 200 and is not blocked by auth")
+            fun `api docs without auth header returns 200`() {
+                val response =
+                    restTemplate.exchange(
+                        "/v3/api-docs",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(HttpHeaders()),
+                        String::class.java,
+                    )
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertNotEquals(
+                    AuthErrorType.INVALID_AUTH_SIGNATURE.value,
+                    response.headers.getFirst(AuthErrorType.HEADER_NAME),
+                )
+                verify(telegramValidatorService, never()).verifySignature(any())
+            }
+        }
+
+        @TestConfiguration
+        class DefaultSecureTestConfig {
+            @RestController
+            @RequestMapping("/test-default-secure")
+            class DefaultSecureTestController {
+                @GetMapping
+                fun defaultSecure(): String = "ok"
+            }
         }
     }
-
-    @Nested
-    @DisplayName("excluded public path: /v3/api-docs is reachable without auth header")
-    inner class ExcludedPublicPath {
-
-        @Test
-        @DisplayName("GET /v3/api-docs without auth header - returns 200 and is not blocked by auth")
-        fun `api docs without auth header returns 200`() {
-            val response = restTemplate.exchange(
-                "/v3/api-docs", HttpMethod.GET, HttpEntity<Void>(HttpHeaders()), String::class.java
-            )
-
-            assertEquals(HttpStatus.OK, response.statusCode)
-            assertNotEquals(
-                AuthErrorType.INVALID_AUTH_SIGNATURE.value,
-                response.headers.getFirst(AuthErrorType.HEADER_NAME)
-            )
-            verify(telegramValidatorService, never()).verifySignature(any())
-        }
-    }
-
-    @TestConfiguration
-    class DefaultSecureTestConfig {
-
-        @RestController
-        @RequestMapping("/test-default-secure")
-        class DefaultSecureTestController {
-
-            @GetMapping
-            fun defaultSecure(): String = "ok"
-        }
-    }
-}

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigAuthInterceptorIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigAuthInterceptorIntegrationTest.kt
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.never
-import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.web.client.TestRestTemplate
@@ -59,8 +59,8 @@ class WebConfigAuthInterceptorIntegrationTest @Autowired constructor(
 
     @BeforeEach
     fun setUp() {
-        `when`(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        `when`(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
     }
 
     private fun buildHeaders(): HttpHeaders {

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigTest.kt
@@ -17,40 +17,43 @@ import java.net.URI
 
 @SpringIntegrationTest
 @DisplayName("WebConfig Spring Integration Test")
-class WebConfigTest @Autowired constructor(
-    private val restTemplate: TestRestTemplate
-) {
+class WebConfigTest
+    @Autowired
+    constructor(
+        private val restTemplate: TestRestTemplate,
+    ) {
+        private val url = "/settings/modes/silent"
 
-    private val url = "/settings/modes/silent"
+        @ParameterizedTest
+        @ValueSource(strings = ["http://localhost:3000", "http://localhost:4000"])
+        @DisplayName("OPTIONS request from allowed origin - returns 200 with CORS headers")
+        fun `cors preflight from allowed origin returns cors headers`(allowedOrigin: String) {
+            val headers =
+                HttpHeaders().apply {
+                    set("Origin", allowedOrigin)
+                    set("Access-Control-Request-Method", "PUT")
+                }
+            val request = RequestEntity<Void>(headers, HttpMethod.OPTIONS, URI(url))
 
-    @ParameterizedTest
-    @ValueSource(strings = ["http://localhost:3000", "http://localhost:4000"])
-    @DisplayName("OPTIONS request from allowed origin - returns 200 with CORS headers")
-    fun `cors preflight from allowed origin returns cors headers`(allowedOrigin: String) {
-        val headers = HttpHeaders().apply {
-            set("Origin", allowedOrigin)
-            set("Access-Control-Request-Method", "PUT")
+            val response = restTemplate.exchange(request, Void::class.java)
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals(allowedOrigin, response.headers["Access-Control-Allow-Origin"]?.first())
+            assertTrue(response.headers["Access-Control-Allow-Methods"]?.first()?.contains("PUT") == true)
         }
-        val request = RequestEntity<Void>(headers, HttpMethod.OPTIONS, URI(url))
 
-        val response = restTemplate.exchange(request, Void::class.java)
+        @Test
+        @DisplayName("request from disallowed origin - does not return CORS allow header")
+        fun `cors request from disallowed origin has no allow-origin header`() {
+            val headers =
+                HttpHeaders().apply {
+                    set("Origin", "http://evil.example.com")
+                    set("Access-Control-Request-Method", "PUT")
+                }
+            val request = RequestEntity<Void>(headers, HttpMethod.OPTIONS, URI(url))
 
-        assertEquals(HttpStatus.OK, response.statusCode)
-        assertEquals(allowedOrigin, response.headers["Access-Control-Allow-Origin"]?.first())
-        assertTrue(response.headers["Access-Control-Allow-Methods"]?.first()?.contains("PUT") == true)
-    }
+            val response = restTemplate.exchange(request, Void::class.java)
 
-    @Test
-    @DisplayName("request from disallowed origin - does not return CORS allow header")
-    fun `cors request from disallowed origin has no allow-origin header`() {
-        val headers = HttpHeaders().apply {
-            set("Origin", "http://evil.example.com")
-            set("Access-Control-Request-Method", "PUT")
+            assertTrue(response.headers["Access-Control-Allow-Origin"].isNullOrEmpty())
         }
-        val request = RequestEntity<Void>(headers, HttpMethod.OPTIONS, URI(url))
-
-        val response = restTemplate.exchange(request, Void::class.java)
-
-        assertTrue(response.headers["Access-Control-Allow-Origin"].isNullOrEmpty())
     }
-}

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorIntegrationTest.kt
@@ -5,8 +5,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.web.client.TestRestTemplate
@@ -64,8 +66,8 @@ class AdminAuthInterceptorIntegrationTest @Autowired constructor(
     @BeforeEach
     fun setUp() {
         cacheManager.getCache(CacheConfig.USER_IS_ADMIN)?.clear()
-        `when`(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        `when`(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
     }
 
     private fun buildHeaders(): HttpHeaders {
@@ -91,7 +93,7 @@ class AdminAuthInterceptorIntegrationTest @Autowired constructor(
         @Test
         @DisplayName("non-admin user - returns 403 with X-Auth-Error-Code forbidden_admin")
         fun `non-admin user returns 403 with forbidden_admin header`() {
-            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
+            whenever(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
 
             val response = restTemplate.exchange(
                 "/systems/admin-test", HttpMethod.GET, HttpEntity<Void>(buildHeaders()), Void::class.java
@@ -107,7 +109,7 @@ class AdminAuthInterceptorIntegrationTest @Autowired constructor(
         @Test
         @DisplayName("expired auth_date - returns 403 with X-Auth-Error-Code session_expired (auth runs first)")
         fun `expired auth_date returns 403 with session_expired header`() {
-            `when`(telegramValidatorService.verifySignature(any())).thenReturn(false)
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
 
             val response = restTemplate.exchange(
                 "/systems/admin-test", HttpMethod.GET, HttpEntity<Void>(buildHeaders()), Void::class.java

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorIntegrationTest.kt
@@ -38,116 +38,134 @@ import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
 @Sql(
     scripts = ["classpath:sql/access/TelegramUserAccessService.sql"],
     config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
-    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
 )
 @Sql(
     scripts = ["classpath:sql/clear.sql"],
     config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
-    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
 )
-class AdminAuthInterceptorIntegrationTest @Autowired constructor(
-    private val restTemplate: TestRestTemplate,
-    private val cacheManager: CacheManager,
-) {
+class AdminAuthInterceptorIntegrationTest
+    @Autowired
+    constructor(
+        private val restTemplate: TestRestTemplate,
+        private val cacheManager: CacheManager,
+    ) {
+        @MockitoBean
+        private lateinit var telegramValidatorService: TelegramValidatorService
 
-    @MockitoBean
-    private lateinit var telegramValidatorService: TelegramValidatorService
+        private val telegramUser =
+            TelegramUserDto(
+                externalUserId = ADMIN_USER_ID,
+                firstName = "First Name",
+                lastName = null,
+                username = "username",
+            )
 
-    private val ADMIN_USER_ID = 1L
-    private val NON_ADMIN_USER_ID = 2L
+        @BeforeEach
+        fun setUp() {
+            cacheManager.getCache(CacheConfig.USER_IS_ADMIN)?.clear()
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+            whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        }
 
-    private val telegramUser = TelegramUserDto(
-        externalUserId = ADMIN_USER_ID,
-        firstName = "First Name",
-        lastName = null,
-        username = "username"
-    )
+        private fun buildHeaders(): HttpHeaders =
+            HttpHeaders().apply {
+                set("X-Authorization-Telegram-Data", "test-init-data")
+            }
 
-    @BeforeEach
-    fun setUp() {
-        cacheManager.getCache(CacheConfig.USER_IS_ADMIN)?.clear()
-        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
-    }
+        @Nested
+        @DisplayName("GET /systems/admin-test")
+        inner class AdminOnlyEndpoint {
+            @Test
+            @DisplayName("admin user - returns 200")
+            fun `admin user returns 200`() {
+                val response =
+                    restTemplate.exchange(
+                        "/systems/admin-test",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(buildHeaders()),
+                        String::class.java,
+                    )
 
-    private fun buildHeaders(): HttpHeaders {
-        return HttpHeaders().apply {
-            set("X-Authorization-Telegram-Data", "test-init-data")
+                assertEquals(HttpStatus.OK, response.statusCode)
+            }
+
+            @Test
+            @DisplayName("non-admin user - returns 403 with X-Auth-Error-Code forbidden_admin")
+            fun `non-admin user returns 403 with forbidden_admin header`() {
+                whenever(
+                    telegramValidatorService.map(any()),
+                ).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
+
+                val response =
+                    restTemplate.exchange(
+                        "/systems/admin-test",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(buildHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
+                assertEquals(
+                    AuthErrorType.FORBIDDEN_ADMIN.value,
+                    response.headers.getFirst(AuthErrorType.HEADER_NAME),
+                )
+            }
+
+            @Test
+            @DisplayName("expired auth_date - returns 403 with X-Auth-Error-Code session_expired (auth runs first)")
+            fun `expired auth_date returns 403 with session_expired header`() {
+                whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
+
+                val response =
+                    restTemplate.exchange(
+                        "/systems/admin-test",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(buildHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
+                assertEquals(
+                    AuthErrorType.SESSION_EXPIRED.value,
+                    response.headers.getFirst(AuthErrorType.HEADER_NAME),
+                )
+                verify(telegramValidatorService, never()).map(any())
+            }
+
+            @Test
+            @DisplayName("missing auth header - returns 401 with X-Auth-Error-Code invalid_auth_signature")
+            fun `missing auth header returns 401 with invalid_auth_signature header`() {
+                val response =
+                    restTemplate.exchange(
+                        "/systems/admin-test",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(HttpHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                assertEquals(
+                    AuthErrorType.INVALID_AUTH_SIGNATURE.value,
+                    response.headers.getFirst(AuthErrorType.HEADER_NAME),
+                )
+            }
+        }
+
+        @TestConfiguration
+        class AdminTestConfig {
+            @RestController
+            @RequestMapping("/systems")
+            class AdminTestController {
+                @AdminOnly
+                @GetMapping("/admin-test")
+                fun adminTest(): String = "ok"
+            }
+        }
+
+        companion object {
+            private const val ADMIN_USER_ID = 1L
+            private const val NON_ADMIN_USER_ID = 2L
         }
     }
-
-    @Nested
-    @DisplayName("GET /systems/admin-test")
-    inner class AdminOnlyEndpoint {
-
-        @Test
-        @DisplayName("admin user - returns 200")
-        fun `admin user returns 200`() {
-            val response = restTemplate.exchange(
-                "/systems/admin-test", HttpMethod.GET, HttpEntity<Void>(buildHeaders()), String::class.java
-            )
-
-            assertEquals(HttpStatus.OK, response.statusCode)
-        }
-
-        @Test
-        @DisplayName("non-admin user - returns 403 with X-Auth-Error-Code forbidden_admin")
-        fun `non-admin user returns 403 with forbidden_admin header`() {
-            whenever(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
-
-            val response = restTemplate.exchange(
-                "/systems/admin-test", HttpMethod.GET, HttpEntity<Void>(buildHeaders()), Void::class.java
-            )
-
-            assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
-            assertEquals(
-                AuthErrorType.FORBIDDEN_ADMIN.value,
-                response.headers.getFirst(AuthErrorType.HEADER_NAME)
-            )
-        }
-
-        @Test
-        @DisplayName("expired auth_date - returns 403 with X-Auth-Error-Code session_expired (auth runs first)")
-        fun `expired auth_date returns 403 with session_expired header`() {
-            whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
-
-            val response = restTemplate.exchange(
-                "/systems/admin-test", HttpMethod.GET, HttpEntity<Void>(buildHeaders()), Void::class.java
-            )
-
-            assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
-            assertEquals(
-                AuthErrorType.SESSION_EXPIRED.value,
-                response.headers.getFirst(AuthErrorType.HEADER_NAME)
-            )
-            verify(telegramValidatorService, never()).map(any())
-        }
-
-        @Test
-        @DisplayName("missing auth header - returns 401 with X-Auth-Error-Code invalid_auth_signature")
-        fun `missing auth header returns 401 with invalid_auth_signature header`() {
-            val response = restTemplate.exchange(
-                "/systems/admin-test", HttpMethod.GET, HttpEntity<Void>(HttpHeaders()), Void::class.java
-            )
-
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-            assertEquals(
-                AuthErrorType.INVALID_AUTH_SIGNATURE.value,
-                response.headers.getFirst(AuthErrorType.HEADER_NAME)
-            )
-        }
-    }
-
-    @TestConfiguration
-    class AdminTestConfig {
-
-        @RestController
-        @RequestMapping("/systems")
-        class AdminTestController {
-
-            @AdminOnly
-            @GetMapping("/admin-test")
-            fun adminTest(): String = "ok"
-        }
-    }
-}

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorIntegrationTest.kt
@@ -55,7 +55,7 @@ class AdminAuthInterceptorIntegrationTest @Autowired constructor(
     private val NON_ADMIN_USER_ID = 2L
 
     private val telegramUser = TelegramUserDto(
-        telegramId = ADMIN_USER_ID,
+        externalUserId = ADMIN_USER_ID,
         firstName = "First Name",
         lastName = null,
         username = "username"
@@ -91,7 +91,7 @@ class AdminAuthInterceptorIntegrationTest @Autowired constructor(
         @Test
         @DisplayName("non-admin user - returns 403 with X-Auth-Error-Code forbidden_admin")
         fun `non-admin user returns 403 with forbidden_admin header`() {
-            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(telegramId = NON_ADMIN_USER_ID))
+            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
 
             val response = restTemplate.exchange(
                 "/systems/admin-test", HttpMethod.GET, HttpEntity<Void>(buildHeaders()), Void::class.java

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorTest.kt
@@ -22,27 +22,28 @@ import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
 @UnitTest
 @DisplayName("AdminAuthInterceptor Unit Test")
 class AdminAuthInterceptorTest {
-
     private lateinit var request: HttpServletRequest
     private lateinit var response: HttpServletResponse
     private lateinit var handlerMethod: HandlerMethod
     private lateinit var interceptor: AdminAuthInterceptor
 
-    private val adminUser = TelegramUserDto(
-        externalUserId = 1L,
-        firstName = "Admin",
-        lastName = null,
-        username = null,
-        isAdmin = true
-    )
+    private val adminUser =
+        TelegramUserDto(
+            externalUserId = 1L,
+            firstName = "Admin",
+            lastName = null,
+            username = null,
+            isAdmin = true,
+        )
 
-    private val nonAdminUser = TelegramUserDto(
-        externalUserId = 2L,
-        firstName = "User",
-        lastName = null,
-        username = null,
-        isAdmin = false
-    )
+    private val nonAdminUser =
+        TelegramUserDto(
+            externalUserId = 2L,
+            firstName = "User",
+            lastName = null,
+            username = null,
+            isAdmin = false,
+        )
 
     @BeforeEach
     fun setUp() {

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorTest.kt
@@ -8,7 +8,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.Mockito.*
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.springframework.web.method.HandlerMethod
 import ru.illine.drinking.ponies.config.web.security.AdminOnly
 import ru.illine.drinking.ponies.config.web.security.AuthErrorType
@@ -43,9 +46,9 @@ class AdminAuthInterceptorTest {
 
     @BeforeEach
     fun setUp() {
-        request = mock(HttpServletRequest::class.java)
-        response = mock(HttpServletResponse::class.java)
-        handlerMethod = mock(HandlerMethod::class.java)
+        request = mock<HttpServletRequest>()
+        response = mock<HttpServletResponse>()
+        handlerMethod = mock<HandlerMethod>()
         interceptor = AdminAuthInterceptor()
     }
 
@@ -62,7 +65,7 @@ class AdminAuthInterceptorTest {
     @Test
     @DisplayName("preHandle(): handler without @AdminOnly - returns true")
     fun `handler without AdminOnly returns true`() {
-        `when`(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(null)
+        whenever(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(null)
 
         val result = interceptor.preHandle(request, response, handlerMethod)
 
@@ -73,8 +76,8 @@ class AdminAuthInterceptorTest {
     @Test
     @DisplayName("preHandle(): @AdminOnly + admin user - returns true")
     fun `admin user returns true`() {
-        `when`(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(AdminOnly())
-        `when`(request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)).thenReturn(adminUser)
+        whenever(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(AdminOnly())
+        whenever(request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)).thenReturn(adminUser)
 
         val result = interceptor.preHandle(request, response, handlerMethod)
 
@@ -85,8 +88,8 @@ class AdminAuthInterceptorTest {
     @Test
     @DisplayName("preHandle(): @AdminOnly + non-admin user - returns false, 403, X-Auth-Error-Code forbidden_admin")
     fun `non-admin user returns false with 403 and forbidden_admin header`() {
-        `when`(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(AdminOnly())
-        `when`(request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)).thenReturn(nonAdminUser)
+        whenever(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(AdminOnly())
+        whenever(request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)).thenReturn(nonAdminUser)
 
         val result = interceptor.preHandle(request, response, handlerMethod)
 
@@ -98,8 +101,8 @@ class AdminAuthInterceptorTest {
     @Test
     @DisplayName("preHandle(): @AdminOnly + missing telegramUser attribute - throws IllegalStateException")
     fun `missing telegramUser attribute fails fast`() {
-        `when`(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(AdminOnly())
-        `when`(request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)).thenReturn(null)
+        whenever(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(AdminOnly())
+        whenever(request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)).thenReturn(null)
 
         assertThrows<IllegalStateException> {
             interceptor.preHandle(request, response, handlerMethod)

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorTest.kt
@@ -26,7 +26,7 @@ class AdminAuthInterceptorTest {
     private lateinit var interceptor: AdminAuthInterceptor
 
     private val adminUser = TelegramUserDto(
-        telegramId = 1L,
+        externalUserId = 1L,
         firstName = "Admin",
         lastName = null,
         username = null,
@@ -34,7 +34,7 @@ class AdminAuthInterceptorTest {
     )
 
     private val nonAdminUser = TelegramUserDto(
-        telegramId = 2L,
+        externalUserId = 2L,
         firstName = "User",
         lastName = null,
         username = null,

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptorTest.kt
@@ -16,7 +16,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
-import java.util.stream.Stream
 import ru.illine.drinking.ponies.config.web.security.AuthErrorType
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
 import ru.illine.drinking.ponies.exception.InvalidAuthSignatureException
@@ -24,11 +23,11 @@ import ru.illine.drinking.ponies.model.dto.TelegramUserDto
 import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
+import java.util.stream.Stream
 
 @UnitTest
 @DisplayName("TelegramAuthInterceptor Unit Test")
 class TelegramAuthInterceptorTest {
-
     private val headerName = "X-Authorization-Telegram-Data"
 
     private lateinit var validatorService: TelegramValidatorService
@@ -60,7 +59,9 @@ class TelegramAuthInterceptorTest {
 
     @ParameterizedTest(name = "[{index}] header={0} - returns false, 401, X-Auth-Error-Code invalid_auth_signature")
     @MethodSource("provideMissingOrBlankHeaders")
-    @DisplayName("preHandle(): missing/empty/blank header - returns false, 401, X-Auth-Error-Code invalid_auth_signature")
+    @DisplayName(
+        "preHandle(): missing/empty/blank header - returns false, 401, X-Auth-Error-Code invalid_auth_signature",
+    )
     fun `preHandle missing or blank header returns false with 401 and invalid_auth_signature header`(
         headerValue: String?,
     ) {
@@ -77,7 +78,9 @@ class TelegramAuthInterceptorTest {
     }
 
     @Test
-    @DisplayName("preHandle(): malformed initData (verifySignature throws) - 401, X-Auth-Error-Code invalid_auth_signature")
+    @DisplayName(
+        "preHandle(): malformed initData (verifySignature throws) - 401, X-Auth-Error-Code invalid_auth_signature",
+    )
     fun `preHandle malformed initData returns false with 401 and invalid_auth_signature header`() {
         whenever(request.method).thenReturn("POST")
         whenever(request.getHeader(headerName)).thenReturn("malformed")
@@ -124,7 +127,7 @@ class TelegramAuthInterceptorTest {
         assertTrue(result)
         verify(request).setAttribute(
             TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE,
-            telegramUser.copy(isAdmin = true)
+            telegramUser.copy(isAdmin = true),
         )
         verifyNoMoreInteractions(response)
     }
@@ -145,13 +148,15 @@ class TelegramAuthInterceptorTest {
         assertTrue(result)
         verify(request).setAttribute(
             TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE,
-            telegramUser.copy(isAdmin = false)
+            telegramUser.copy(isAdmin = false),
         )
         verifyNoMoreInteractions(response)
     }
 
     @Test
-    @DisplayName("preHandle(): expired auth_date (verifySignature returns false) - 403, X-Auth-Error-Code session_expired")
+    @DisplayName(
+        "preHandle(): expired auth_date (verifySignature returns false) - 403, X-Auth-Error-Code session_expired",
+    )
     fun `preHandle expired auth_date returns false with 403 and session_expired header`() {
         whenever(request.method).thenReturn("POST")
         whenever(request.getHeader(headerName)).thenReturn("expired-data")
@@ -166,12 +171,12 @@ class TelegramAuthInterceptorTest {
     }
 
     companion object {
-
         @JvmStatic
-        fun provideMissingOrBlankHeaders(): Stream<Arguments> = Stream.of(
-            Arguments.of(null as String?), // header absent
-            Arguments.of(""),              // empty
-            Arguments.of("   "),           // whitespace only
-        )
+        fun provideMissingOrBlankHeaders(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of(null as String?), // header absent
+                Arguments.of(""), // empty
+                Arguments.of("   "), // whitespace only
+            )
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptorTest.kt
@@ -10,8 +10,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
 import java.util.stream.Stream
 import ru.illine.drinking.ponies.config.web.security.AuthErrorType
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
@@ -35,17 +39,17 @@ class TelegramAuthInterceptorTest {
 
     @BeforeEach
     fun setUp() {
-        validatorService = mock(TelegramValidatorService::class.java)
-        telegramUserAccessService = mock(TelegramUserAccessService::class.java)
-        request = mock(HttpServletRequest::class.java)
-        response = mock(HttpServletResponse::class.java)
+        validatorService = mock<TelegramValidatorService>()
+        telegramUserAccessService = mock<TelegramUserAccessService>()
+        request = mock<HttpServletRequest>()
+        response = mock<HttpServletResponse>()
         interceptor = TelegramAuthInterceptor(validatorService, telegramUserAccessService)
     }
 
     @Test
     @DisplayName("preHandle(): OPTIONS request - returns true without validation")
     fun `preHandle OPTIONS request returns true`() {
-        `when`(request.method).thenReturn("OPTIONS")
+        whenever(request.method).thenReturn("OPTIONS")
 
         val result = interceptor.preHandle(request, response, Any())
 
@@ -60,8 +64,8 @@ class TelegramAuthInterceptorTest {
     fun `preHandle missing or blank header returns false with 401 and invalid_auth_signature header`(
         headerValue: String?,
     ) {
-        `when`(request.method).thenReturn("POST")
-        `when`(request.getHeader(headerName)).thenReturn(headerValue)
+        whenever(request.method).thenReturn("POST")
+        whenever(request.getHeader(headerName)).thenReturn(headerValue)
 
         val result = interceptor.preHandle(request, response, Any())
 
@@ -75,9 +79,9 @@ class TelegramAuthInterceptorTest {
     @Test
     @DisplayName("preHandle(): malformed initData (verifySignature throws) - 401, X-Auth-Error-Code invalid_auth_signature")
     fun `preHandle malformed initData returns false with 401 and invalid_auth_signature header`() {
-        `when`(request.method).thenReturn("POST")
-        `when`(request.getHeader(headerName)).thenReturn("malformed")
-        `when`(validatorService.verifySignature(any()))
+        whenever(request.method).thenReturn("POST")
+        whenever(request.getHeader(headerName)).thenReturn("malformed")
+        whenever(validatorService.verifySignature(any()))
             .thenThrow(InvalidAuthSignatureException("Failed to decode 'initData'"))
 
         val result = interceptor.preHandle(request, response, Any())
@@ -91,9 +95,9 @@ class TelegramAuthInterceptorTest {
     @Test
     @DisplayName("preHandle(): unexpected exception during verify - 401, X-Auth-Error-Code unknown")
     fun `preHandle unexpected exception returns false with 401 and unknown header`() {
-        `when`(request.method).thenReturn("POST")
-        `when`(request.getHeader(headerName)).thenReturn("data")
-        `when`(validatorService.verifySignature(any()))
+        whenever(request.method).thenReturn("POST")
+        whenever(request.getHeader(headerName)).thenReturn("data")
+        whenever(validatorService.verifySignature(any()))
             .thenThrow(RuntimeException("boom"))
 
         val result = interceptor.preHandle(request, response, Any())
@@ -109,11 +113,11 @@ class TelegramAuthInterceptorTest {
     fun `preHandle valid signature enriches isAdmin true`() {
         val initData = "valid-init-data"
         val telegramUser = TelegramUserDto(externalUserId = 1L, firstName = "Test", lastName = null, username = null)
-        `when`(request.method).thenReturn("POST")
-        `when`(request.getHeader(headerName)).thenReturn(initData)
-        `when`(validatorService.verifySignature(any())).thenReturn(true)
-        `when`(validatorService.map(initData)).thenReturn(telegramUser)
-        `when`(telegramUserAccessService.findIsAdminByExternalUserId(1L)).thenReturn(true)
+        whenever(request.method).thenReturn("POST")
+        whenever(request.getHeader(headerName)).thenReturn(initData)
+        whenever(validatorService.verifySignature(any())).thenReturn(true)
+        whenever(validatorService.map(initData)).thenReturn(telegramUser)
+        whenever(telegramUserAccessService.findIsAdminByExternalUserId(1L)).thenReturn(true)
 
         val result = interceptor.preHandle(request, response, Any())
 
@@ -130,11 +134,11 @@ class TelegramAuthInterceptorTest {
     fun `preHandle valid signature enriches isAdmin false`() {
         val initData = "valid-init-data"
         val telegramUser = TelegramUserDto(externalUserId = 2L, firstName = "Test", lastName = null, username = null)
-        `when`(request.method).thenReturn("POST")
-        `when`(request.getHeader(headerName)).thenReturn(initData)
-        `when`(validatorService.verifySignature(any())).thenReturn(true)
-        `when`(validatorService.map(initData)).thenReturn(telegramUser)
-        `when`(telegramUserAccessService.findIsAdminByExternalUserId(2L)).thenReturn(false)
+        whenever(request.method).thenReturn("POST")
+        whenever(request.getHeader(headerName)).thenReturn(initData)
+        whenever(validatorService.verifySignature(any())).thenReturn(true)
+        whenever(validatorService.map(initData)).thenReturn(telegramUser)
+        whenever(telegramUserAccessService.findIsAdminByExternalUserId(2L)).thenReturn(false)
 
         val result = interceptor.preHandle(request, response, Any())
 
@@ -149,9 +153,9 @@ class TelegramAuthInterceptorTest {
     @Test
     @DisplayName("preHandle(): expired auth_date (verifySignature returns false) - 403, X-Auth-Error-Code session_expired")
     fun `preHandle expired auth_date returns false with 403 and session_expired header`() {
-        `when`(request.method).thenReturn("POST")
-        `when`(request.getHeader(headerName)).thenReturn("expired-data")
-        `when`(validatorService.verifySignature(any())).thenReturn(false)
+        whenever(request.method).thenReturn("POST")
+        whenever(request.getHeader(headerName)).thenReturn("expired-data")
+        whenever(validatorService.verifySignature(any())).thenReturn(false)
 
         val result = interceptor.preHandle(request, response, Any())
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptorTest.kt
@@ -108,7 +108,7 @@ class TelegramAuthInterceptorTest {
     @DisplayName("preHandle(): valid signature - enriches isAdmin=true and sets telegramUser attribute")
     fun `preHandle valid signature enriches isAdmin true`() {
         val initData = "valid-init-data"
-        val telegramUser = TelegramUserDto(telegramId = 1L, firstName = "Test", lastName = null, username = null)
+        val telegramUser = TelegramUserDto(externalUserId = 1L, firstName = "Test", lastName = null, username = null)
         `when`(request.method).thenReturn("POST")
         `when`(request.getHeader(headerName)).thenReturn(initData)
         `when`(validatorService.verifySignature(any())).thenReturn(true)
@@ -129,7 +129,7 @@ class TelegramAuthInterceptorTest {
     @DisplayName("preHandle(): valid signature - enriches isAdmin=false when access service returns false")
     fun `preHandle valid signature enriches isAdmin false`() {
         val initData = "valid-init-data"
-        val telegramUser = TelegramUserDto(telegramId = 2L, firstName = "Test", lastName = null, username = null)
+        val telegramUser = TelegramUserDto(externalUserId = 2L, firstName = "Test", lastName = null, username = null)
         `when`(request.method).thenReturn("POST")
         `when`(request.getHeader(headerName)).thenReturn(initData)
         `when`(validatorService.verifySignature(any())).thenReturn(true)

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/NotificationControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/NotificationControllerTest.kt
@@ -8,8 +8,12 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.http.HttpEntity
@@ -42,8 +46,8 @@ class NotificationControllerTest @Autowired constructor(
 
     @BeforeEach
     fun setUp() {
-        `when`(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        `when`(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
     }
 
     private fun buildHeaders(): HttpHeaders {
@@ -60,7 +64,7 @@ class NotificationControllerTest @Autowired constructor(
         @DisplayName("valid request - returns 200 with next notification time")
         fun `returns 200 with next notification time`() {
             val expectedInstant = Instant.parse("2025-01-01T14:00:00Z")
-            `when`(notificationSettingsService.getNextNotificationAt(any())).thenReturn(expectedInstant)
+            whenever(notificationSettingsService.getNextNotificationAt(any())).thenReturn(expectedInstant)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -77,7 +81,7 @@ class NotificationControllerTest @Autowired constructor(
         @DisplayName("service throws IllegalArgumentException - returns 400")
         fun `returns 400 when service throws`() {
             doThrow(IllegalArgumentException("User not found"))
-                .`when`(notificationSettingsService).getNextNotificationAt(any())
+                .whenever(notificationSettingsService).getNextNotificationAt(any())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -102,7 +106,7 @@ class NotificationControllerTest @Autowired constructor(
         @DisplayName("settings not found (e.g. disabled user) - returns 404")
         fun `returns 404 when settings not found`() {
             doThrow(NotificationSettingsNotFoundException("Not found"))
-                .`when`(notificationSettingsService).getNextNotificationAt(any())
+                .whenever(notificationSettingsService).getNextNotificationAt(any())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -123,7 +127,7 @@ class NotificationControllerTest @Autowired constructor(
         fun `returns 200 with paused true`() {
             val expectedPauseUntil = Instant.parse("2025-01-01T18:00:00Z")
             val expected = PauseStateResponse(paused = true, pauseUntil = expectedPauseUntil)
-            `when`(notificationSettingsService.getPauseState(any())).thenReturn(expected)
+            whenever(notificationSettingsService.getPauseState(any())).thenReturn(expected)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -141,7 +145,7 @@ class NotificationControllerTest @Autowired constructor(
         @DisplayName("not paused - returns 200 with paused=false and null pauseUntil")
         fun `returns 200 with paused false`() {
             val expected = PauseStateResponse(paused = false, pauseUntil = null)
-            `when`(notificationSettingsService.getPauseState(any())).thenReturn(expected)
+            whenever(notificationSettingsService.getPauseState(any())).thenReturn(expected)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -169,7 +173,7 @@ class NotificationControllerTest @Autowired constructor(
         @DisplayName("settings not found (e.g. disabled user) - returns 404")
         fun `returns 404 when settings not found`() {
             doThrow(NotificationSettingsNotFoundException("Not found"))
-                .`when`(notificationSettingsService).getPauseState(any())
+                .whenever(notificationSettingsService).getPauseState(any())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -195,7 +199,7 @@ class NotificationControllerTest @Autowired constructor(
 
             assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
             verify(notificationSettingsService).pauseNotifications(telegramUser.externalUserId, 60)
-            verify(notificationSettingsService, never()).cancelPause(anyLong())
+            verify(notificationSettingsService, never()).cancelPause(any<Long>())
         }
 
         @Test
@@ -209,7 +213,7 @@ class NotificationControllerTest @Autowired constructor(
 
             assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
             verify(notificationSettingsService).cancelPause(telegramUser.externalUserId)
-            verify(notificationSettingsService, never()).pauseNotifications(anyLong(), anyLong())
+            verify(notificationSettingsService, never()).pauseNotifications(any<Long>(), any<Long>())
         }
 
         @ParameterizedTest(name = "[{index}] minutes={0} - returns 400 from @Min/@Max validation")
@@ -267,7 +271,7 @@ class NotificationControllerTest @Autowired constructor(
         @DisplayName("settings not found (e.g. disabled user) - returns 404")
         fun `returns 404 when settings not found`() {
             doThrow(NotificationSettingsNotFoundException("Not found"))
-                .`when`(notificationSettingsService).pauseNotifications(anyLong(), anyLong())
+                .whenever(notificationSettingsService).pauseNotifications(any<Long>(), any<Long>())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/NotificationControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/NotificationControllerTest.kt
@@ -32,253 +32,314 @@ import java.time.Instant
 
 @SpringIntegrationTest
 @DisplayName("NotificationController Spring Integration Test")
-class NotificationControllerTest @Autowired constructor(
-    private val restTemplate: TestRestTemplate
-) {
+class NotificationControllerTest
+    @Autowired
+    constructor(
+        private val restTemplate: TestRestTemplate,
+    ) {
+        @MockitoBean
+        private lateinit var telegramValidatorService: TelegramValidatorService
 
-    @MockitoBean
-    private lateinit var telegramValidatorService: TelegramValidatorService
+        @MockitoBean
+        private lateinit var notificationSettingsService: NotificationSettingsService
 
-    @MockitoBean
-    private lateinit var notificationSettingsService: NotificationSettingsService
+        private val telegramUser = DtoGenerator.generateTelegramUserDto()
 
-    private val telegramUser = DtoGenerator.generateTelegramUserDto()
+        @BeforeEach
+        fun setUp() {
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+            whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        }
 
-    @BeforeEach
-    fun setUp() {
-        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
-    }
+        private fun buildHeaders(): HttpHeaders =
+            HttpHeaders().apply {
+                set("X-Authorization-Telegram-Data", "test-init-data")
+            }
 
-    private fun buildHeaders(): HttpHeaders {
-        return HttpHeaders().apply {
-            set("X-Authorization-Telegram-Data", "test-init-data")
+        @Nested
+        @DisplayName("GET /notifications/next")
+        inner class GetNextNotification {
+            @Test
+            @DisplayName("valid request - returns 200 with next notification time")
+            fun `returns 200 with next notification time`() {
+                val expectedInstant = Instant.parse("2025-01-01T14:00:00Z")
+                whenever(notificationSettingsService.getNextNotificationAt(any())).thenReturn(expectedInstant)
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/next",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        NotificationNextResponse::class.java,
+                    )
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertNotNull(response.body)
+                assertEquals(expectedInstant, response.body!!.nextNotificationAt)
+                verify(notificationSettingsService).getNextNotificationAt(any())
+            }
+
+            @Test
+            @DisplayName("service throws IllegalArgumentException - returns 400")
+            fun `returns 400 when service throws`() {
+                doThrow(IllegalArgumentException("User not found"))
+                    .whenever(notificationSettingsService)
+                    .getNextNotificationAt(any())
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/next",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+            }
+
+            @Test
+            @DisplayName("missing auth header - returns 401")
+            fun `returns 401`() {
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/next",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(HttpHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                verifyNoInteractions(notificationSettingsService)
+            }
+
+            @Test
+            @DisplayName("settings not found (e.g. disabled user) - returns 404")
+            fun `returns 404 when settings not found`() {
+                doThrow(NotificationSettingsNotFoundException("Not found"))
+                    .whenever(notificationSettingsService)
+                    .getNextNotificationAt(any())
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/next",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+                verify(notificationSettingsService).getNextNotificationAt(any())
+            }
+        }
+
+        @Nested
+        @DisplayName("GET /notifications/pause")
+        inner class GetPauseState {
+            @Test
+            @DisplayName("paused user - returns 200 with paused=true and pauseUntil")
+            fun `returns 200 with paused true`() {
+                val expectedPauseUntil = Instant.parse("2025-01-01T18:00:00Z")
+                val expected = PauseStateResponse(paused = true, pauseUntil = expectedPauseUntil)
+                whenever(notificationSettingsService.getPauseState(any())).thenReturn(expected)
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/pause",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        PauseStateResponse::class.java,
+                    )
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertNotNull(response.body)
+                assertEquals(true, response.body!!.paused)
+                assertEquals(expectedPauseUntil, response.body!!.pauseUntil)
+                verify(notificationSettingsService).getPauseState(any())
+            }
+
+            @Test
+            @DisplayName("not paused - returns 200 with paused=false and null pauseUntil")
+            fun `returns 200 with paused false`() {
+                val expected = PauseStateResponse(paused = false, pauseUntil = null)
+                whenever(notificationSettingsService.getPauseState(any())).thenReturn(expected)
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/pause",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        PauseStateResponse::class.java,
+                    )
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertNotNull(response.body)
+                assertEquals(false, response.body!!.paused)
+                assertEquals(null, response.body!!.pauseUntil)
+            }
+
+            @Test
+            @DisplayName("missing auth header - returns 401")
+            fun `returns 401`() {
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/pause",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(HttpHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                verifyNoInteractions(notificationSettingsService)
+            }
+
+            @Test
+            @DisplayName("settings not found (e.g. disabled user) - returns 404")
+            fun `returns 404 when settings not found`() {
+                doThrow(NotificationSettingsNotFoundException("Not found"))
+                    .whenever(notificationSettingsService)
+                    .getPauseState(any())
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/pause",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+            }
+        }
+
+        @Nested
+        @DisplayName("PUT /notifications/pause")
+        inner class ChangePause {
+            @Test
+            @DisplayName("minutes=60 - returns 204 and calls pauseNotifications")
+            fun `returns 204 on pause`() {
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/pause?minutes=60",
+                        HttpMethod.PUT,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
+                verify(notificationSettingsService).pauseNotifications(telegramUser.externalUserId, 60)
+                verify(notificationSettingsService, never()).cancelPause(any<Long>())
+            }
+
+            @Test
+            @DisplayName("minutes=0 - returns 204 and calls cancelPause")
+            fun `returns 204 on cancel`() {
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/pause?minutes=0",
+                        HttpMethod.PUT,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
+                verify(notificationSettingsService).cancelPause(telegramUser.externalUserId)
+                verify(notificationSettingsService, never()).pauseNotifications(any<Long>(), any<Long>())
+            }
+
+            @ParameterizedTest(name = "[{index}] minutes={0} - returns 400 from @Min/@Max validation")
+            @ValueSource(longs = [-1, 301])
+            @DisplayName("minutes out of [0, 300] range - returns 400 from validation")
+            fun `returns 400 on out-of-range minutes`(minutes: Long) {
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/pause?minutes=$minutes",
+                        HttpMethod.PUT,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                verifyNoInteractions(notificationSettingsService)
+            }
+
+            @Test
+            @DisplayName("missing minutes param - returns 400")
+            fun `returns 400 on missing minutes`() {
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/pause",
+                        HttpMethod.PUT,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                verifyNoInteractions(notificationSettingsService)
+            }
+
+            @Test
+            @DisplayName("invalid minutes type - returns 400")
+            fun `returns 400 on invalid minutes type`() {
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/pause?minutes=abc",
+                        HttpMethod.PUT,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                verifyNoInteractions(notificationSettingsService)
+            }
+
+            @Test
+            @DisplayName("missing auth header - returns 401")
+            fun `returns 401`() {
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/pause?minutes=60",
+                        HttpMethod.PUT,
+                        HttpEntity<Void>(HttpHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                verifyNoInteractions(notificationSettingsService)
+            }
+
+            @Test
+            @DisplayName("settings not found (e.g. disabled user) - returns 404")
+            fun `returns 404 when settings not found`() {
+                doThrow(NotificationSettingsNotFoundException("Not found"))
+                    .whenever(notificationSettingsService)
+                    .pauseNotifications(any<Long>(), any<Long>())
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/pause?minutes=60",
+                        HttpMethod.PUT,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+            }
         }
     }
-
-    @Nested
-    @DisplayName("GET /notifications/next")
-    inner class GetNextNotification {
-
-        @Test
-        @DisplayName("valid request - returns 200 with next notification time")
-        fun `returns 200 with next notification time`() {
-            val expectedInstant = Instant.parse("2025-01-01T14:00:00Z")
-            whenever(notificationSettingsService.getNextNotificationAt(any())).thenReturn(expectedInstant)
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/notifications/next", HttpMethod.GET, HttpEntity<Void>(headers), NotificationNextResponse::class.java
-            )
-
-            assertEquals(HttpStatus.OK, response.statusCode)
-            assertNotNull(response.body)
-            assertEquals(expectedInstant, response.body!!.nextNotificationAt)
-            verify(notificationSettingsService).getNextNotificationAt(any())
-        }
-
-        @Test
-        @DisplayName("service throws IllegalArgumentException - returns 400")
-        fun `returns 400 when service throws`() {
-            doThrow(IllegalArgumentException("User not found"))
-                .whenever(notificationSettingsService).getNextNotificationAt(any())
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/notifications/next", HttpMethod.GET, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-        }
-
-        @Test
-        @DisplayName("missing auth header - returns 401")
-        fun `returns 401`() {
-            val response = restTemplate.exchange(
-                "/notifications/next", HttpMethod.GET, HttpEntity<Void>(HttpHeaders()), Void::class.java
-            )
-
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-            verifyNoInteractions(notificationSettingsService)
-        }
-
-        @Test
-        @DisplayName("settings not found (e.g. disabled user) - returns 404")
-        fun `returns 404 when settings not found`() {
-            doThrow(NotificationSettingsNotFoundException("Not found"))
-                .whenever(notificationSettingsService).getNextNotificationAt(any())
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/notifications/next", HttpMethod.GET, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
-            verify(notificationSettingsService).getNextNotificationAt(any())
-        }
-    }
-
-    @Nested
-    @DisplayName("GET /notifications/pause")
-    inner class GetPauseState {
-
-        @Test
-        @DisplayName("paused user - returns 200 with paused=true and pauseUntil")
-        fun `returns 200 with paused true`() {
-            val expectedPauseUntil = Instant.parse("2025-01-01T18:00:00Z")
-            val expected = PauseStateResponse(paused = true, pauseUntil = expectedPauseUntil)
-            whenever(notificationSettingsService.getPauseState(any())).thenReturn(expected)
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/notifications/pause", HttpMethod.GET, HttpEntity<Void>(headers), PauseStateResponse::class.java
-            )
-
-            assertEquals(HttpStatus.OK, response.statusCode)
-            assertNotNull(response.body)
-            assertEquals(true, response.body!!.paused)
-            assertEquals(expectedPauseUntil, response.body!!.pauseUntil)
-            verify(notificationSettingsService).getPauseState(any())
-        }
-
-        @Test
-        @DisplayName("not paused - returns 200 with paused=false and null pauseUntil")
-        fun `returns 200 with paused false`() {
-            val expected = PauseStateResponse(paused = false, pauseUntil = null)
-            whenever(notificationSettingsService.getPauseState(any())).thenReturn(expected)
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/notifications/pause", HttpMethod.GET, HttpEntity<Void>(headers), PauseStateResponse::class.java
-            )
-
-            assertEquals(HttpStatus.OK, response.statusCode)
-            assertNotNull(response.body)
-            assertEquals(false, response.body!!.paused)
-            assertEquals(null, response.body!!.pauseUntil)
-        }
-
-        @Test
-        @DisplayName("missing auth header - returns 401")
-        fun `returns 401`() {
-            val response = restTemplate.exchange(
-                "/notifications/pause", HttpMethod.GET, HttpEntity<Void>(HttpHeaders()), Void::class.java
-            )
-
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-            verifyNoInteractions(notificationSettingsService)
-        }
-
-        @Test
-        @DisplayName("settings not found (e.g. disabled user) - returns 404")
-        fun `returns 404 when settings not found`() {
-            doThrow(NotificationSettingsNotFoundException("Not found"))
-                .whenever(notificationSettingsService).getPauseState(any())
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/notifications/pause", HttpMethod.GET, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
-        }
-    }
-
-    @Nested
-    @DisplayName("PUT /notifications/pause")
-    inner class ChangePause {
-
-        @Test
-        @DisplayName("minutes=60 - returns 204 and calls pauseNotifications")
-        fun `returns 204 on pause`() {
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/notifications/pause?minutes=60", HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
-            verify(notificationSettingsService).pauseNotifications(telegramUser.externalUserId, 60)
-            verify(notificationSettingsService, never()).cancelPause(any<Long>())
-        }
-
-        @Test
-        @DisplayName("minutes=0 - returns 204 and calls cancelPause")
-        fun `returns 204 on cancel`() {
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/notifications/pause?minutes=0", HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
-            verify(notificationSettingsService).cancelPause(telegramUser.externalUserId)
-            verify(notificationSettingsService, never()).pauseNotifications(any<Long>(), any<Long>())
-        }
-
-        @ParameterizedTest(name = "[{index}] minutes={0} - returns 400 from @Min/@Max validation")
-        @ValueSource(longs = [-1, 301])
-        @DisplayName("minutes out of [0, 300] range - returns 400 from validation")
-        fun `returns 400 on out-of-range minutes`(minutes: Long) {
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/notifications/pause?minutes=$minutes", HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-            verifyNoInteractions(notificationSettingsService)
-        }
-
-        @Test
-        @DisplayName("missing minutes param - returns 400")
-        fun `returns 400 on missing minutes`() {
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/notifications/pause", HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-            verifyNoInteractions(notificationSettingsService)
-        }
-
-        @Test
-        @DisplayName("invalid minutes type - returns 400")
-        fun `returns 400 on invalid minutes type`() {
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/notifications/pause?minutes=abc", HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-            verifyNoInteractions(notificationSettingsService)
-        }
-
-        @Test
-        @DisplayName("missing auth header - returns 401")
-        fun `returns 401`() {
-            val response = restTemplate.exchange(
-                "/notifications/pause?minutes=60", HttpMethod.PUT, HttpEntity<Void>(HttpHeaders()), Void::class.java
-            )
-
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-            verifyNoInteractions(notificationSettingsService)
-        }
-
-        @Test
-        @DisplayName("settings not found (e.g. disabled user) - returns 404")
-        fun `returns 404 when settings not found`() {
-            doThrow(NotificationSettingsNotFoundException("Not found"))
-                .whenever(notificationSettingsService).pauseNotifications(any<Long>(), any<Long>())
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/notifications/pause?minutes=60", HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
-        }
-    }
-}

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/NotificationControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/NotificationControllerTest.kt
@@ -194,7 +194,7 @@ class NotificationControllerTest @Autowired constructor(
             )
 
             assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
-            verify(notificationSettingsService).pauseNotifications(telegramUser.telegramId, 60)
+            verify(notificationSettingsService).pauseNotifications(telegramUser.externalUserId, 60)
             verify(notificationSettingsService, never()).cancelPause(anyLong())
         }
 
@@ -208,7 +208,7 @@ class NotificationControllerTest @Autowired constructor(
             )
 
             assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
-            verify(notificationSettingsService).cancelPause(telegramUser.telegramId)
+            verify(notificationSettingsService).cancelPause(telegramUser.externalUserId)
             verify(notificationSettingsService, never()).pauseNotifications(anyLong(), anyLong())
         }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/SettingControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/SettingControllerTest.kt
@@ -7,8 +7,11 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.http.HttpEntity
@@ -40,8 +43,8 @@ class SettingControllerTest @Autowired constructor(
 
     @BeforeEach
     fun setUp() {
-        `when`(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        `when`(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
     }
 
     private fun buildHeaders(): HttpHeaders {
@@ -59,7 +62,7 @@ class SettingControllerTest @Autowired constructor(
         fun `returns 200 with all settings`() {
             val expectedInterval = IntervalNotificationType.HOUR_AND_HALF
             val settingDto = DtoGenerator.generateSettingDto()
-            `when`(notificationSettingsService.getAllSettings(any())).thenReturn(settingDto)
+            whenever(notificationSettingsService.getAllSettings(any())).thenReturn(settingDto)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -81,7 +84,7 @@ class SettingControllerTest @Autowired constructor(
         @DisplayName("notifications disabled - returns 200 with notificationActive=false")
         fun `returns 200 with only notificationActive when disabled`() {
             val settingDto = SettingDto(notificationActive = false)
-            `when`(notificationSettingsService.getAllSettings(any())).thenReturn(settingDto)
+            whenever(notificationSettingsService.getAllSettings(any())).thenReturn(settingDto)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -250,7 +253,7 @@ class SettingControllerTest @Autowired constructor(
         @DisplayName("invalid timezone value - returns 400")
         fun `returns 400 when invalid timezone value`() {
             doThrow(IllegalArgumentException("Invalid timezone"))
-                .`when`(notificationSettingsService).changeTimezone(any(), any())
+                .whenever(notificationSettingsService).changeTimezone(any(), any())
             val headers = buildHeaders()
             val url = "/settings/timezone?timezone=Invalid/Zone"
 
@@ -368,7 +371,7 @@ class SettingControllerTest @Autowired constructor(
         @DisplayName("service rejects out-of-range / non-allowed goalMl - returns 400")
         fun `returns 400 when service rejects goalMl`(goalMl: Int) {
             doThrow(IllegalArgumentException("Daily goal must be one of [2000, 2250, 2500, 2750, 3000] ml, got: $goalMl"))
-                .`when`(notificationSettingsService).changeDailyGoal(any(), any())
+                .whenever(notificationSettingsService).changeDailyGoal(any(), any())
             val headers = buildHeaders()
             val url = "/settings/goal?goalMl=$goalMl"
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/SettingControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/SettingControllerTest.kt
@@ -29,355 +29,395 @@ import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
 
 @SpringIntegrationTest
 @DisplayName("SettingController Spring Integration Test")
-class SettingControllerTest @Autowired constructor(
-    private val restTemplate: TestRestTemplate
-) {
+class SettingControllerTest
+    @Autowired
+    constructor(
+        private val restTemplate: TestRestTemplate,
+    ) {
+        @MockitoBean
+        private lateinit var telegramValidatorService: TelegramValidatorService
 
-    @MockitoBean
-    private lateinit var telegramValidatorService: TelegramValidatorService
+        @MockitoBean
+        private lateinit var notificationSettingsService: NotificationSettingsService
 
-    @MockitoBean
-    private lateinit var notificationSettingsService: NotificationSettingsService
+        private val telegramUser = DtoGenerator.generateTelegramUserDto()
 
-    private val telegramUser = DtoGenerator.generateTelegramUserDto()
-
-    @BeforeEach
-    fun setUp() {
-        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
-    }
-
-    private fun buildHeaders(): HttpHeaders {
-        return HttpHeaders().apply {
-            set("X-Authorization-Telegram-Data", "test-init-data")
+        @BeforeEach
+        fun setUp() {
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+            whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
         }
-    }
 
-    @Nested
-    @DisplayName("GET /settings")
-    inner class GetSettings {
+        private fun buildHeaders(): HttpHeaders =
+            HttpHeaders().apply {
+                set("X-Authorization-Telegram-Data", "test-init-data")
+            }
 
-        @Test
-        @DisplayName("valid request - returns 200 with all settings")
-        fun `returns 200 with all settings`() {
-            val expectedInterval = IntervalNotificationType.HOUR_AND_HALF
-            val settingDto = DtoGenerator.generateSettingDto()
-            whenever(notificationSettingsService.getAllSettings(any())).thenReturn(settingDto)
-            val headers = buildHeaders()
+        @Nested
+        @DisplayName("GET /settings")
+        inner class GetSettings {
+            @Test
+            @DisplayName("valid request - returns 200 with all settings")
+            fun `returns 200 with all settings`() {
+                val expectedInterval = IntervalNotificationType.HOUR_AND_HALF
+                val settingDto = DtoGenerator.generateSettingDto()
+                whenever(notificationSettingsService.getAllSettings(any())).thenReturn(settingDto)
+                val headers = buildHeaders()
 
-            val response = restTemplate.exchange(
-                "/settings", HttpMethod.GET, HttpEntity<Void>(headers), SettingResponse::class.java
+                val response =
+                    restTemplate.exchange(
+                        "/settings",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        SettingResponse::class.java,
+                    )
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertEquals(expectedInterval.name, response.body!!.interval)
+                assertEquals(expectedInterval.displayName, response.body!!.intervalDisplayName)
+                assertEquals(expectedInterval.minutes, response.body!!.intervalMinutes)
+                assertEquals("23:00", response.body!!.quietModeStart)
+                assertEquals("08:00", response.body!!.quietModeEnd)
+                assertEquals("America/New_York", response.body!!.timezone)
+                assertEquals(2500, response.body!!.dailyGoalMl)
+                assertEquals(true, response.body!!.notificationActive)
+            }
+
+            @Test
+            @DisplayName("notifications disabled - returns 200 with notificationActive=false")
+            fun `returns 200 with only notificationActive when disabled`() {
+                val settingDto = SettingDto(notificationActive = false)
+                whenever(notificationSettingsService.getAllSettings(any())).thenReturn(settingDto)
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/settings",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        SettingResponse::class.java,
+                    )
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertEquals(false, response.body!!.notificationActive)
+                assertEquals(null, response.body!!.interval)
+                assertEquals(null, response.body!!.intervalDisplayName)
+                assertEquals(null, response.body!!.intervalMinutes)
+                assertEquals(null, response.body!!.quietModeStart)
+                assertEquals(null, response.body!!.quietModeEnd)
+                assertEquals(null, response.body!!.timezone)
+                assertEquals(null, response.body!!.dailyGoalMl)
+            }
+
+            @Test
+            @DisplayName("missing auth header - returns 401")
+            fun `returns 401`() {
+                val response =
+                    restTemplate.exchange(
+                        "/settings",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(HttpHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                verifyNoInteractions(notificationSettingsService)
+            }
+        }
+
+        @Nested
+        @DisplayName("PUT /settings/quiet-mode")
+        inner class ChangeQuietMode {
+            @Test
+            @DisplayName("valid request - returns 204")
+            fun `returns 204`() {
+                val headers = buildHeaders()
+                val url = "/settings/quiet-mode?start=08:00&end=22:00"
+
+                val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
+
+                assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
+                verify(notificationSettingsService).changeQuietMode(any(), any(), any())
+            }
+
+            @Test
+            @DisplayName("missing header - returns 401")
+            fun `returns 401`() {
+                val url = "/settings/quiet-mode?start=08:00&end=22:00"
+
+                val response =
+                    restTemplate.exchange(
+                        url,
+                        HttpMethod.PUT,
+                        HttpEntity<Void>(HttpHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                verifyNoInteractions(notificationSettingsService)
+            }
+
+            @ParameterizedTest(name = "[{index}] query={0} - returns 400")
+            @ValueSource(
+                strings = [
+                    "?end=22:00", // missing start param
+                    "?start=08:00", // missing end param
+                    "?start=invalid&end=22:00", // invalid time format
+                ],
             )
+            @DisplayName("invalid request - returns 400")
+            fun `returns 400 on invalid request`(queryString: String) {
+                val headers = buildHeaders()
+                val url = "/settings/quiet-mode$queryString"
 
-            assertEquals(HttpStatus.OK, response.statusCode)
-            assertEquals(expectedInterval.name, response.body!!.interval)
-            assertEquals(expectedInterval.displayName, response.body!!.intervalDisplayName)
-            assertEquals(expectedInterval.minutes, response.body!!.intervalMinutes)
-            assertEquals("23:00", response.body!!.quietModeStart)
-            assertEquals("08:00", response.body!!.quietModeEnd)
-            assertEquals("America/New_York", response.body!!.timezone)
-            assertEquals(2500, response.body!!.dailyGoalMl)
-            assertEquals(true, response.body!!.notificationActive)
+                val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                verifyNoInteractions(notificationSettingsService)
+            }
         }
 
-        @Test
-        @DisplayName("notifications disabled - returns 200 with notificationActive=false")
-        fun `returns 200 with only notificationActive when disabled`() {
-            val settingDto = SettingDto(notificationActive = false)
-            whenever(notificationSettingsService.getAllSettings(any())).thenReturn(settingDto)
-            val headers = buildHeaders()
+        @Nested
+        @DisplayName("PUT /settings/interval")
+        inner class ChangeInterval {
+            @Test
+            @DisplayName("valid request - returns 204")
+            fun `returns 204`() {
+                val headers = buildHeaders()
+                val url = "/settings/interval?interval=${IntervalNotificationType.HOUR.name}"
 
-            val response = restTemplate.exchange(
-                "/settings", HttpMethod.GET, HttpEntity<Void>(headers), SettingResponse::class.java
-            )
+                val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
 
-            assertEquals(HttpStatus.OK, response.statusCode)
-            assertEquals(false, response.body!!.notificationActive)
-            assertEquals(null, response.body!!.interval)
-            assertEquals(null, response.body!!.intervalDisplayName)
-            assertEquals(null, response.body!!.intervalMinutes)
-            assertEquals(null, response.body!!.quietModeStart)
-            assertEquals(null, response.body!!.quietModeEnd)
-            assertEquals(null, response.body!!.timezone)
-            assertEquals(null, response.body!!.dailyGoalMl)
+                assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
+                verify(notificationSettingsService).changeInterval(any<Long>(), any<IntervalNotificationType>())
+            }
+
+            @Test
+            @DisplayName("missing auth header - returns 401")
+            fun `returns 401`() {
+                val url = "/settings/interval?interval=${IntervalNotificationType.HOUR.name}"
+
+                val response =
+                    restTemplate.exchange(
+                        url,
+                        HttpMethod.PUT,
+                        HttpEntity<Void>(HttpHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                verifyNoInteractions(notificationSettingsService)
+            }
+
+            @Test
+            @DisplayName("missing interval param - returns 400")
+            fun `returns 400 when missing param`() {
+                val headers = buildHeaders()
+                val url = "/settings/interval"
+
+                val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+            }
+
+            @Test
+            @DisplayName("invalid interval value - returns 400")
+            fun `returns 400 when invalid value`() {
+                val headers = buildHeaders()
+                val url = "/settings/interval?interval=INVALID_VALUE"
+
+                val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+            }
         }
 
-        @Test
-        @DisplayName("missing auth header - returns 401")
-        fun `returns 401`() {
-            val response = restTemplate.exchange(
-                "/settings", HttpMethod.GET, HttpEntity<Void>(HttpHeaders()), Void::class.java
-            )
+        @Nested
+        @DisplayName("PUT /settings/timezone")
+        inner class ChangeTimezone {
+            @Test
+            @DisplayName("valid request - returns 204")
+            fun `returns 204`() {
+                val headers = buildHeaders()
+                val url = "/settings/timezone?timezone=Europe/Berlin"
 
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-            verifyNoInteractions(notificationSettingsService)
-        }
-    }
+                val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
 
-    @Nested
-    @DisplayName("PUT /settings/quiet-mode")
-    inner class ChangeQuietMode {
+                assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
+                verify(notificationSettingsService).changeTimezone(any(), any())
+            }
 
-        @Test
-        @DisplayName("valid request - returns 204")
-        fun `returns 204`() {
-            val headers = buildHeaders()
-            val url = "/settings/quiet-mode?start=08:00&end=22:00"
+            @Test
+            @DisplayName("missing auth header - returns 401")
+            fun `returns 401`() {
+                val url = "/settings/timezone?timezone=Europe/Berlin"
 
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
+                val response =
+                    restTemplate.exchange(
+                        url,
+                        HttpMethod.PUT,
+                        HttpEntity<Void>(HttpHeaders()),
+                        Void::class.java,
+                    )
 
-            assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
-            verify(notificationSettingsService).changeQuietMode(any(), any(), any())
-        }
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                verifyNoInteractions(notificationSettingsService)
+            }
 
-        @Test
-        @DisplayName("missing header - returns 401")
-        fun `returns 401`() {
-            val url = "/settings/quiet-mode?start=08:00&end=22:00"
+            @Test
+            @DisplayName("missing timezone param - returns 400")
+            fun `returns 400 when missing param`() {
+                val headers = buildHeaders()
+                val url = "/settings/timezone"
 
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(HttpHeaders()), Void::class.java)
+                val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
 
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-            verifyNoInteractions(notificationSettingsService)
-        }
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+            }
 
-        @ParameterizedTest(name = "[{index}] query={0} - returns 400")
-        @ValueSource(
-            strings = [
-                "?end=22:00",                  // missing start param
-                "?start=08:00",                // missing end param
-                "?start=invalid&end=22:00",    // invalid time format
-            ]
-        )
-        @DisplayName("invalid request - returns 400")
-        fun `returns 400 on invalid request`(queryString: String) {
-            val headers = buildHeaders()
-            val url = "/settings/quiet-mode$queryString"
+            @Test
+            @DisplayName("invalid timezone value - returns 400")
+            fun `returns 400 when invalid timezone value`() {
+                doThrow(IllegalArgumentException("Invalid timezone"))
+                    .whenever(notificationSettingsService)
+                    .changeTimezone(any(), any())
+                val headers = buildHeaders()
+                val url = "/settings/timezone?timezone=Invalid/Zone"
 
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
+                val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
 
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-            verifyNoInteractions(notificationSettingsService)
-        }
-    }
-
-    @Nested
-    @DisplayName("PUT /settings/interval")
-    inner class ChangeInterval {
-
-        @Test
-        @DisplayName("valid request - returns 204")
-        fun `returns 204`() {
-            val headers = buildHeaders()
-            val url = "/settings/interval?interval=${IntervalNotificationType.HOUR.name}"
-
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
-
-            assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
-            verify(notificationSettingsService).changeInterval(any<Long>(), any<IntervalNotificationType>())
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+            }
         }
 
-        @Test
-        @DisplayName("missing auth header - returns 401")
-        fun `returns 401`() {
-            val url = "/settings/interval?interval=${IntervalNotificationType.HOUR.name}"
+        @Nested
+        @DisplayName("PUT /settings/notification-status")
+        inner class ChangeNotificationStatus {
+            @ParameterizedTest(name = "[{index}] active={0} - returns 204")
+            @ValueSource(booleans = [true, false])
+            @DisplayName("valid request - returns 204")
+            fun `returns 204 on valid request`(active: Boolean) {
+                val headers = buildHeaders()
+                val url = "/settings/notification-status?active=$active"
 
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(HttpHeaders()), Void::class.java)
+                val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
 
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-            verifyNoInteractions(notificationSettingsService)
+                assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
+                verify(notificationSettingsService).changeNotificationStatus(telegramUser.externalUserId, active)
+            }
+
+            @Test
+            @DisplayName("missing auth header - returns 401")
+            fun `returns 401`() {
+                val url = "/settings/notification-status?active=false"
+
+                val response =
+                    restTemplate.exchange(
+                        url,
+                        HttpMethod.PUT,
+                        HttpEntity<Void>(HttpHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                verifyNoInteractions(notificationSettingsService)
+            }
+
+            @Test
+            @DisplayName("missing active param - returns 400")
+            fun `returns 400`() {
+                val headers = buildHeaders()
+                val url = "/settings/notification-status"
+
+                val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+            }
+
+            @Test
+            @DisplayName("invalid active value - returns 400")
+            fun `returns 400 when invalid active value`() {
+                val headers = buildHeaders()
+                val url = "/settings/notification-status?active=INVALID"
+
+                val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+            }
         }
 
-        @Test
-        @DisplayName("missing interval param - returns 400")
-        fun `returns 400 when missing param`() {
-            val headers = buildHeaders()
-            val url = "/settings/interval"
+        @Nested
+        @DisplayName("PUT /settings/goal")
+        inner class ChangeDailyGoal {
+            @Test
+            @DisplayName("valid request goalMl=2500 - returns 204 and delegates to service")
+            fun `returns 204 on valid goal`() {
+                val headers = buildHeaders()
+                val url = "/settings/goal?goalMl=2500"
 
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
+                val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
 
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-        }
+                assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
+                verify(notificationSettingsService).changeDailyGoal(telegramUser.externalUserId, 2500)
+            }
 
-        @Test
-        @DisplayName("invalid interval value - returns 400")
-        fun `returns 400 when invalid value`() {
-            val headers = buildHeaders()
-            val url = "/settings/interval?interval=INVALID_VALUE"
+            @Test
+            @DisplayName("missing auth header - returns 401")
+            fun `returns 401`() {
+                val url = "/settings/goal?goalMl=2500"
 
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
+                val response =
+                    restTemplate.exchange(
+                        url,
+                        HttpMethod.PUT,
+                        HttpEntity<Void>(HttpHeaders()),
+                        Void::class.java,
+                    )
 
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-        }
-    }
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                verifyNoInteractions(notificationSettingsService)
+            }
 
-    @Nested
-    @DisplayName("PUT /settings/timezone")
-    inner class ChangeTimezone {
+            @Test
+            @DisplayName("missing goalMl param - returns 400")
+            fun `returns 400 on missing param`() {
+                val headers = buildHeaders()
+                val url = "/settings/goal"
 
-        @Test
-        @DisplayName("valid request - returns 204")
-        fun `returns 204`() {
-            val headers = buildHeaders()
-            val url = "/settings/timezone?timezone=Europe/Berlin"
+                val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
 
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                verifyNoInteractions(notificationSettingsService)
+            }
 
-            assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
-            verify(notificationSettingsService).changeTimezone(any(), any())
-        }
+            @Test
+            @DisplayName("invalid goalMl type - returns 400")
+            fun `returns 400 on invalid goal type`() {
+                val headers = buildHeaders()
+                val url = "/settings/goal?goalMl=abc"
 
-        @Test
-        @DisplayName("missing auth header - returns 401")
-        fun `returns 401`() {
-            val url = "/settings/timezone?timezone=Europe/Berlin"
+                val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
 
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(HttpHeaders()), Void::class.java)
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                verifyNoInteractions(notificationSettingsService)
+            }
 
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-            verifyNoInteractions(notificationSettingsService)
-        }
+            @ParameterizedTest(name = "[{index}] goalMl={0} - service rejects, returns 400")
+            @ValueSource(ints = [1999, 3001, 2100])
+            @DisplayName("service rejects out-of-range / non-allowed goalMl - returns 400")
+            fun `returns 400 when service rejects goalMl`(goalMl: Int) {
+                doThrow(
+                    IllegalArgumentException(
+                        "Daily goal must be one of [2000, 2250, 2500, 2750, 3000] ml, got: $goalMl",
+                    ),
+                ).whenever(notificationSettingsService)
+                    .changeDailyGoal(any(), any())
+                val headers = buildHeaders()
+                val url = "/settings/goal?goalMl=$goalMl"
 
-        @Test
-        @DisplayName("missing timezone param - returns 400")
-        fun `returns 400 when missing param`() {
-            val headers = buildHeaders()
-            val url = "/settings/timezone"
+                val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
 
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-        }
-
-        @Test
-        @DisplayName("invalid timezone value - returns 400")
-        fun `returns 400 when invalid timezone value`() {
-            doThrow(IllegalArgumentException("Invalid timezone"))
-                .whenever(notificationSettingsService).changeTimezone(any(), any())
-            val headers = buildHeaders()
-            val url = "/settings/timezone?timezone=Invalid/Zone"
-
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-        }
-    }
-
-    @Nested
-    @DisplayName("PUT /settings/notification-status")
-    inner class ChangeNotificationStatus {
-
-        @ParameterizedTest(name = "[{index}] active={0} - returns 204")
-        @ValueSource(booleans = [true, false])
-        @DisplayName("valid request - returns 204")
-        fun `returns 204 on valid request`(active: Boolean) {
-            val headers = buildHeaders()
-            val url = "/settings/notification-status?active=$active"
-
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
-
-            assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
-            verify(notificationSettingsService).changeNotificationStatus(telegramUser.externalUserId, active)
-        }
-
-        @Test
-        @DisplayName("missing auth header - returns 401")
-        fun `returns 401`() {
-            val url = "/settings/notification-status?active=false"
-
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(HttpHeaders()), Void::class.java)
-
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-            verifyNoInteractions(notificationSettingsService)
-        }
-
-        @Test
-        @DisplayName("missing active param - returns 400")
-        fun `returns 400`() {
-            val headers = buildHeaders()
-            val url = "/settings/notification-status"
-
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-        }
-
-        @Test
-        @DisplayName("invalid active value - returns 400")
-        fun `returns 400 when invalid active value`() {
-            val headers = buildHeaders()
-            val url = "/settings/notification-status?active=INVALID"
-
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-        }
-    }
-
-    @Nested
-    @DisplayName("PUT /settings/goal")
-    inner class ChangeDailyGoal {
-
-        @Test
-        @DisplayName("valid request goalMl=2500 - returns 204 and delegates to service")
-        fun `returns 204 on valid goal`() {
-            val headers = buildHeaders()
-            val url = "/settings/goal?goalMl=2500"
-
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
-
-            assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
-            verify(notificationSettingsService).changeDailyGoal(telegramUser.externalUserId, 2500)
-        }
-
-        @Test
-        @DisplayName("missing auth header - returns 401")
-        fun `returns 401`() {
-            val url = "/settings/goal?goalMl=2500"
-
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(HttpHeaders()), Void::class.java)
-
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-            verifyNoInteractions(notificationSettingsService)
-        }
-
-
-        @Test
-        @DisplayName("missing goalMl param - returns 400")
-        fun `returns 400 on missing param`() {
-            val headers = buildHeaders()
-            val url = "/settings/goal"
-
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-            verifyNoInteractions(notificationSettingsService)
-        }
-
-        @Test
-        @DisplayName("invalid goalMl type - returns 400")
-        fun `returns 400 on invalid goal type`() {
-            val headers = buildHeaders()
-            val url = "/settings/goal?goalMl=abc"
-
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-            verifyNoInteractions(notificationSettingsService)
-        }
-
-        @ParameterizedTest(name = "[{index}] goalMl={0} - service rejects, returns 400")
-        @ValueSource(ints = [1999, 3001, 2100])
-        @DisplayName("service rejects out-of-range / non-allowed goalMl - returns 400")
-        fun `returns 400 when service rejects goalMl`(goalMl: Int) {
-            doThrow(IllegalArgumentException("Daily goal must be one of [2000, 2250, 2500, 2750, 3000] ml, got: $goalMl"))
-                .whenever(notificationSettingsService).changeDailyGoal(any(), any())
-            val headers = buildHeaders()
-            val url = "/settings/goal?goalMl=$goalMl"
-
-            val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+            }
         }
     }
-}

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/SettingControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/SettingControllerTest.kt
@@ -274,7 +274,7 @@ class SettingControllerTest @Autowired constructor(
             val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
 
             assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
-            verify(notificationSettingsService).changeNotificationStatus(telegramUser.telegramId, active)
+            verify(notificationSettingsService).changeNotificationStatus(telegramUser.externalUserId, active)
         }
 
         @Test
@@ -324,7 +324,7 @@ class SettingControllerTest @Autowired constructor(
             val response = restTemplate.exchange(url, HttpMethod.PUT, HttpEntity<Void>(headers), Void::class.java)
 
             assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
-            verify(notificationSettingsService).changeDailyGoal(telegramUser.telegramId, 2500)
+            verify(notificationSettingsService).changeDailyGoal(telegramUser.externalUserId, 2500)
         }
 
         @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
@@ -69,19 +69,19 @@ class StatisticsControllerTest @Autowired constructor(
         fun `returns 200 with serialized entries`() {
             val entries = listOf(
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = telegramUser.telegramId,
+                    externalUserId = telegramUser.externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 7, 8, 15, 0),
                     eventType = AnswerNotificationType.YES,
                     waterAmountMl = 250,
                 ),
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = telegramUser.telegramId,
+                    externalUserId = telegramUser.externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 7, 13, 0, 0),
                     eventType = AnswerNotificationType.YES,
                     waterAmountMl = 500,
                 ),
             )
-            `when`(statisticsService.getToday(telegramUser.telegramId)).thenReturn(entries)
+            `when`(statisticsService.getToday(telegramUser.externalUserId)).thenReturn(entries)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -96,13 +96,13 @@ class StatisticsControllerTest @Autowired constructor(
             assertEquals(250, body.entries[0].amountMl)
             assertEquals(Instant.parse("2026-05-07T13:00:00Z"), body.entries[1].eventTime)
             assertEquals(500, body.entries[1].amountMl)
-            verify(statisticsService).getToday(telegramUser.telegramId)
+            verify(statisticsService).getToday(telegramUser.externalUserId)
         }
 
         @Test
         @DisplayName("empty list - returns 200 with empty entries")
         fun `returns 200 with empty entries`() {
-            `when`(statisticsService.getToday(telegramUser.telegramId)).thenReturn(emptyList())
+            `when`(statisticsService.getToday(telegramUser.externalUserId)).thenReturn(emptyList())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -148,7 +148,7 @@ class StatisticsControllerTest @Autowired constructor(
         @DisplayName("valid range - returns 200 with full body and forwards from/to to service")
         fun `valid range returns 200`() {
             val dto = dailyDto()
-            `when`(statisticsService.getStatistics(eq(telegramUser.telegramId), eq(from), eq(to))).thenReturn(dto)
+            `when`(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(from), eq(to))).thenReturn(dto)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -170,7 +170,7 @@ class StatisticsControllerTest @Autowired constructor(
             assertEquals(Instant.parse("2026-04-15T10:30:00Z"), body.firstEntryAt)
             val fromCaptor = argumentCaptor<LocalDate>()
             val toCaptor = argumentCaptor<LocalDate>()
-            verify(statisticsService).getStatistics(eq(telegramUser.telegramId), fromCaptor.capture(), toCaptor.capture())
+            verify(statisticsService).getStatistics(eq(telegramUser.externalUserId), fromCaptor.capture(), toCaptor.capture())
             assertEquals(from, fromCaptor.firstValue)
             assertEquals(to, toCaptor.firstValue)
         }
@@ -179,7 +179,7 @@ class StatisticsControllerTest @Autowired constructor(
         @DisplayName("from == to - returns 200 with 24 hourly buckets")
         fun `from equals to returns hourly`() {
             val day = LocalDate.of(2026, 5, 12)
-            `when`(statisticsService.getStatistics(eq(telegramUser.telegramId), eq(day), eq(day))).thenReturn(hourlyDto())
+            `when`(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(day), eq(day))).thenReturn(hourlyDto())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -196,7 +196,7 @@ class StatisticsControllerTest @Autowired constructor(
         @Test
         @DisplayName("firstEntryAt = null is rendered as null in response")
         fun `null firstEntryAt rendered as null`() {
-            `when`(statisticsService.getStatistics(eq(telegramUser.telegramId), eq(from), eq(to)))
+            `when`(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(from), eq(to)))
                 .thenReturn(dailyDto(firstEntryAt = null))
             val headers = buildHeaders()
 
@@ -329,13 +329,13 @@ class StatisticsControllerTest @Autowired constructor(
             )
 
             assertEquals(HttpStatus.CREATED, response.statusCode)
-            val userIdCaptor = argumentCaptor<Long>()
+            val externalUserIdCaptor = argumentCaptor<Long>()
             val consumedAtCaptor = argumentCaptor<Instant>()
             val amountCaptor = argumentCaptor<Int>()
             verify(waterStatisticService).manualRecordEvent(
-                userIdCaptor.capture(), consumedAtCaptor.capture(), amountCaptor.capture()
+                externalUserIdCaptor.capture(), consumedAtCaptor.capture(), amountCaptor.capture()
             )
-            assertEquals(telegramUser.telegramId, userIdCaptor.firstValue)
+            assertEquals(telegramUser.externalUserId, externalUserIdCaptor.firstValue)
             assertEquals(consumedAt, consumedAtCaptor.firstValue)
             assertEquals(250, amountCaptor.firstValue)
         }
@@ -350,13 +350,13 @@ class StatisticsControllerTest @Autowired constructor(
             )
 
             assertEquals(HttpStatus.CREATED, response.statusCode)
-            val userIdCaptor = argumentCaptor<Long>()
+            val externalUserIdCaptor = argumentCaptor<Long>()
             val consumedAtCaptor = nullableArgumentCaptor<Instant>()
             val amountCaptor = argumentCaptor<Int>()
             verify(waterStatisticService).manualRecordEvent(
-                userIdCaptor.capture(), consumedAtCaptor.capture(), amountCaptor.capture()
+                externalUserIdCaptor.capture(), consumedAtCaptor.capture(), amountCaptor.capture()
             )
-            assertEquals(telegramUser.telegramId, userIdCaptor.firstValue)
+            assertEquals(telegramUser.externalUserId, externalUserIdCaptor.firstValue)
             assertEquals(250, amountCaptor.firstValue)
             assertNull(consumedAtCaptor.firstValue)
         }

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
@@ -9,11 +9,14 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.nullableArgumentCaptor
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.http.*
@@ -50,8 +53,8 @@ class StatisticsControllerTest @Autowired constructor(
 
     @BeforeEach
     fun setUp() {
-        `when`(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        `when`(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
     }
 
     private fun buildHeaders(): HttpHeaders {
@@ -81,7 +84,7 @@ class StatisticsControllerTest @Autowired constructor(
                     waterAmountMl = 500,
                 ),
             )
-            `when`(statisticsService.getToday(telegramUser.externalUserId)).thenReturn(entries)
+            whenever(statisticsService.getToday(telegramUser.externalUserId)).thenReturn(entries)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -102,7 +105,7 @@ class StatisticsControllerTest @Autowired constructor(
         @Test
         @DisplayName("empty list - returns 200 with empty entries")
         fun `returns 200 with empty entries`() {
-            `when`(statisticsService.getToday(telegramUser.externalUserId)).thenReturn(emptyList())
+            whenever(statisticsService.getToday(telegramUser.externalUserId)).thenReturn(emptyList())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -148,7 +151,7 @@ class StatisticsControllerTest @Autowired constructor(
         @DisplayName("valid range - returns 200 with full body and forwards from/to to service")
         fun `valid range returns 200`() {
             val dto = dailyDto()
-            `when`(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(from), eq(to))).thenReturn(dto)
+            whenever(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(from), eq(to))).thenReturn(dto)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -180,7 +183,7 @@ class StatisticsControllerTest @Autowired constructor(
         @DisplayName("from == to - returns 200 with 24 hourly buckets")
         fun `from equals to returns hourly`() {
             val day = LocalDate.of(2026, 5, 12)
-            `when`(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(day), eq(day))).thenReturn(hourlyDto())
+            whenever(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(day), eq(day))).thenReturn(hourlyDto())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -197,7 +200,7 @@ class StatisticsControllerTest @Autowired constructor(
         @Test
         @DisplayName("firstEntryAt = null is rendered as null in response")
         fun `null firstEntryAt rendered as null`() {
-            `when`(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(from), eq(to)))
+            whenever(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(from), eq(to)))
                 .thenReturn(dailyDto(firstEntryAt = null))
             val headers = buildHeaders()
 
@@ -213,7 +216,7 @@ class StatisticsControllerTest @Autowired constructor(
         @Test
         @DisplayName("service throws IllegalArgumentException (e.g. from > to in user TZ) - returns 400")
         fun `service IllegalArgumentException returns 400`() {
-            `when`(statisticsService.getStatistics(any(), any(), any()))
+            whenever(statisticsService.getStatistics(any(), any(), any()))
                 .thenThrow(IllegalArgumentException("Invalid parameter: 'from' must be before or equal to 'to'"))
             val headers = buildHeaders()
 
@@ -295,7 +298,7 @@ class StatisticsControllerTest @Autowired constructor(
         @DisplayName("notifications disabled (NotificationSettingsNotFoundException) - returns 404")
         fun `returns 404 when settings not found`() {
             doThrow(NotificationSettingsNotFoundException("not found"))
-                .`when`(statisticsService).getStatistics(any(), any(), any())
+                .whenever(statisticsService).getStatistics(any(), any(), any())
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -366,7 +369,7 @@ class StatisticsControllerTest @Autowired constructor(
         @DisplayName("service throws IllegalArgumentException - returns 400 (handler maps to BAD_REQUEST)")
         fun `returns 400 on service IllegalArgumentException`() {
             doThrow(IllegalArgumentException("invalid"))
-                .`when`(waterStatisticService).manualRecordEvent(any(), any(), any())
+                .whenever(waterStatisticService).manualRecordEvent(any(), any(), any())
             val body = objectMapper.writeValueAsString(DtoGenerator.generateWaterEntryRequest(pastInstant(), 250))
 
             val response = restTemplate.exchange(
@@ -439,7 +442,7 @@ class StatisticsControllerTest @Autowired constructor(
         @Test
         @DisplayName("invalid signature - returns 403")
         fun `returns 403 on invalid signature`() {
-            `when`(telegramValidatorService.verifySignature(any())).thenReturn(false)
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
             val body = objectMapper.writeValueAsString(DtoGenerator.generateWaterEntryRequest(pastInstant(), 250))
 
             val response = restTemplate.exchange(

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
@@ -1,7 +1,9 @@
 package ru.illine.drinking.ponies.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -19,7 +21,11 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
-import org.springframework.http.*
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import ru.illine.drinking.ponies.exception.NotificationSettingsNotFoundException
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
@@ -31,439 +37,556 @@ import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
-import java.time.*
+import java.time.DayOfWeek
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 @SpringIntegrationTest
 @DisplayName("StatisticsController Spring Integration Test")
-class StatisticsControllerTest @Autowired constructor(
-    private val restTemplate: TestRestTemplate,
-    private val objectMapper: ObjectMapper
-) {
+class StatisticsControllerTest
+    @Autowired
+    constructor(
+        private val restTemplate: TestRestTemplate,
+        private val objectMapper: ObjectMapper,
+    ) {
+        @MockitoBean
+        private lateinit var telegramValidatorService: TelegramValidatorService
 
-    @MockitoBean
-    private lateinit var telegramValidatorService: TelegramValidatorService
+        @MockitoBean
+        private lateinit var statisticsService: StatisticsService
 
-    @MockitoBean
-    private lateinit var statisticsService: StatisticsService
+        @MockitoBean
+        private lateinit var waterStatisticService: WaterStatisticService
 
-    @MockitoBean
-    private lateinit var waterStatisticService: WaterStatisticService
+        private val telegramUser = DtoGenerator.generateTelegramUserDto()
 
-    private val telegramUser = DtoGenerator.generateTelegramUserDto()
-
-    @BeforeEach
-    fun setUp() {
-        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
-    }
-
-    private fun buildHeaders(): HttpHeaders {
-        return HttpHeaders().apply {
-            set("X-Authorization-Telegram-Data", "test-init-data")
-        }
-    }
-
-    @Nested
-    @DisplayName("GET /statistics/today")
-    inner class GetToday {
-
-        @Test
-        @DisplayName("valid request - returns 200 with entries serialized as ISO 8601 UTC")
-        fun `returns 200 with serialized entries`() {
-            val entries = listOf(
-                DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = telegramUser.externalUserId,
-                    eventTime = LocalDateTime.of(2026, 5, 7, 8, 15, 0),
-                    eventType = AnswerNotificationType.YES,
-                    waterAmountMl = 250,
-                ),
-                DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = telegramUser.externalUserId,
-                    eventTime = LocalDateTime.of(2026, 5, 7, 13, 0, 0),
-                    eventType = AnswerNotificationType.YES,
-                    waterAmountMl = 500,
-                ),
-            )
-            whenever(statisticsService.getToday(telegramUser.externalUserId)).thenReturn(entries)
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/statistics/today", HttpMethod.GET, HttpEntity<Void>(headers), StatisticsTodayResponse::class.java
-            )
-
-            assertEquals(HttpStatus.OK, response.statusCode)
-            assertNotNull(response.body)
-            val body = response.body!!
-            assertEquals(2, body.entries.size)
-            assertEquals(Instant.parse("2026-05-07T08:15:00Z"), body.entries[0].eventTime)
-            assertEquals(250, body.entries[0].amountMl)
-            assertEquals(Instant.parse("2026-05-07T13:00:00Z"), body.entries[1].eventTime)
-            assertEquals(500, body.entries[1].amountMl)
-            verify(statisticsService).getToday(telegramUser.externalUserId)
+        @BeforeEach
+        fun setUp() {
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+            whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
         }
 
-        @Test
-        @DisplayName("empty list - returns 200 with empty entries")
-        fun `returns 200 with empty entries`() {
-            whenever(statisticsService.getToday(telegramUser.externalUserId)).thenReturn(emptyList())
-            val headers = buildHeaders()
+        private fun buildHeaders(): HttpHeaders =
+            HttpHeaders().apply {
+                set("X-Authorization-Telegram-Data", "test-init-data")
+            }
 
-            val response = restTemplate.exchange(
-                "/statistics/today", HttpMethod.GET, HttpEntity<Void>(headers), StatisticsTodayResponse::class.java
-            )
+        @Nested
+        @DisplayName("GET /statistics/today")
+        inner class GetToday {
+            @Test
+            @DisplayName("valid request - returns 200 with entries serialized as ISO 8601 UTC")
+            fun `returns 200 with serialized entries`() {
+                val entries =
+                    listOf(
+                        DtoGenerator.generateWaterStatisticDto(
+                            externalUserId = telegramUser.externalUserId,
+                            eventTime = LocalDateTime.of(2026, 5, 7, 8, 15, 0),
+                            eventType = AnswerNotificationType.YES,
+                            waterAmountMl = 250,
+                        ),
+                        DtoGenerator.generateWaterStatisticDto(
+                            externalUserId = telegramUser.externalUserId,
+                            eventTime = LocalDateTime.of(2026, 5, 7, 13, 0, 0),
+                            eventType = AnswerNotificationType.YES,
+                            waterAmountMl = 500,
+                        ),
+                    )
+                whenever(statisticsService.getToday(telegramUser.externalUserId)).thenReturn(entries)
+                val headers = buildHeaders()
 
-            assertEquals(HttpStatus.OK, response.statusCode)
-            assertNotNull(response.body)
-            assertEquals(0, response.body!!.entries.size)
-        }
+                val response =
+                    restTemplate.exchange(
+                        "/statistics/today",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        StatisticsTodayResponse::class.java,
+                    )
 
-        @Test
-        @DisplayName("missing auth header - returns 401")
-        fun `returns 401`() {
-            val response = restTemplate.exchange(
-                "/statistics/today", HttpMethod.GET, HttpEntity<Void>(HttpHeaders()), Void::class.java
-            )
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertNotNull(response.body)
+                val body = response.body!!
+                assertEquals(2, body.entries.size)
+                assertEquals(Instant.parse("2026-05-07T08:15:00Z"), body.entries[0].eventTime)
+                assertEquals(250, body.entries[0].amountMl)
+                assertEquals(Instant.parse("2026-05-07T13:00:00Z"), body.entries[1].eventTime)
+                assertEquals(500, body.entries[1].amountMl)
+                verify(statisticsService).getToday(telegramUser.externalUserId)
+            }
 
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-            verifyNoInteractions(statisticsService)
-        }
-    }
+            @Test
+            @DisplayName("empty list - returns 200 with empty entries")
+            fun `returns 200 with empty entries`() {
+                whenever(statisticsService.getToday(telegramUser.externalUserId)).thenReturn(emptyList())
+                val headers = buildHeaders()
 
-    @Nested
-    @DisplayName("GET /statistics")
-    inner class GetStatistics {
+                val response =
+                    restTemplate.exchange(
+                        "/statistics/today",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        StatisticsTodayResponse::class.java,
+                    )
 
-        private val from = LocalDate.of(2026, 5, 4)
-        private val to = LocalDate.of(2026, 5, 10)
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertNotNull(response.body)
+                assertEquals(0, response.body!!.entries.size)
+            }
 
-        private fun dailyDto(firstEntryAt: Instant? = Instant.parse("2026-04-15T10:30:00Z")) =
-            DtoGenerator.generateStatisticsDto(firstEntryAt = firstEntryAt)
+            @Test
+            @DisplayName("missing auth header - returns 401")
+            fun `returns 401`() {
+                val response =
+                    restTemplate.exchange(
+                        "/statistics/today",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(HttpHeaders()),
+                        Void::class.java,
+                    )
 
-        private fun hourlyDto() = DtoGenerator.generateStatisticsDto(
-            points = (0 until 24).map { StatisticsPointDto("%02d:00".format(it), if (it == 8) 250 else 0) },
-            averageMlPerDay = 250,
-            bestDay = null,
-            currentStreakDays = 1,
-            insightText = "today insight",
-        )
-
-        @Test
-        @DisplayName("valid range - returns 200 with full body and forwards from/to to service")
-        fun `valid range returns 200`() {
-            val dto = dailyDto()
-            whenever(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(from), eq(to))).thenReturn(dto)
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/statistics?from=$from&to=$to",
-                HttpMethod.GET, HttpEntity<Void>(headers), StatisticsResponse::class.java
-            )
-
-            assertEquals(HttpStatus.OK, response.statusCode)
-            assertNotNull(response.body)
-            val body = response.body!!
-            assertEquals(dto.points.size, body.points.size)
-            assertEquals(dto.dailyGoalMl, body.dailyGoalMl)
-            assertEquals(dto.averageMlPerDay, body.averageMlPerDay)
-            assertEquals(dto.currentStreakDays, body.currentStreakDays)
-            assertEquals(dto.insightText, body.insight.text)
-            val bestDay = body.bestDay!!
-            assertEquals(LocalDate.of(2026, 5, 6), bestDay.date)
-            assertEquals(2400, bestDay.valueMl)
-            assertEquals(DayOfWeek.WEDNESDAY, bestDay.weekday)
-            assertEquals(Instant.parse("2026-04-15T10:30:00Z"), body.firstEntryAt)
-            val fromCaptor = argumentCaptor<LocalDate>()
-            val toCaptor = argumentCaptor<LocalDate>()
-            verify(statisticsService).getStatistics(eq(telegramUser.externalUserId), fromCaptor.capture(), toCaptor.capture())
-            assertEquals(from, fromCaptor.firstValue)
-            assertEquals(to, toCaptor.firstValue)
-        }
-
-        @Test
-        @DisplayName("from == to - returns 200 with 24 hourly buckets")
-        fun `from equals to returns hourly`() {
-            val day = LocalDate.of(2026, 5, 12)
-            whenever(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(day), eq(day))).thenReturn(hourlyDto())
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/statistics?from=$day&to=$day",
-                HttpMethod.GET, HttpEntity<Void>(headers), StatisticsResponse::class.java
-            )
-
-            assertEquals(HttpStatus.OK, response.statusCode)
-            assertEquals(24, response.body!!.points.size)
-            assertEquals("00:00", response.body!!.points.first().label)
-            assertEquals("23:00", response.body!!.points.last().label)
-        }
-
-        @Test
-        @DisplayName("firstEntryAt = null is rendered as null in response")
-        fun `null firstEntryAt rendered as null`() {
-            whenever(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(from), eq(to)))
-                .thenReturn(dailyDto(firstEntryAt = null))
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/statistics?from=$from&to=$to",
-                HttpMethod.GET, HttpEntity<Void>(headers), StatisticsResponse::class.java
-            )
-
-            assertEquals(HttpStatus.OK, response.statusCode)
-            assertNull(response.body!!.firstEntryAt)
-        }
-
-        @Test
-        @DisplayName("service throws IllegalArgumentException (e.g. from > to in user TZ) - returns 400")
-        fun `service IllegalArgumentException returns 400`() {
-            whenever(statisticsService.getStatistics(any(), any(), any()))
-                .thenThrow(IllegalArgumentException("Invalid parameter: 'from' must be before or equal to 'to'"))
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/statistics?from=2026-05-10&to=2026-05-09",
-                HttpMethod.GET, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-        }
-
-        @ParameterizedTest(name = "[{index}] from={0} - returns 400 (malformed date)")
-        @ValueSource(strings = ["foobar", "2026-13-01", "2026-05-32", ""])
-        @DisplayName("malformed from - returns 400")
-        fun `malformed from returns 400`(from: String) {
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/statistics?from=$from&to=2026-05-10",
-                HttpMethod.GET, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-            verifyNoInteractions(statisticsService)
-        }
-
-        @Test
-        @DisplayName("missing from param - returns 400")
-        fun `missing from returns 400`() {
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/statistics?to=2026-05-10", HttpMethod.GET, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-            verifyNoInteractions(statisticsService)
-        }
-
-        @Test
-        @DisplayName("missing to param - returns 400")
-        fun `missing to returns 400`() {
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/statistics?from=2026-05-10", HttpMethod.GET, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-            verifyNoInteractions(statisticsService)
-        }
-
-        @Test
-        @DisplayName("missing both params - returns 400")
-        fun `missing both returns 400`() {
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/statistics", HttpMethod.GET, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-            verifyNoInteractions(statisticsService)
-        }
-
-        @Test
-        @DisplayName("missing auth header - returns 401")
-        fun `returns 401`() {
-            val response = restTemplate.exchange(
-                "/statistics?from=2026-05-04&to=2026-05-10",
-                HttpMethod.GET, HttpEntity<Void>(HttpHeaders()), Void::class.java
-            )
-
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-            verifyNoInteractions(statisticsService)
-        }
-
-        @Test
-        @DisplayName("notifications disabled (NotificationSettingsNotFoundException) - returns 404")
-        fun `returns 404 when settings not found`() {
-            doThrow(NotificationSettingsNotFoundException("not found"))
-                .whenever(statisticsService).getStatistics(any(), any(), any())
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/statistics?from=$from&to=$to",
-                HttpMethod.GET, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
-        }
-    }
-
-    @Nested
-    @DisplayName("POST /statistics/water")
-    inner class PostWater {
-
-        private fun jsonHeaders(): HttpHeaders {
-            return buildHeaders().apply {
-                contentType = MediaType.APPLICATION_JSON
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                verifyNoInteractions(statisticsService)
             }
         }
 
-        private fun pastInstant(): Instant = Instant.now().minus(Duration.ofMinutes(5))
+        @Nested
+        @DisplayName("GET /statistics")
+        inner class GetStatistics {
+            private val from = LocalDate.of(2026, 5, 4)
+            private val to = LocalDate.of(2026, 5, 10)
 
-        @Test
-        @DisplayName("valid request - returns 201 and calls service with parsed args")
-        fun `returns 201 on valid request`() {
-            val consumedAt = pastInstant()
-            val body = objectMapper.writeValueAsString(DtoGenerator.generateWaterEntryRequest(consumedAt, 250))
+            private fun dailyDto(firstEntryAt: Instant? = Instant.parse("2026-04-15T10:30:00Z")) =
+                DtoGenerator.generateStatisticsDto(firstEntryAt = firstEntryAt)
 
-            val response = restTemplate.exchange(
-                "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
-            )
-
-            assertEquals(HttpStatus.CREATED, response.statusCode)
-            val externalUserIdCaptor = argumentCaptor<Long>()
-            val consumedAtCaptor = argumentCaptor<Instant>()
-            val amountCaptor = argumentCaptor<Int>()
-            verify(waterStatisticService).manualRecordEvent(
-                externalUserIdCaptor.capture(), consumedAtCaptor.capture(), amountCaptor.capture()
-            )
-            assertEquals(telegramUser.externalUserId, externalUserIdCaptor.firstValue)
-            assertEquals(consumedAt, consumedAtCaptor.firstValue)
-            assertEquals(250, amountCaptor.firstValue)
-        }
-
-        @Test
-        @DisplayName("valid request - returns 201 and calls service with parsed args")
-        fun `returns 201 on valid request on null consumerAt`() {
-            val body = objectMapper.writeValueAsString(DtoGenerator.generateWaterEntryRequest(consumedAt = null, amountMl = 250))
-
-            val response = restTemplate.exchange(
-                "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
-            )
-
-            assertEquals(HttpStatus.CREATED, response.statusCode)
-            val externalUserIdCaptor = argumentCaptor<Long>()
-            val consumedAtCaptor = nullableArgumentCaptor<Instant>()
-            val amountCaptor = argumentCaptor<Int>()
-            verify(waterStatisticService).manualRecordEvent(
-                externalUserIdCaptor.capture(), consumedAtCaptor.capture(), amountCaptor.capture()
-            )
-            assertEquals(telegramUser.externalUserId, externalUserIdCaptor.firstValue)
-            assertEquals(250, amountCaptor.firstValue)
-            assertNull(consumedAtCaptor.firstValue)
-        }
-
-        @Test
-        @DisplayName("service throws IllegalArgumentException - returns 400 (handler maps to BAD_REQUEST)")
-        fun `returns 400 on service IllegalArgumentException`() {
-            doThrow(IllegalArgumentException("invalid"))
-                .whenever(waterStatisticService).manualRecordEvent(any(), any(), any())
-            val body = objectMapper.writeValueAsString(DtoGenerator.generateWaterEntryRequest(pastInstant(), 250))
-
-            val response = restTemplate.exchange(
-                "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
-            )
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-        }
-
-        @ParameterizedTest(name = "[{index}] amountMl={0} fails bean validation")
-        @ValueSource(ints = [Int.MIN_VALUE, -1, 0, 49, 1001, Int.MAX_VALUE])
-        @DisplayName("amountMl outside [MIN_ML, MAX_ML] - returns 400 (bean validation)")
-        fun `returns 400 on amount out of bounds`(amount: Int) {
-            val body = objectMapper.writeValueAsString(DtoGenerator.generateWaterEntryRequest(pastInstant(), amount))
-
-            val response = restTemplate.exchange(
-                "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
-            )
-
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-            verifyNoInteractions(waterStatisticService)
-        }
-
-        @Test
-        @DisplayName("consumedAt in the future - returns 400 (bean validation)")
-        fun `returns 400 on future consumedAt`() {
-            val body = objectMapper.writeValueAsString(
-                DtoGenerator.generateWaterEntryRequest(
-                    consumedAt = Instant.now().plus(Duration.ofHours(1)),
-                    amountMl = 250,
+            private fun hourlyDto() =
+                DtoGenerator.generateStatisticsDto(
+                    points = (0 until 24).map { StatisticsPointDto("%02d:00".format(it), if (it == 8) 250 else 0) },
+                    averageMlPerDay = 250,
+                    bestDay = null,
+                    currentStreakDays = 1,
+                    insightText = "today insight",
                 )
-            )
 
-            val response = restTemplate.exchange(
-                "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
-            )
+            @Test
+            @DisplayName("valid range - returns 200 with full body and forwards from/to to service")
+            fun `valid range returns 200`() {
+                val dto = dailyDto()
+                whenever(
+                    statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(from), eq(to)),
+                ).thenReturn(dto)
+                val headers = buildHeaders()
 
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-            verifyNoInteractions(waterStatisticService)
+                val response =
+                    restTemplate.exchange(
+                        "/statistics?from=$from&to=$to",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        StatisticsResponse::class.java,
+                    )
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertNotNull(response.body)
+                val body = response.body!!
+                assertEquals(dto.points.size, body.points.size)
+                assertEquals(dto.dailyGoalMl, body.dailyGoalMl)
+                assertEquals(dto.averageMlPerDay, body.averageMlPerDay)
+                assertEquals(dto.currentStreakDays, body.currentStreakDays)
+                assertEquals(dto.insightText, body.insight.text)
+                val bestDay = body.bestDay!!
+                assertEquals(LocalDate.of(2026, 5, 6), bestDay.date)
+                assertEquals(2400, bestDay.valueMl)
+                assertEquals(DayOfWeek.WEDNESDAY, bestDay.weekday)
+                assertEquals(Instant.parse("2026-04-15T10:30:00Z"), body.firstEntryAt)
+                val fromCaptor = argumentCaptor<LocalDate>()
+                val toCaptor = argumentCaptor<LocalDate>()
+                verify(
+                    statisticsService,
+                ).getStatistics(eq(telegramUser.externalUserId), fromCaptor.capture(), toCaptor.capture())
+                assertEquals(from, fromCaptor.firstValue)
+                assertEquals(to, toCaptor.firstValue)
+            }
+
+            @Test
+            @DisplayName("from == to - returns 200 with 24 hourly buckets")
+            fun `from equals to returns hourly`() {
+                val day = LocalDate.of(2026, 5, 12)
+                whenever(
+                    statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(day), eq(day)),
+                ).thenReturn(hourlyDto())
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/statistics?from=$day&to=$day",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        StatisticsResponse::class.java,
+                    )
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertEquals(24, response.body!!.points.size)
+                assertEquals(
+                    "00:00",
+                    response.body!!
+                        .points
+                        .first()
+                        .label,
+                )
+                assertEquals(
+                    "23:00",
+                    response.body!!
+                        .points
+                        .last()
+                        .label,
+                )
+            }
+
+            @Test
+            @DisplayName("firstEntryAt = null is rendered as null in response")
+            fun `null firstEntryAt rendered as null`() {
+                whenever(statisticsService.getStatistics(eq(telegramUser.externalUserId), eq(from), eq(to)))
+                    .thenReturn(dailyDto(firstEntryAt = null))
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/statistics?from=$from&to=$to",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        StatisticsResponse::class.java,
+                    )
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertNull(response.body!!.firstEntryAt)
+            }
+
+            @Test
+            @DisplayName("service throws IllegalArgumentException (e.g. from > to in user TZ) - returns 400")
+            fun `service IllegalArgumentException returns 400`() {
+                whenever(statisticsService.getStatistics(any(), any(), any()))
+                    .thenThrow(IllegalArgumentException("Invalid parameter: 'from' must be before or equal to 'to'"))
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/statistics?from=2026-05-10&to=2026-05-09",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+            }
+
+            @ParameterizedTest(name = "[{index}] from={0} - returns 400 (malformed date)")
+            @ValueSource(strings = ["foobar", "2026-13-01", "2026-05-32", ""])
+            @DisplayName("malformed from - returns 400")
+            fun `malformed from returns 400`(from: String) {
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/statistics?from=$from&to=2026-05-10",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                verifyNoInteractions(statisticsService)
+            }
+
+            @Test
+            @DisplayName("missing from param - returns 400")
+            fun `missing from returns 400`() {
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/statistics?to=2026-05-10",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                verifyNoInteractions(statisticsService)
+            }
+
+            @Test
+            @DisplayName("missing to param - returns 400")
+            fun `missing to returns 400`() {
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/statistics?from=2026-05-10",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                verifyNoInteractions(statisticsService)
+            }
+
+            @Test
+            @DisplayName("missing both params - returns 400")
+            fun `missing both returns 400`() {
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/statistics",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                verifyNoInteractions(statisticsService)
+            }
+
+            @Test
+            @DisplayName("missing auth header - returns 401")
+            fun `returns 401`() {
+                val response =
+                    restTemplate.exchange(
+                        "/statistics?from=2026-05-04&to=2026-05-10",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(HttpHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                verifyNoInteractions(statisticsService)
+            }
+
+            @Test
+            @DisplayName("notifications disabled (NotificationSettingsNotFoundException) - returns 404")
+            fun `returns 404 when settings not found`() {
+                doThrow(NotificationSettingsNotFoundException("not found"))
+                    .whenever(statisticsService)
+                    .getStatistics(any(), any(), any())
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/statistics?from=$from&to=$to",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+            }
         }
 
-        @ParameterizedTest(name = "[{index}] body={0}")
-        @MethodSource("ru.illine.drinking.ponies.controller.StatisticsControllerTest#malformedBodies")
-        @DisplayName("malformed/missing JSON body fields - returns 400")
-        fun `returns 400 on malformed body`(body: String?) {
-            val entity: HttpEntity<*> = if (body == null) HttpEntity<Void>(jsonHeaders()) else HttpEntity(body, jsonHeaders())
+        @Nested
+        @DisplayName("POST /statistics/water")
+        inner class PostWater {
+            private fun jsonHeaders(): HttpHeaders =
+                buildHeaders().apply {
+                    contentType = MediaType.APPLICATION_JSON
+                }
 
-            val response = restTemplate.exchange(
-                "/statistics/water", HttpMethod.POST, entity, Void::class.java
-            )
+            private fun pastInstant(): Instant = Instant.now().minus(Duration.ofMinutes(5))
 
-            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
-            verifyNoInteractions(waterStatisticService)
+            @Test
+            @DisplayName("valid request - returns 201 and calls service with parsed args")
+            fun `returns 201 on valid request`() {
+                val consumedAt = pastInstant()
+                val body = objectMapper.writeValueAsString(DtoGenerator.generateWaterEntryRequest(consumedAt, 250))
+
+                val response =
+                    restTemplate.exchange(
+                        "/statistics/water",
+                        HttpMethod.POST,
+                        HttpEntity(body, jsonHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.CREATED, response.statusCode)
+                val externalUserIdCaptor = argumentCaptor<Long>()
+                val consumedAtCaptor = argumentCaptor<Instant>()
+                val amountCaptor = argumentCaptor<Int>()
+                verify(waterStatisticService).manualRecordEvent(
+                    externalUserIdCaptor.capture(),
+                    consumedAtCaptor.capture(),
+                    amountCaptor.capture(),
+                )
+                assertEquals(telegramUser.externalUserId, externalUserIdCaptor.firstValue)
+                assertEquals(consumedAt, consumedAtCaptor.firstValue)
+                assertEquals(250, amountCaptor.firstValue)
+            }
+
+            @Test
+            @DisplayName("valid request - returns 201 and calls service with parsed args")
+            fun `returns 201 on valid request on null consumerAt`() {
+                val body =
+                    objectMapper.writeValueAsString(
+                        DtoGenerator.generateWaterEntryRequest(consumedAt = null, amountMl = 250),
+                    )
+
+                val response =
+                    restTemplate.exchange(
+                        "/statistics/water",
+                        HttpMethod.POST,
+                        HttpEntity(body, jsonHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.CREATED, response.statusCode)
+                val externalUserIdCaptor = argumentCaptor<Long>()
+                val consumedAtCaptor = nullableArgumentCaptor<Instant>()
+                val amountCaptor = argumentCaptor<Int>()
+                verify(waterStatisticService).manualRecordEvent(
+                    externalUserIdCaptor.capture(),
+                    consumedAtCaptor.capture(),
+                    amountCaptor.capture(),
+                )
+                assertEquals(telegramUser.externalUserId, externalUserIdCaptor.firstValue)
+                assertEquals(250, amountCaptor.firstValue)
+                assertNull(consumedAtCaptor.firstValue)
+            }
+
+            @Test
+            @DisplayName("service throws IllegalArgumentException - returns 400 (handler maps to BAD_REQUEST)")
+            fun `returns 400 on service IllegalArgumentException`() {
+                doThrow(IllegalArgumentException("invalid"))
+                    .whenever(waterStatisticService)
+                    .manualRecordEvent(any(), any(), any())
+                val body = objectMapper.writeValueAsString(DtoGenerator.generateWaterEntryRequest(pastInstant(), 250))
+
+                val response =
+                    restTemplate.exchange(
+                        "/statistics/water",
+                        HttpMethod.POST,
+                        HttpEntity(body, jsonHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+            }
+
+            @ParameterizedTest(name = "[{index}] amountMl={0} fails bean validation")
+            @ValueSource(ints = [Int.MIN_VALUE, -1, 0, 49, 1001, Int.MAX_VALUE])
+            @DisplayName("amountMl outside [MIN_ML, MAX_ML] - returns 400 (bean validation)")
+            fun `returns 400 on amount out of bounds`(amount: Int) {
+                val body =
+                    objectMapper.writeValueAsString(
+                        DtoGenerator.generateWaterEntryRequest(pastInstant(), amount),
+                    )
+
+                val response =
+                    restTemplate.exchange(
+                        "/statistics/water",
+                        HttpMethod.POST,
+                        HttpEntity(body, jsonHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                verifyNoInteractions(waterStatisticService)
+            }
+
+            @Test
+            @DisplayName("consumedAt in the future - returns 400 (bean validation)")
+            fun `returns 400 on future consumedAt`() {
+                val body =
+                    objectMapper.writeValueAsString(
+                        DtoGenerator.generateWaterEntryRequest(
+                            consumedAt = Instant.now().plus(Duration.ofHours(1)),
+                            amountMl = 250,
+                        ),
+                    )
+
+                val response =
+                    restTemplate.exchange(
+                        "/statistics/water",
+                        HttpMethod.POST,
+                        HttpEntity(body, jsonHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                verifyNoInteractions(waterStatisticService)
+            }
+
+            @ParameterizedTest(name = "[{index}] body={0}")
+            @MethodSource("ru.illine.drinking.ponies.controller.StatisticsControllerTest#malformedBodies")
+            @DisplayName("malformed/missing JSON body fields - returns 400")
+            fun `returns 400 on malformed body`(body: String?) {
+                val entity: HttpEntity<*> =
+                    if (body ==
+                        null
+                    ) {
+                        HttpEntity<Void>(jsonHeaders())
+                    } else {
+                        HttpEntity(body, jsonHeaders())
+                    }
+
+                val response =
+                    restTemplate.exchange(
+                        "/statistics/water",
+                        HttpMethod.POST,
+                        entity,
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                verifyNoInteractions(waterStatisticService)
+            }
+
+            @Test
+            @DisplayName("missing auth header - returns 401")
+            fun `returns 401 on missing auth header`() {
+                val body = objectMapper.writeValueAsString(DtoGenerator.generateWaterEntryRequest(pastInstant(), 250))
+                val headers = HttpHeaders().apply { contentType = MediaType.APPLICATION_JSON }
+
+                val response =
+                    restTemplate.exchange(
+                        "/statistics/water",
+                        HttpMethod.POST,
+                        HttpEntity(body, headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                verifyNoInteractions(waterStatisticService)
+            }
+
+            @Test
+            @DisplayName("invalid signature - returns 403")
+            fun `returns 403 on invalid signature`() {
+                whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
+                val body = objectMapper.writeValueAsString(DtoGenerator.generateWaterEntryRequest(pastInstant(), 250))
+
+                val response =
+                    restTemplate.exchange(
+                        "/statistics/water",
+                        HttpMethod.POST,
+                        HttpEntity(body, jsonHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
+                verifyNoInteractions(waterStatisticService)
+            }
         }
 
-        @Test
-        @DisplayName("missing auth header - returns 401")
-        fun `returns 401 on missing auth header`() {
-            val body = objectMapper.writeValueAsString(DtoGenerator.generateWaterEntryRequest(pastInstant(), 250))
-            val headers = HttpHeaders().apply { contentType = MediaType.APPLICATION_JSON }
-
-            val response = restTemplate.exchange(
-                "/statistics/water", HttpMethod.POST, HttpEntity(body, headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-            verifyNoInteractions(waterStatisticService)
-        }
-
-        @Test
-        @DisplayName("invalid signature - returns 403")
-        fun `returns 403 on invalid signature`() {
-            whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
-            val body = objectMapper.writeValueAsString(DtoGenerator.generateWaterEntryRequest(pastInstant(), 250))
-
-            val response = restTemplate.exchange(
-                "/statistics/water", HttpMethod.POST, HttpEntity(body, jsonHeaders()), Void::class.java
-            )
-
-            assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
-            verifyNoInteractions(waterStatisticService)
+        companion object {
+            @JvmStatic
+            fun malformedBodies(): List<String?> {
+                val pastIso = Instant.now().minus(Duration.ofMinutes(5)).toString()
+                return listOf(
+                    null,
+                    """{"consumedAt":"$pastIso"}""",
+                    """{"consumedAt":"not-a-date","amountMl":250}""",
+                    """{}""",
+                )
+            }
         }
     }
-
-    companion object {
-        @JvmStatic
-        fun malformedBodies(): List<String?> {
-            val pastIso = Instant.now().minus(Duration.ofMinutes(5)).toString()
-            return listOf(
-                null,
-                """{"consumedAt":"$pastIso"}""",
-                """{"consumedAt":"not-a-date","amountMl":250}""",
-                """{}""",
-            )
-        }
-    }
-}

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
@@ -164,9 +164,10 @@ class StatisticsControllerTest @Autowired constructor(
             assertEquals(dto.averageMlPerDay, body.averageMlPerDay)
             assertEquals(dto.currentStreakDays, body.currentStreakDays)
             assertEquals(dto.insightText, body.insight.text)
-            assertEquals(LocalDate.of(2026, 5, 6), body.bestDay!!.date)
-            assertEquals(2400, body.bestDay!!.valueMl)
-            assertEquals(DayOfWeek.WEDNESDAY, body.bestDay!!.weekday)
+            val bestDay = body.bestDay!!
+            assertEquals(LocalDate.of(2026, 5, 6), bestDay.date)
+            assertEquals(2400, bestDay.valueMl)
+            assertEquals(DayOfWeek.WEDNESDAY, bestDay.weekday)
             assertEquals(Instant.parse("2026-04-15T10:30:00Z"), body.firstEntryAt)
             val fromCaptor = argumentCaptor<LocalDate>()
             val toCaptor = argumentCaptor<LocalDate>()

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/SystemControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/SystemControllerTest.kt
@@ -23,74 +23,85 @@ import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
 
 @SpringIntegrationTest
 @DisplayName("SystemController Spring Integration Test")
-class SystemControllerTest @Autowired constructor(
-    private val restTemplate: TestRestTemplate
-) {
+class SystemControllerTest
+    @Autowired
+    constructor(
+        private val restTemplate: TestRestTemplate,
+    ) {
+        @MockitoBean
+        private lateinit var telegramValidatorService: TelegramValidatorService
 
-    @MockitoBean
-    private lateinit var telegramValidatorService: TelegramValidatorService
+        private val telegramUser = DtoGenerator.generateTelegramUserDto()
 
-    private val telegramUser = DtoGenerator.generateTelegramUserDto()
+        @BeforeEach
+        fun setUp() {
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+            whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        }
 
-    @BeforeEach
-    fun setUp() {
-        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
-    }
+        private fun buildHeaders(): HttpHeaders =
+            HttpHeaders().apply {
+                set("X-Authorization-Telegram-Data", "test-init-data")
+            }
 
-    private fun buildHeaders(): HttpHeaders {
-        return HttpHeaders().apply {
-            set("X-Authorization-Telegram-Data", "test-init-data")
+        @Nested
+        @DisplayName("GET /systems/version")
+        inner class GetVersion {
+            @Test
+            @DisplayName("valid request - returns 200 with version from configuration")
+            fun `returns 200 with version`() {
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/systems/version",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        VersionResponse::class.java,
+                    )
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertNotNull(response.body)
+                assertEquals("X.Y.Z-test", response.body!!.version)
+            }
+
+            @Test
+            @DisplayName("missing auth header - returns 401 with X-Auth-Error-Code invalid_auth_signature")
+            fun `returns 401 with invalid_auth_signature header`() {
+                val response =
+                    restTemplate.exchange(
+                        "/systems/version",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(HttpHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                assertEquals(
+                    AuthErrorType.INVALID_AUTH_SIGNATURE.value,
+                    response.headers.getFirst(AuthErrorType.HEADER_NAME),
+                )
+            }
+
+            @Test
+            @DisplayName("expired auth_date - returns 403 with X-Auth-Error-Code session_expired")
+            fun `returns 403 with session_expired header`() {
+                whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/systems/version",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
+                assertEquals(
+                    AuthErrorType.SESSION_EXPIRED.value,
+                    response.headers.getFirst(AuthErrorType.HEADER_NAME),
+                )
+            }
         }
     }
-
-    @Nested
-    @DisplayName("GET /systems/version")
-    inner class GetVersion {
-
-        @Test
-        @DisplayName("valid request - returns 200 with version from configuration")
-        fun `returns 200 with version`() {
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/systems/version", HttpMethod.GET, HttpEntity<Void>(headers), VersionResponse::class.java
-            )
-
-            assertEquals(HttpStatus.OK, response.statusCode)
-            assertNotNull(response.body)
-            assertEquals("X.Y.Z-test", response.body!!.version)
-        }
-
-        @Test
-        @DisplayName("missing auth header - returns 401 with X-Auth-Error-Code invalid_auth_signature")
-        fun `returns 401 with invalid_auth_signature header`() {
-            val response = restTemplate.exchange(
-                "/systems/version", HttpMethod.GET, HttpEntity<Void>(HttpHeaders()), Void::class.java
-            )
-
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-            assertEquals(
-                AuthErrorType.INVALID_AUTH_SIGNATURE.value,
-                response.headers.getFirst(AuthErrorType.HEADER_NAME)
-            )
-        }
-
-        @Test
-        @DisplayName("expired auth_date - returns 403 with X-Auth-Error-Code session_expired")
-        fun `returns 403 with session_expired header`() {
-            whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/systems/version", HttpMethod.GET, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
-            assertEquals(
-                AuthErrorType.SESSION_EXPIRED.value,
-                response.headers.getFirst(AuthErrorType.HEADER_NAME)
-            )
-        }
-    }
-}

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/SystemControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/SystemControllerTest.kt
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.http.HttpEntity
@@ -34,8 +34,8 @@ class SystemControllerTest @Autowired constructor(
 
     @BeforeEach
     fun setUp() {
-        `when`(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        `when`(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
     }
 
     private fun buildHeaders(): HttpHeaders {
@@ -79,7 +79,7 @@ class SystemControllerTest @Autowired constructor(
         @Test
         @DisplayName("expired auth_date - returns 403 with X-Auth-Error-Code session_expired")
         fun `returns 403 with session_expired header`() {
-            `when`(telegramValidatorService.verifySignature(any())).thenReturn(false)
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/UserControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/UserControllerTest.kt
@@ -49,7 +49,7 @@ class UserControllerTest @Autowired constructor(
     private val NON_ADMIN_USER_ID = 2L
     private val MISSING_USER_ID = 0L
 
-    private val telegramUser = DtoGenerator.generateTelegramUserDto(telegramId = ADMIN_USER_ID)
+    private val telegramUser = DtoGenerator.generateTelegramUserDto(externalUserId = ADMIN_USER_ID)
 
     @BeforeEach
     fun setUp() {
@@ -79,14 +79,14 @@ class UserControllerTest @Autowired constructor(
 
             assertEquals(HttpStatus.OK, response.statusCode)
             assertNotNull(response.body)
-            assertEquals(ADMIN_USER_ID, response.body!!.telegramUserId)
+            assertEquals(ADMIN_USER_ID, response.body!!.externalUserId)
             assertEquals(true, response.body!!.isAdmin)
         }
 
         @Test
         @DisplayName("non-admin user - returns 200 with isAdmin=false")
         fun `returns 200 with isAdmin false for non-admin`() {
-            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(telegramId = NON_ADMIN_USER_ID))
+            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -95,14 +95,14 @@ class UserControllerTest @Autowired constructor(
 
             assertEquals(HttpStatus.OK, response.statusCode)
             assertNotNull(response.body)
-            assertEquals(NON_ADMIN_USER_ID, response.body!!.telegramUserId)
+            assertEquals(NON_ADMIN_USER_ID, response.body!!.externalUserId)
             assertEquals(false, response.body!!.isAdmin)
         }
 
         @Test
         @DisplayName("user not in DB - returns 200 with isAdmin=false")
         fun `returns 200 with isAdmin false for user not in db`() {
-            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(telegramId = MISSING_USER_ID))
+            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = MISSING_USER_ID))
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -111,7 +111,7 @@ class UserControllerTest @Autowired constructor(
 
             assertEquals(HttpStatus.OK, response.statusCode)
             assertNotNull(response.body)
-            assertEquals(MISSING_USER_ID, response.body!!.telegramUserId)
+            assertEquals(MISSING_USER_ID, response.body!!.externalUserId)
             assertEquals(false, response.body!!.isAdmin)
         }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/UserControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/UserControllerTest.kt
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.cache.CacheManager
@@ -54,8 +54,8 @@ class UserControllerTest @Autowired constructor(
     @BeforeEach
     fun setUp() {
         cacheManager.getCache(CacheConfig.USER_IS_ADMIN)?.clear()
-        `when`(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        `when`(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
     }
 
     private fun buildHeaders(): HttpHeaders {
@@ -86,7 +86,7 @@ class UserControllerTest @Autowired constructor(
         @Test
         @DisplayName("non-admin user - returns 200 with isAdmin=false")
         fun `returns 200 with isAdmin false for non-admin`() {
-            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
+            whenever(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -102,7 +102,7 @@ class UserControllerTest @Autowired constructor(
         @Test
         @DisplayName("user not in DB - returns 200 with isAdmin=false")
         fun `returns 200 with isAdmin false for user not in db`() {
-            `when`(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = MISSING_USER_ID))
+            whenever(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = MISSING_USER_ID))
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(
@@ -132,7 +132,7 @@ class UserControllerTest @Autowired constructor(
         @Test
         @DisplayName("expired auth_date - returns 403 with X-Auth-Error-Code session_expired")
         fun `returns 403 with session_expired header`() {
-            `when`(telegramValidatorService.verifySignature(any())).thenReturn(false)
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
             val headers = buildHeaders()
 
             val response = restTemplate.exchange(

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/UserControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/UserControllerTest.kt
@@ -30,120 +30,145 @@ import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
 @Sql(
     scripts = ["classpath:sql/access/TelegramUserAccessService.sql"],
     config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
-    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
 )
 @Sql(
     scripts = ["classpath:sql/clear.sql"],
     config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
-    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
 )
-class UserControllerTest @Autowired constructor(
-    private val restTemplate: TestRestTemplate,
-    private val cacheManager: CacheManager,
-) {
+class UserControllerTest
+    @Autowired
+    constructor(
+        private val restTemplate: TestRestTemplate,
+        private val cacheManager: CacheManager,
+    ) {
+        @MockitoBean
+        private lateinit var telegramValidatorService: TelegramValidatorService
 
-    @MockitoBean
-    private lateinit var telegramValidatorService: TelegramValidatorService
+        private val telegramUser = DtoGenerator.generateTelegramUserDto(externalUserId = ADMIN_USER_ID)
 
-    private val ADMIN_USER_ID = 1L
-    private val NON_ADMIN_USER_ID = 2L
-    private val MISSING_USER_ID = 0L
+        @BeforeEach
+        fun setUp() {
+            cacheManager.getCache(CacheConfig.USER_IS_ADMIN)?.clear()
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+            whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
+        }
 
-    private val telegramUser = DtoGenerator.generateTelegramUserDto(externalUserId = ADMIN_USER_ID)
+        private fun buildHeaders(): HttpHeaders =
+            HttpHeaders().apply {
+                set("X-Authorization-Telegram-Data", "test-init-data")
+            }
 
-    @BeforeEach
-    fun setUp() {
-        cacheManager.getCache(CacheConfig.USER_IS_ADMIN)?.clear()
-        whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
-        whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
-    }
+        @Nested
+        @DisplayName("GET /users/me")
+        inner class GetMe {
+            @Test
+            @DisplayName("admin user - returns 200 with isAdmin=true")
+            fun `returns 200 with isAdmin true for admin`() {
+                val headers = buildHeaders()
 
-    private fun buildHeaders(): HttpHeaders {
-        return HttpHeaders().apply {
-            set("X-Authorization-Telegram-Data", "test-init-data")
+                val response =
+                    restTemplate.exchange(
+                        "/users/me",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        MeResponse::class.java,
+                    )
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertNotNull(response.body)
+                assertEquals(ADMIN_USER_ID, response.body!!.externalUserId)
+                assertEquals(true, response.body!!.isAdmin)
+            }
+
+            @Test
+            @DisplayName("non-admin user - returns 200 with isAdmin=false")
+            fun `returns 200 with isAdmin false for non-admin`() {
+                whenever(
+                    telegramValidatorService.map(any()),
+                ).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/users/me",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        MeResponse::class.java,
+                    )
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertNotNull(response.body)
+                assertEquals(NON_ADMIN_USER_ID, response.body!!.externalUserId)
+                assertEquals(false, response.body!!.isAdmin)
+            }
+
+            @Test
+            @DisplayName("user not in DB - returns 200 with isAdmin=false")
+            fun `returns 200 with isAdmin false for user not in db`() {
+                whenever(
+                    telegramValidatorService.map(any()),
+                ).thenReturn(telegramUser.copy(externalUserId = MISSING_USER_ID))
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/users/me",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        MeResponse::class.java,
+                    )
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertNotNull(response.body)
+                assertEquals(MISSING_USER_ID, response.body!!.externalUserId)
+                assertEquals(false, response.body!!.isAdmin)
+            }
+
+            @Test
+            @DisplayName("missing auth header - returns 401 with X-Auth-Error-Code invalid_auth_signature")
+            fun `returns 401 with invalid_auth_signature header`() {
+                val response =
+                    restTemplate.exchange(
+                        "/users/me",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(HttpHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                assertEquals(
+                    AuthErrorType.INVALID_AUTH_SIGNATURE.value,
+                    response.headers.getFirst(AuthErrorType.HEADER_NAME),
+                )
+            }
+
+            @Test
+            @DisplayName("expired auth_date - returns 403 with X-Auth-Error-Code session_expired")
+            fun `returns 403 with session_expired header`() {
+                whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
+                val headers = buildHeaders()
+
+                val response =
+                    restTemplate.exchange(
+                        "/users/me",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(headers),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
+                assertEquals(
+                    AuthErrorType.SESSION_EXPIRED.value,
+                    response.headers.getFirst(AuthErrorType.HEADER_NAME),
+                )
+            }
+        }
+
+        companion object {
+            private const val ADMIN_USER_ID = 1L
+            private const val NON_ADMIN_USER_ID = 2L
+            private const val MISSING_USER_ID = 0L
         }
     }
-
-    @Nested
-    @DisplayName("GET /users/me")
-    inner class GetMe {
-
-        @Test
-        @DisplayName("admin user - returns 200 with isAdmin=true")
-        fun `returns 200 with isAdmin true for admin`() {
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/users/me", HttpMethod.GET, HttpEntity<Void>(headers), MeResponse::class.java
-            )
-
-            assertEquals(HttpStatus.OK, response.statusCode)
-            assertNotNull(response.body)
-            assertEquals(ADMIN_USER_ID, response.body!!.externalUserId)
-            assertEquals(true, response.body!!.isAdmin)
-        }
-
-        @Test
-        @DisplayName("non-admin user - returns 200 with isAdmin=false")
-        fun `returns 200 with isAdmin false for non-admin`() {
-            whenever(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/users/me", HttpMethod.GET, HttpEntity<Void>(headers), MeResponse::class.java
-            )
-
-            assertEquals(HttpStatus.OK, response.statusCode)
-            assertNotNull(response.body)
-            assertEquals(NON_ADMIN_USER_ID, response.body!!.externalUserId)
-            assertEquals(false, response.body!!.isAdmin)
-        }
-
-        @Test
-        @DisplayName("user not in DB - returns 200 with isAdmin=false")
-        fun `returns 200 with isAdmin false for user not in db`() {
-            whenever(telegramValidatorService.map(any())).thenReturn(telegramUser.copy(externalUserId = MISSING_USER_ID))
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/users/me", HttpMethod.GET, HttpEntity<Void>(headers), MeResponse::class.java
-            )
-
-            assertEquals(HttpStatus.OK, response.statusCode)
-            assertNotNull(response.body)
-            assertEquals(MISSING_USER_ID, response.body!!.externalUserId)
-            assertEquals(false, response.body!!.isAdmin)
-        }
-
-        @Test
-        @DisplayName("missing auth header - returns 401 with X-Auth-Error-Code invalid_auth_signature")
-        fun `returns 401 with invalid_auth_signature header`() {
-            val response = restTemplate.exchange(
-                "/users/me", HttpMethod.GET, HttpEntity<Void>(HttpHeaders()), Void::class.java
-            )
-
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-            assertEquals(
-                AuthErrorType.INVALID_AUTH_SIGNATURE.value,
-                response.headers.getFirst(AuthErrorType.HEADER_NAME)
-            )
-        }
-
-        @Test
-        @DisplayName("expired auth_date - returns 403 with X-Auth-Error-Code session_expired")
-        fun `returns 403 with session_expired header`() {
-            whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
-            val headers = buildHeaders()
-
-            val response = restTemplate.exchange(
-                "/users/me", HttpMethod.GET, HttpEntity<Void>(headers), Void::class.java
-            )
-
-            assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
-            assertEquals(
-                AuthErrorType.SESSION_EXPIRED.value,
-                response.headers.getFirst(AuthErrorType.HEADER_NAME)
-            )
-        }
-    }
-}

--- a/src/test/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessServiceTest.kt
@@ -37,8 +37,8 @@ class NotificationAccessServiceTest @Autowired constructor(
 
     private val DEFAULT_ID = 1L
     private val NOT_EXISTED_USER_ID = 0L
-    private val DEFAULT_TELEGRAM_USER_ID = 1L
-    private val DISABLED_TELEGRAM_USER_ID = 2L
+    private val DEFAULT_EXTERNAL_USER_ID = 1L
+    private val DISABLED_EXTERNAL_USER_ID = 2L
     private val WITHOUT_NOTIFICATION_ATTEMPTS = 0
 
     private fun getMutableClock() = clock as ClockHelperTest.MutableClock
@@ -55,30 +55,30 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("findNotificationSettingByTelegramUserId(): returns a found record")
-    fun `successful findNotificationSettingByTelegramUserId`() {
-        assertDoesNotThrow { accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID) }
+    @DisplayName("findNotificationSettingByExternalUserId(): returns a found record")
+    fun `successful findNotificationSettingByExternalUserId`() {
+        assertDoesNotThrow { accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID) }
     }
 
     @Test
-    @DisplayName("existsByTelegramUserId(): returns a true")
-    fun `successful existsByTelegramUserId true`() {
+    @DisplayName("existsByExternalUserId(): returns a true")
+    fun `successful existsByExternalUserId true`() {
         val actual =
             assertDoesNotThrow(
                 ThrowingSupplier {
-                    accessService.existsByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+                    accessService.existsByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
                 }
             )
         assertTrue(actual)
     }
 
     @Test
-    @DisplayName("existsByTelegramUserId(): returns a false")
-    fun `successful existsByTelegramUserId false`() {
+    @DisplayName("existsByExternalUserId(): returns a false")
+    fun `successful existsByExternalUserId false`() {
         val actual =
             assertDoesNotThrow(
                 ThrowingSupplier {
-                    accessService.existsByTelegramUserId(NOT_EXISTED_USER_ID)
+                    accessService.existsByExternalUserId(NOT_EXISTED_USER_ID)
                 }
             )
         assertFalse(actual)
@@ -96,13 +96,13 @@ class NotificationAccessServiceTest @Autowired constructor(
                 }
             )
         assertNotNull(actual.id)
-        assertNotEquals(DEFAULT_TELEGRAM_USER_ID, actual.externalUserId)
+        assertNotEquals(DEFAULT_EXTERNAL_USER_ID, actual.externalUserId)
     }
 
     @Test
     @DisplayName("save(): returns an existed record")
     fun `successful save update`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = DEFAULT_TELEGRAM_USER_ID)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = DEFAULT_EXTERNAL_USER_ID)
 
         val actual =
             assertDoesNotThrow(
@@ -111,15 +111,15 @@ class NotificationAccessServiceTest @Autowired constructor(
                 }
             )
         assertEquals(DEFAULT_ID, actual.id)
-        assertEquals(DEFAULT_TELEGRAM_USER_ID, actual.externalUserId)
+        assertEquals(DEFAULT_EXTERNAL_USER_ID, actual.externalUserId)
     }
 
     @Test
     @DisplayName("save(): reuses existing chat entity when externalChatId already exists")
     fun `successful save with existing chat`() {
         val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = DEFAULT_TELEGRAM_USER_ID,
-            externalChatId = DEFAULT_TELEGRAM_USER_ID
+            externalUserId = DEFAULT_EXTERNAL_USER_ID,
+            externalChatId = DEFAULT_EXTERNAL_USER_ID
         )
 
         val actual =
@@ -128,7 +128,7 @@ class NotificationAccessServiceTest @Autowired constructor(
                     accessService.save(dto.telegramUser, dto.telegramChat, dto)
                 }
             )
-        assertEquals(DEFAULT_TELEGRAM_USER_ID, actual.externalUserId)
+        assertEquals(DEFAULT_EXTERNAL_USER_ID, actual.externalUserId)
     }
 
     @Test
@@ -139,7 +139,7 @@ class NotificationAccessServiceTest @Autowired constructor(
         val actual =
             assertDoesNotThrow(
                 ThrowingSupplier {
-                    accessService.updateTimeOfLastNotification(DEFAULT_TELEGRAM_USER_ID, time)
+                    accessService.updateTimeOfLastNotification(DEFAULT_EXTERNAL_USER_ID, time)
                 }
             )
 
@@ -150,7 +150,7 @@ class NotificationAccessServiceTest @Autowired constructor(
     @Test
     @DisplayName("updateNotificationSettings(): returns an updated set of records")
     fun `successful updateNotificationSettings`() {
-        val existed = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val existed = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
 
         val actual =
             assertDoesNotThrow(
@@ -168,10 +168,10 @@ class NotificationAccessServiceTest @Autowired constructor(
     fun `successful enableNotifications`() {
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.enableNotifications(DISABLED_TELEGRAM_USER_ID)
+                accessService.enableNotifications(DISABLED_EXTERNAL_USER_ID)
             }
         )
-        assertTrue(accessService.isEnabledNotifications(DISABLED_TELEGRAM_USER_ID))
+        assertTrue(accessService.isEnabledNotifications(DISABLED_EXTERNAL_USER_ID))
     }
 
     @Test
@@ -179,10 +179,10 @@ class NotificationAccessServiceTest @Autowired constructor(
     fun `successful disableNotifications`() {
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.disableNotifications(DEFAULT_TELEGRAM_USER_ID)
+                accessService.disableNotifications(DEFAULT_EXTERNAL_USER_ID)
             }
         )
-        assertFalse(accessService.isEnabledNotifications(DEFAULT_TELEGRAM_USER_ID))
+        assertFalse(accessService.isEnabledNotifications(DEFAULT_EXTERNAL_USER_ID))
     }
 
     @Test
@@ -192,7 +192,7 @@ class NotificationAccessServiceTest @Autowired constructor(
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.updateNotificationSettings(DEFAULT_TELEGRAM_USER_ID, newInterval)
+                accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, newInterval)
             }
         )
 
@@ -206,7 +206,7 @@ class NotificationAccessServiceTest @Autowired constructor(
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.updateNotificationSettings(DEFAULT_TELEGRAM_USER_ID, sameInterval)
+                accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, sameInterval)
             }
         )
 
@@ -221,11 +221,11 @@ class NotificationAccessServiceTest @Autowired constructor(
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.changeQuietMode(DEFAULT_TELEGRAM_USER_ID, expectedStart, expectedEnd)
+                accessService.changeQuietMode(DEFAULT_EXTERNAL_USER_ID, expectedStart, expectedEnd)
             }
         )
 
-        val actual = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertEquals(expectedStart, actual.quietModeStart)
         assertEquals(expectedEnd, actual.quietModeEnd)
     }
@@ -233,15 +233,15 @@ class NotificationAccessServiceTest @Autowired constructor(
     @Test
     @DisplayName("disableQuietMode(): clears quiet mode start and end times")
     fun `successful disableQuietMode`() {
-        accessService.changeQuietMode(DEFAULT_TELEGRAM_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
+        accessService.changeQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.disableQuietMode(DEFAULT_TELEGRAM_USER_ID)
+                accessService.disableQuietMode(DEFAULT_EXTERNAL_USER_ID)
             }
         )
 
-        val actual = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertNull(actual.quietModeStart)
         assertNull(actual.quietModeEnd)
     }
@@ -253,11 +253,11 @@ class NotificationAccessServiceTest @Autowired constructor(
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.changeTimezone(DEFAULT_TELEGRAM_USER_ID, newTimezone)
+                accessService.changeTimezone(DEFAULT_EXTERNAL_USER_ID, newTimezone)
             }
         )
 
-        val actual = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertEquals(newTimezone, actual.telegramUser.userTimeZone)
     }
 
@@ -270,13 +270,13 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("findNotificationSettingByTelegramUserId(): throws NotificationSettingsNotFoundException when record not found by telegramUserId")
-    fun `failure findNotificationSettingByTelegramUserId not found`() {
-        assertThrows<NotificationSettingsNotFoundException> { accessService.findNotificationSettingByTelegramUserId(NOT_EXISTED_USER_ID) }
+    @DisplayName("findNotificationSettingByExternalUserId(): throws NotificationSettingsNotFoundException when record not found by externalUserId")
+    fun `failure findNotificationSettingByExternalUserId not found`() {
+        assertThrows<NotificationSettingsNotFoundException> { accessService.findNotificationSettingByExternalUserId(NOT_EXISTED_USER_ID) }
     }
 
     @Test
-    @DisplayName("updateTimeOfLastNotification(): throws NotificationSettingsNotFoundException when record not found by telegramUserId")
+    @DisplayName("updateTimeOfLastNotification(): throws NotificationSettingsNotFoundException when record not found by externalUserId")
     fun `failure updateTimeOfLastNotification not found`() {
         val time = LocalDateTime.now()
         assertThrows<NotificationSettingsNotFoundException> { accessService.updateTimeOfLastNotification(NOT_EXISTED_USER_ID, time) }
@@ -290,7 +290,7 @@ class NotificationAccessServiceTest @Autowired constructor(
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.updateNotificationSettings(DEFAULT_TELEGRAM_USER_ID, IntervalNotificationType.HALF_HOUR)
+                accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, IntervalNotificationType.HALF_HOUR)
             }
         )
 
@@ -302,11 +302,11 @@ class NotificationAccessServiceTest @Autowired constructor(
     @Test
     @DisplayName("updateNotificationSettings(): does not reset timeOfLastNotification and notificationAttempts when interval is the same")
     fun `successful updateNotificationSettings does not reset timeOfLastNotification and notificationAttempts on same interval`() {
-        val before = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.updateNotificationSettings(DEFAULT_TELEGRAM_USER_ID, IntervalNotificationType.TWO_HOURS)
+                accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, IntervalNotificationType.TWO_HOURS)
             }
         )
 
@@ -315,7 +315,7 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("updateNotificationSettings(): throws NotificationSettingsNotFoundException when record not found by telegramUserId")
+    @DisplayName("updateNotificationSettings(): throws NotificationSettingsNotFoundException when record not found by externalUserId")
     fun `failure updateNotificationSettings not found`() {
         assertThrows<NotificationSettingsNotFoundException> {
             accessService.updateNotificationSettings(NOT_EXISTED_USER_ID, IntervalNotificationType.HOUR)
@@ -327,11 +327,11 @@ class NotificationAccessServiceTest @Autowired constructor(
     fun `successful updateNotificationSettings clears pauseUntil on interval change`() {
         getMutableClock().setTime("2025-06-15T10:00:00Z")
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        accessService.setPause(DEFAULT_TELEGRAM_USER_ID, pauseUntil)
+        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.updateNotificationSettings(DEFAULT_TELEGRAM_USER_ID, IntervalNotificationType.HALF_HOUR)
+                accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, IntervalNotificationType.HALF_HOUR)
             }
         )
 
@@ -344,12 +344,12 @@ class NotificationAccessServiceTest @Autowired constructor(
     @DisplayName("setPause(): sets pauseUntil and shifts timeOfLastNotification to pauseUntil minus interval")
     fun `successful setPause sets pauseUntil and shifts timeOfLastNotification`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        // SQL fixture sets DEFAULT_TELEGRAM_USER_ID with TWO_HOURS interval (120 minutes)
+        // SQL fixture sets DEFAULT_EXTERNAL_USER_ID with TWO_HOURS interval (120 minutes)
         val expectedTimeOfLastNotification = pauseUntil.minusMinutes(IntervalNotificationType.TWO_HOURS.minutes)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_TELEGRAM_USER_ID, pauseUntil)
+                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
             }
         )
 
@@ -361,12 +361,12 @@ class NotificationAccessServiceTest @Autowired constructor(
     @DisplayName("setPause(): does NOT reset notificationAttempts when pause is set")
     fun `successful setPause keeps notificationAttempts`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        // SQL fixture seeds notification_attempts = 1 for DEFAULT_TELEGRAM_USER_ID
-        val before = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        // SQL fixture seeds notification_attempts = 1 for DEFAULT_EXTERNAL_USER_ID
+        val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_TELEGRAM_USER_ID, pauseUntil)
+                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
             }
         )
 
@@ -379,11 +379,11 @@ class NotificationAccessServiceTest @Autowired constructor(
         getMutableClock().setTime("2025-06-15T14:00:00Z")
         val expectedTime = LocalDateTime.now(clock)
         // First put user into paused state
-        accessService.setPause(DEFAULT_TELEGRAM_USER_ID, LocalDateTime.of(2025, 6, 15, 18, 0))
+        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, LocalDateTime.of(2025, 6, 15, 18, 0))
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_TELEGRAM_USER_ID, null)
+                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, null)
             }
         )
 
@@ -394,11 +394,11 @@ class NotificationAccessServiceTest @Autowired constructor(
     @Test
     @DisplayName("setPause(): cancel does NOT reset notificationAttempts")
     fun `successful setPause cancel keeps notificationAttempts`() {
-        val before = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_TELEGRAM_USER_ID, null)
+                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, null)
             }
         )
 
@@ -410,11 +410,11 @@ class NotificationAccessServiceTest @Autowired constructor(
     fun `successful setPause re-pause overwrites`() {
         val firstPause = LocalDateTime.of(2025, 6, 15, 14, 0)
         val secondPause = LocalDateTime.of(2025, 6, 15, 18, 0)
-        accessService.setPause(DEFAULT_TELEGRAM_USER_ID, firstPause)
+        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, firstPause)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_TELEGRAM_USER_ID, secondPause)
+                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, secondPause)
             }
         )
 
@@ -430,14 +430,14 @@ class NotificationAccessServiceTest @Autowired constructor(
     fun `successful setPause persists pauseUntil`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
 
-        accessService.setPause(DEFAULT_TELEGRAM_USER_ID, pauseUntil)
+        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
 
-        val reloaded = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val reloaded = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertEquals(pauseUntil, reloaded.pauseUntil)
     }
 
     @Test
-    @DisplayName("setPause(): throws NotificationSettingsNotFoundException when record not found by telegramUserId")
+    @DisplayName("setPause(): throws NotificationSettingsNotFoundException when record not found by externalUserId")
     fun `failure setPause not found`() {
         assertThrows<NotificationSettingsNotFoundException> {
             accessService.setPause(NOT_EXISTED_USER_ID, LocalDateTime.of(2025, 6, 15, 14, 0))
@@ -445,7 +445,7 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("setPause(): throws NotificationSettingsNotFoundException when record not found by telegramUserId on cancel")
+    @DisplayName("setPause(): throws NotificationSettingsNotFoundException when record not found by externalUserId on cancel")
     fun `failure setPause cancel not found`() {
         assertThrows<NotificationSettingsNotFoundException> {
             accessService.setPause(NOT_EXISTED_USER_ID, null)
@@ -456,7 +456,7 @@ class NotificationAccessServiceTest @Autowired constructor(
     @DisplayName("setPause(): throws NotificationSettingsNotFoundException for disabled user (filtered by @SQLRestriction)")
     fun `failure setPause disabled user`() {
         assertThrows<NotificationSettingsNotFoundException> {
-            accessService.setPause(DISABLED_TELEGRAM_USER_ID, LocalDateTime.of(2025, 6, 15, 14, 0))
+            accessService.setPause(DISABLED_EXTERNAL_USER_ID, LocalDateTime.of(2025, 6, 15, 14, 0))
         }
     }
 
@@ -464,15 +464,15 @@ class NotificationAccessServiceTest @Autowired constructor(
     @DisplayName("changeQuietMode(): clears active pauseUntil")
     fun `changeQuietMode clears active pauseUntil`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        accessService.setPause(DEFAULT_TELEGRAM_USER_ID, pauseUntil)
+        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.changeQuietMode(DEFAULT_TELEGRAM_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
+                accessService.changeQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
             }
         )
 
-        val actual = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertNull(actual.pauseUntil)
         assertEquals(LocalTime.of(22, 0), actual.quietModeStart)
         assertEquals(LocalTime.of(8, 0), actual.quietModeEnd)
@@ -482,16 +482,16 @@ class NotificationAccessServiceTest @Autowired constructor(
     @DisplayName("disableQuietMode(): clears active pauseUntil")
     fun `disableQuietMode clears active pauseUntil`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        accessService.changeQuietMode(DEFAULT_TELEGRAM_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
-        accessService.setPause(DEFAULT_TELEGRAM_USER_ID, pauseUntil)
+        accessService.changeQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
+        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.disableQuietMode(DEFAULT_TELEGRAM_USER_ID)
+                accessService.disableQuietMode(DEFAULT_EXTERNAL_USER_ID)
             }
         )
 
-        val actual = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertNull(actual.pauseUntil)
         assertNull(actual.quietModeStart)
         assertNull(actual.quietModeEnd)
@@ -501,17 +501,17 @@ class NotificationAccessServiceTest @Autowired constructor(
     @DisplayName("disableNotifications(): clears active pauseUntil before disabling")
     fun `disableNotifications clears active pauseUntil`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        accessService.setPause(DEFAULT_TELEGRAM_USER_ID, pauseUntil)
+        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.disableNotifications(DEFAULT_TELEGRAM_USER_ID)
+                accessService.disableNotifications(DEFAULT_EXTERNAL_USER_ID)
             }
         )
         // While disabled the entity is filtered out by @SQLRestriction, so re-enable to read it.
-        accessService.enableNotifications(DEFAULT_TELEGRAM_USER_ID)
+        accessService.enableNotifications(DEFAULT_EXTERNAL_USER_ID)
 
-        val actual = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertNull(actual.pauseUntil)
     }
 
@@ -522,11 +522,11 @@ class NotificationAccessServiceTest @Autowired constructor(
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.updateDailyGoal(DEFAULT_TELEGRAM_USER_ID, newGoalMl)
+                accessService.updateDailyGoal(DEFAULT_EXTERNAL_USER_ID, newGoalMl)
             }
         )
 
-        val actual = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
+        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertEquals(newGoalMl, actual.dailyGoalMl)
     }
 
@@ -544,15 +544,15 @@ class NotificationAccessServiceTest @Autowired constructor(
     @DisplayName("updateDailyGoal(): does not affect dailyGoalMl of other users")
     fun `successful updateDailyGoal does not affect other users`() {
         val newGoalForFirst = 2500
-        val before = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
-        // DISABLED_TELEGRAM_USER_ID is filtered by @SQLRestriction, so re-enable to read it back.
-        accessService.enableNotifications(DISABLED_TELEGRAM_USER_ID)
-        val secondBefore = accessService.findNotificationSettingByTelegramUserId(DISABLED_TELEGRAM_USER_ID)
+        val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+        // DISABLED_EXTERNAL_USER_ID is filtered by @SQLRestriction, so re-enable to read it back.
+        accessService.enableNotifications(DISABLED_EXTERNAL_USER_ID)
+        val secondBefore = accessService.findNotificationSettingByExternalUserId(DISABLED_EXTERNAL_USER_ID)
 
-        accessService.updateDailyGoal(DEFAULT_TELEGRAM_USER_ID, newGoalForFirst)
+        accessService.updateDailyGoal(DEFAULT_EXTERNAL_USER_ID, newGoalForFirst)
 
-        val firstAfter = accessService.findNotificationSettingByTelegramUserId(DEFAULT_TELEGRAM_USER_ID)
-        val secondAfter = accessService.findNotificationSettingByTelegramUserId(DISABLED_TELEGRAM_USER_ID)
+        val firstAfter = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+        val secondAfter = accessService.findNotificationSettingByExternalUserId(DISABLED_EXTERNAL_USER_ID)
         assertNotEquals(before.dailyGoalMl, firstAfter.dailyGoalMl)
         assertEquals(newGoalForFirst, firstAfter.dailyGoalMl)
         assertEquals(secondBefore.dailyGoalMl, secondAfter.dailyGoalMl)
@@ -563,7 +563,7 @@ class NotificationAccessServiceTest @Autowired constructor(
     fun `setPause cancel after pause expired keeps timeOfLastNotification`() {
         getMutableClock().setTime("2025-06-15T10:00:00Z")
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 11, 0)
-        accessService.setPause(DEFAULT_TELEGRAM_USER_ID, pauseUntil)
+        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
         val timerWhilePaused = pauseUntil.minusMinutes(IntervalNotificationType.TWO_HOURS.minutes)
 
         // Advance clock past pauseUntil so the pause is expired.
@@ -571,7 +571,7 @@ class NotificationAccessServiceTest @Autowired constructor(
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_TELEGRAM_USER_ID, null)
+                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, null)
             }
         )
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessServiceTest.kt
@@ -1,6 +1,12 @@
 package ru.illine.drinking.ponies.dao.access
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -23,560 +29,606 @@ import java.time.LocalTime
 @Sql(
     scripts = ["classpath:sql/access/NotificationAccessService.sql"],
     config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
-    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
 )
 @Sql(
     scripts = ["classpath:sql/clear.sql"],
     config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
-    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
 )
-class NotificationAccessServiceTest @Autowired constructor(
-    private val accessService: NotificationAccessService,
-    private val clock: Clock,
-) {
+class NotificationAccessServiceTest
+    @Autowired
+    constructor(
+        private val accessService: NotificationAccessService,
+        private val clock: Clock,
+    ) {
+        private fun getMutableClock() = clock as ClockHelperTest.MutableClock
 
-    private val DEFAULT_ID = 1L
-    private val NOT_EXISTED_USER_ID = 0L
-    private val DEFAULT_EXTERNAL_USER_ID = 1L
-    private val DISABLED_EXTERNAL_USER_ID = 2L
-    private val WITHOUT_NOTIFICATION_ATTEMPTS = 0
+        @BeforeEach
+        fun resetClock() {
+            getMutableClock().setTime(ClockHelperTest.DEFAULT_TIME)
+        }
 
-    private fun getMutableClock() = clock as ClockHelperTest.MutableClock
+        @Test
+        @DisplayName("findAllNotificationSettings(): returns a not empty set")
+        fun `successful findAllNotificationSettings`() {
+            assertFalse(accessService.findAllNotificationSettings().isEmpty())
+        }
 
-    @BeforeEach
-    fun resetClock() {
-        getMutableClock().setTime(ClockHelperTest.DEFAULT_TIME)
-    }
+        @Test
+        @DisplayName("findNotificationSettingByExternalUserId(): returns a found record")
+        fun `successful findNotificationSettingByExternalUserId`() {
+            assertDoesNotThrow { accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID) }
+        }
 
-    @Test
-    @DisplayName("findAllNotificationSettings(): returns a not empty set")
-    fun `successful findAllNotificationSettings`() {
-        assertFalse(accessService.findAllNotificationSettings().isEmpty())
-    }
+        @Test
+        @DisplayName("existsByExternalUserId(): returns a true")
+        fun `successful existsByExternalUserId true`() {
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.existsByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+                    },
+                )
+            assertTrue(actual)
+        }
 
-    @Test
-    @DisplayName("findNotificationSettingByExternalUserId(): returns a found record")
-    fun `successful findNotificationSettingByExternalUserId`() {
-        assertDoesNotThrow { accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID) }
-    }
+        @Test
+        @DisplayName("existsByExternalUserId(): returns a false")
+        fun `successful existsByExternalUserId false`() {
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.existsByExternalUserId(NOT_EXISTED_USER_ID)
+                    },
+                )
+            assertFalse(actual)
+        }
 
-    @Test
-    @DisplayName("existsByExternalUserId(): returns a true")
-    fun `successful existsByExternalUserId true`() {
-        val actual =
+        @Test
+        @DisplayName("save(): returns a new record")
+        fun `successful save new`() {
+            val dto = DtoGenerator.generateNotificationDto()
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.save(dto.telegramUser, dto.telegramChat, dto)
+                    },
+                )
+            assertNotNull(actual.id)
+            assertNotEquals(DEFAULT_EXTERNAL_USER_ID, actual.externalUserId)
+        }
+
+        @Test
+        @DisplayName("save(): returns an existed record")
+        fun `successful save update`() {
+            val dto = DtoGenerator.generateNotificationDto(externalUserId = DEFAULT_EXTERNAL_USER_ID)
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.save(dto.telegramUser, dto.telegramChat, dto)
+                    },
+                )
+            assertEquals(DEFAULT_ID, actual.id)
+            assertEquals(DEFAULT_EXTERNAL_USER_ID, actual.externalUserId)
+        }
+
+        @Test
+        @DisplayName("save(): reuses existing chat entity when externalChatId already exists")
+        fun `successful save with existing chat`() {
+            val dto =
+                DtoGenerator.generateNotificationDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    externalChatId = DEFAULT_EXTERNAL_USER_ID,
+                )
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.save(dto.telegramUser, dto.telegramChat, dto)
+                    },
+                )
+            assertEquals(DEFAULT_EXTERNAL_USER_ID, actual.externalUserId)
+        }
+
+        @Test
+        @DisplayName("updateTimeOfLastNotification(): returns an updated record")
+        fun `successful updateTimeOfLastNotification`() {
+            val time = LocalDateTime.now()
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.updateTimeOfLastNotification(DEFAULT_EXTERNAL_USER_ID, time)
+                    },
+                )
+
+            assertEquals(time, actual.timeOfLastNotification)
+            assertEquals(WITHOUT_NOTIFICATION_ATTEMPTS, actual.notificationAttempts)
+        }
+
+        @Test
+        @DisplayName("updateNotificationSettings(): returns an updated set of records")
+        fun `successful updateNotificationSettings`() {
+            val existed = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.updateNotificationSettings(setOf(existed))
+                    },
+                )
+
+            assertFalse(actual.isEmpty())
+            assertEquals(existed.id, actual.first().id)
+        }
+
+        @Test
+        @DisplayName("updateNotificationsEnabled(): changed 'enabled' flag as true")
+        fun `successful updateNotificationsEnabled`() {
             assertDoesNotThrow(
                 ThrowingSupplier {
-                    accessService.existsByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
-                }
+                    accessService.updateNotificationsEnabled(DISABLED_EXTERNAL_USER_ID)
+                },
             )
-        assertTrue(actual)
-    }
+            assertTrue(accessService.findIsEnabledNotificationsByExternalUserId(DISABLED_EXTERNAL_USER_ID))
+        }
 
-    @Test
-    @DisplayName("existsByExternalUserId(): returns a false")
-    fun `successful existsByExternalUserId false`() {
-        val actual =
+        @Test
+        @DisplayName("updateNotificationsDisabled(): changed 'enabled' flag as false")
+        fun `successful updateNotificationsDisabled`() {
             assertDoesNotThrow(
                 ThrowingSupplier {
-                    accessService.existsByExternalUserId(NOT_EXISTED_USER_ID)
-                }
+                    accessService.updateNotificationsDisabled(DEFAULT_EXTERNAL_USER_ID)
+                },
             )
-        assertFalse(actual)
-    }
+            assertFalse(accessService.findIsEnabledNotificationsByExternalUserId(DEFAULT_EXTERNAL_USER_ID))
+        }
 
-    @Test
-    @DisplayName("save(): returns a new record")
-    fun `successful save new`() {
-        val dto = DtoGenerator.generateNotificationDto()
+        @Test
+        @DisplayName("updateNotificationSettings(): updates interval when it differs from current")
+        fun `successful updateNotificationSettings changes interval`() {
+            val newInterval = IntervalNotificationType.HALF_HOUR
 
-        val actual =
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, newInterval)
+                    },
+                )
+
+            assertEquals(newInterval, actual.notificationInterval)
+        }
+
+        @Test
+        @DisplayName("updateNotificationSettings(): does not update when interval is the same")
+        fun `successful updateNotificationSettings same interval`() {
+            val sameInterval = IntervalNotificationType.TWO_HOURS
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, sameInterval)
+                    },
+                )
+
+            assertEquals(sameInterval, actual.notificationInterval)
+        }
+
+        @Test
+        @DisplayName("updateQuietMode(): persists quiet mode start and end times")
+        fun `successful updateQuietMode`() {
+            val expectedStart = LocalTime.of(22, 0)
+            val expectedEnd = LocalTime.of(8, 0)
+
             assertDoesNotThrow(
                 ThrowingSupplier {
-                    accessService.save(dto.telegramUser, dto.telegramChat, dto)
-                }
+                    accessService.updateQuietMode(DEFAULT_EXTERNAL_USER_ID, expectedStart, expectedEnd)
+                },
             )
-        assertNotNull(actual.id)
-        assertNotEquals(DEFAULT_EXTERNAL_USER_ID, actual.externalUserId)
-    }
 
-    @Test
-    @DisplayName("save(): returns an existed record")
-    fun `successful save update`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = DEFAULT_EXTERNAL_USER_ID)
+            val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+            assertEquals(expectedStart, actual.quietModeStart)
+            assertEquals(expectedEnd, actual.quietModeEnd)
+        }
 
-        val actual =
+        @Test
+        @DisplayName("updateQuietModeDisabled(): clears quiet mode start and end times")
+        fun `successful updateQuietModeDisabled`() {
+            accessService.updateQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
+
             assertDoesNotThrow(
                 ThrowingSupplier {
-                    accessService.save(dto.telegramUser, dto.telegramChat, dto)
-                }
+                    accessService.updateQuietModeDisabled(DEFAULT_EXTERNAL_USER_ID)
+                },
             )
-        assertEquals(DEFAULT_ID, actual.id)
-        assertEquals(DEFAULT_EXTERNAL_USER_ID, actual.externalUserId)
-    }
 
-    @Test
-    @DisplayName("save(): reuses existing chat entity when externalChatId already exists")
-    fun `successful save with existing chat`() {
-        val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = DEFAULT_EXTERNAL_USER_ID,
-            externalChatId = DEFAULT_EXTERNAL_USER_ID
-        )
+            val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+            assertNull(actual.quietModeStart)
+            assertNull(actual.quietModeEnd)
+        }
 
-        val actual =
+        @Test
+        @DisplayName("updateTimezone(): persists new timezone for existing user")
+        fun `successful updateTimezone`() {
+            val newTimezone = "America/New_York"
+
             assertDoesNotThrow(
                 ThrowingSupplier {
-                    accessService.save(dto.telegramUser, dto.telegramChat, dto)
-                }
+                    accessService.updateTimezone(DEFAULT_EXTERNAL_USER_ID, newTimezone)
+                },
             )
-        assertEquals(DEFAULT_EXTERNAL_USER_ID, actual.externalUserId)
-    }
 
-    @Test
-    @DisplayName("updateTimeOfLastNotification(): returns an updated record")
-    fun `successful updateTimeOfLastNotification`() {
-        val time = LocalDateTime.now()
+            val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+            assertEquals(newTimezone, actual.telegramUser.userTimeZone)
+        }
 
-        val actual =
+        @Test
+        @DisplayName("updateTimezone(): throws IllegalArgumentException when user does not exist")
+        fun `failure updateTimezone not found`() {
+            assertThrows<IllegalArgumentException> {
+                accessService.updateTimezone(NOT_EXISTED_USER_ID, "Europe/Berlin")
+            }
+        }
+
+        @Test
+        @DisplayName(
+            "findNotificationSettingByExternalUserId(): throws NotificationSettingsNotFoundException when record not found by externalUserId",
+        )
+        fun `failure findNotificationSettingByExternalUserId not found`() {
+            assertThrows<NotificationSettingsNotFoundException> {
+                accessService.findNotificationSettingByExternalUserId(NOT_EXISTED_USER_ID)
+            }
+        }
+
+        @Test
+        @DisplayName(
+            "updateTimeOfLastNotification(): throws NotificationSettingsNotFoundException when record not found by externalUserId",
+        )
+        fun `failure updateTimeOfLastNotification not found`() {
+            val time = LocalDateTime.now()
+            assertThrows<NotificationSettingsNotFoundException> {
+                accessService.updateTimeOfLastNotification(NOT_EXISTED_USER_ID, time)
+            }
+        }
+
+        @Test
+        @DisplayName(
+            "updateNotificationSettings(): resets timeOfLastNotification and notificationAttempts when interval changes",
+        )
+        fun `updateNotificationSettings resets timer and attempts on interval change`() {
+            getMutableClock().setTime("2025-06-15T14:00:00Z")
+            val expectedTime = LocalDateTime.now(clock)
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.updateNotificationSettings(
+                            DEFAULT_EXTERNAL_USER_ID,
+                            IntervalNotificationType.HALF_HOUR,
+                        )
+                    },
+                )
+
+            assertEquals(IntervalNotificationType.HALF_HOUR, actual.notificationInterval)
+            assertEquals(expectedTime, actual.timeOfLastNotification)
+            assertEquals(WITHOUT_NOTIFICATION_ATTEMPTS, actual.notificationAttempts)
+        }
+
+        @Test
+        @DisplayName(
+            "updateNotificationSettings(): does not reset timeOfLastNotification and notificationAttempts when interval is the same",
+        )
+        fun `updateNotificationSettings keeps timer and attempts on same interval`() {
+            val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.updateNotificationSettings(
+                            DEFAULT_EXTERNAL_USER_ID,
+                            IntervalNotificationType.TWO_HOURS,
+                        )
+                    },
+                )
+
+            assertEquals(before.timeOfLastNotification, actual.timeOfLastNotification)
+            assertEquals(before.notificationAttempts, actual.notificationAttempts)
+        }
+
+        @Test
+        @DisplayName(
+            "updateNotificationSettings(): throws NotificationSettingsNotFoundException when record not found by externalUserId",
+        )
+        fun `failure updateNotificationSettings not found`() {
+            assertThrows<NotificationSettingsNotFoundException> {
+                accessService.updateNotificationSettings(NOT_EXISTED_USER_ID, IntervalNotificationType.HOUR)
+            }
+        }
+
+        @Test
+        @DisplayName("updateNotificationSettings(): clears active pauseUntil when interval changes")
+        fun `successful updateNotificationSettings clears pauseUntil on interval change`() {
+            getMutableClock().setTime("2025-06-15T10:00:00Z")
+            val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
+            accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.updateNotificationSettings(
+                            DEFAULT_EXTERNAL_USER_ID,
+                            IntervalNotificationType.HALF_HOUR,
+                        )
+                    },
+                )
+
+            assertEquals(IntervalNotificationType.HALF_HOUR, actual.notificationInterval)
+            assertNull(actual.pauseUntil)
+            assertEquals(LocalDateTime.now(clock), actual.timeOfLastNotification)
+        }
+
+        @Test
+        @DisplayName("updatePause(): sets pauseUntil and shifts timeOfLastNotification to pauseUntil minus interval")
+        fun `successful updatePause sets pauseUntil and shifts timeOfLastNotification`() {
+            val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
+            // SQL fixture sets DEFAULT_EXTERNAL_USER_ID with TWO_HOURS interval (120 minutes)
+            val expectedTimeOfLastNotification = pauseUntil.minusMinutes(IntervalNotificationType.TWO_HOURS.minutes)
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
+                    },
+                )
+
+            assertEquals(pauseUntil, actual.pauseUntil)
+            assertEquals(expectedTimeOfLastNotification, actual.timeOfLastNotification)
+        }
+
+        @Test
+        @DisplayName("updatePause(): does NOT reset notificationAttempts when pause is set")
+        fun `successful updatePause keeps notificationAttempts`() {
+            val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
+            // SQL fixture seeds notification_attempts = 1 for DEFAULT_EXTERNAL_USER_ID
+            val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
+                    },
+                )
+
+            assertEquals(before.notificationAttempts, actual.notificationAttempts)
+        }
+
+        @Test
+        @DisplayName("updatePause(): with null pauseUntil resets pauseUntil to null and timeOfLastNotification to now")
+        fun `successful updatePause cancel resets to now`() {
+            getMutableClock().setTime("2025-06-15T14:00:00Z")
+            val expectedTime = LocalDateTime.now(clock)
+            // First put user into paused state
+            accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, LocalDateTime.of(2025, 6, 15, 18, 0))
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, null)
+                    },
+                )
+
+            assertNull(actual.pauseUntil)
+            assertEquals(expectedTime, actual.timeOfLastNotification)
+        }
+
+        @Test
+        @DisplayName("updatePause(): cancel does NOT reset notificationAttempts")
+        fun `successful updatePause cancel keeps notificationAttempts`() {
+            val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, null)
+                    },
+                )
+
+            assertEquals(before.notificationAttempts, actual.notificationAttempts)
+        }
+
+        @Test
+        @DisplayName("updatePause(): re-pause overwrites previous pauseUntil and timeOfLastNotification")
+        fun `successful updatePause re-pause overwrites`() {
+            val firstPause = LocalDateTime.of(2025, 6, 15, 14, 0)
+            val secondPause = LocalDateTime.of(2025, 6, 15, 18, 0)
+            accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, firstPause)
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, secondPause)
+                    },
+                )
+
+            assertEquals(secondPause, actual.pauseUntil)
+            assertEquals(
+                secondPause.minusMinutes(IntervalNotificationType.TWO_HOURS.minutes),
+                actual.timeOfLastNotification,
+            )
+        }
+
+        @Test
+        @DisplayName("updatePause(): persists pauseUntil so subsequent reads return it")
+        fun `successful updatePause persists pauseUntil`() {
+            val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
+
+            accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
+
+            val reloaded = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+            assertEquals(pauseUntil, reloaded.pauseUntil)
+        }
+
+        @Test
+        @DisplayName(
+            "updatePause(): throws NotificationSettingsNotFoundException when record not found by externalUserId",
+        )
+        fun `failure updatePause not found`() {
+            assertThrows<NotificationSettingsNotFoundException> {
+                accessService.updatePause(NOT_EXISTED_USER_ID, LocalDateTime.of(2025, 6, 15, 14, 0))
+            }
+        }
+
+        @Test
+        @DisplayName(
+            "updatePause(): throws NotificationSettingsNotFoundException when record not found by externalUserId on cancel",
+        )
+        fun `failure updatePause cancel not found`() {
+            assertThrows<NotificationSettingsNotFoundException> {
+                accessService.updatePause(NOT_EXISTED_USER_ID, null)
+            }
+        }
+
+        @Test
+        @DisplayName(
+            "updatePause(): throws NotificationSettingsNotFoundException for disabled user (filtered by @SQLRestriction)",
+        )
+        fun `failure updatePause disabled user`() {
+            assertThrows<NotificationSettingsNotFoundException> {
+                accessService.updatePause(DISABLED_EXTERNAL_USER_ID, LocalDateTime.of(2025, 6, 15, 14, 0))
+            }
+        }
+
+        @Test
+        @DisplayName("updateQuietMode(): clears active pauseUntil")
+        fun `updateQuietMode clears active pauseUntil`() {
+            val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
+            accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
+
             assertDoesNotThrow(
                 ThrowingSupplier {
-                    accessService.updateTimeOfLastNotification(DEFAULT_EXTERNAL_USER_ID, time)
-                }
+                    accessService.updateQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
+                },
             )
 
-        assertEquals(time, actual.timeOfLastNotification)
-        assertEquals(WITHOUT_NOTIFICATION_ATTEMPTS, actual.notificationAttempts)
-    }
+            val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+            assertNull(actual.pauseUntil)
+            assertEquals(LocalTime.of(22, 0), actual.quietModeStart)
+            assertEquals(LocalTime.of(8, 0), actual.quietModeEnd)
+        }
 
-    @Test
-    @DisplayName("updateNotificationSettings(): returns an updated set of records")
-    fun `successful updateNotificationSettings`() {
-        val existed = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+        @Test
+        @DisplayName("updateQuietModeDisabled(): clears active pauseUntil")
+        fun `updateQuietModeDisabled clears active pauseUntil`() {
+            val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
+            accessService.updateQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
+            accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
 
-        val actual =
             assertDoesNotThrow(
                 ThrowingSupplier {
-                    accessService.updateNotificationSettings(setOf(existed))
-                }
+                    accessService.updateQuietModeDisabled(DEFAULT_EXTERNAL_USER_ID)
+                },
             )
 
-        assertFalse(actual.isEmpty())
-        assertEquals(existed.id, actual.first().id)
-    }
+            val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+            assertNull(actual.pauseUntil)
+            assertNull(actual.quietModeStart)
+            assertNull(actual.quietModeEnd)
+        }
 
-    @Test
-    @DisplayName("updateNotificationsEnabled(): changed 'enabled' flag as true")
-    fun `successful updateNotificationsEnabled`() {
-        assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updateNotificationsEnabled(DISABLED_EXTERNAL_USER_ID)
-            }
+        @Test
+        @DisplayName("updateNotificationsDisabled(): clears active pauseUntil before disabling")
+        fun `updateNotificationsDisabled clears active pauseUntil`() {
+            val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
+            accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
+
+            assertDoesNotThrow(
+                ThrowingSupplier {
+                    accessService.updateNotificationsDisabled(DEFAULT_EXTERNAL_USER_ID)
+                },
+            )
+            // While disabled the entity is filtered out by @SQLRestriction, so re-enable to read it.
+            accessService.updateNotificationsEnabled(DEFAULT_EXTERNAL_USER_ID)
+
+            val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+            assertNull(actual.pauseUntil)
+        }
+
+        @Test
+        @DisplayName("updateDailyGoal(): persists new daily goal for existing user")
+        fun `successful updateDailyGoal updates value`() {
+            val newGoalMl = 3000
+
+            assertDoesNotThrow(
+                ThrowingSupplier {
+                    accessService.updateDailyGoal(DEFAULT_EXTERNAL_USER_ID, newGoalMl)
+                },
+            )
+
+            val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+            assertEquals(newGoalMl, actual.dailyGoalMl)
+        }
+
+        @Test
+        @DisplayName("updateDailyGoal(): does not throw when user does not exist (no-op update)")
+        fun `successful updateDailyGoal noop for missing user`() {
+            assertDoesNotThrow(
+                ThrowingSupplier {
+                    accessService.updateDailyGoal(NOT_EXISTED_USER_ID, 1500)
+                },
+            )
+        }
+
+        @Test
+        @DisplayName("updateDailyGoal(): does not affect dailyGoalMl of other users")
+        fun `successful updateDailyGoal does not affect other users`() {
+            val newGoalForFirst = 2500
+            val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+            // DISABLED_EXTERNAL_USER_ID is filtered by @SQLRestriction, so re-enable to read it back.
+            accessService.updateNotificationsEnabled(DISABLED_EXTERNAL_USER_ID)
+            val secondBefore = accessService.findNotificationSettingByExternalUserId(DISABLED_EXTERNAL_USER_ID)
+
+            accessService.updateDailyGoal(DEFAULT_EXTERNAL_USER_ID, newGoalForFirst)
+
+            val firstAfter = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+            val secondAfter = accessService.findNotificationSettingByExternalUserId(DISABLED_EXTERNAL_USER_ID)
+            assertNotEquals(before.dailyGoalMl, firstAfter.dailyGoalMl)
+            assertEquals(newGoalForFirst, firstAfter.dailyGoalMl)
+            assertEquals(secondBefore.dailyGoalMl, secondAfter.dailyGoalMl)
+        }
+
+        @Test
+        @DisplayName(
+            "updatePause(null): on already-expired pause, clears pauseUntil but does NOT reset timeOfLastNotification",
         )
-        assertTrue(accessService.findIsEnabledNotificationsByExternalUserId(DISABLED_EXTERNAL_USER_ID))
-    }
+        fun `updatePause cancel after pause expired keeps timeOfLastNotification`() {
+            getMutableClock().setTime("2025-06-15T10:00:00Z")
+            val pauseUntil = LocalDateTime.of(2025, 6, 15, 11, 0)
+            accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
+            val timerWhilePaused = pauseUntil.minusMinutes(IntervalNotificationType.TWO_HOURS.minutes)
 
-    @Test
-    @DisplayName("updateNotificationsDisabled(): changed 'enabled' flag as false")
-    fun `successful updateNotificationsDisabled`() {
-        assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updateNotificationsDisabled(DEFAULT_EXTERNAL_USER_ID)
-            }
-        )
-        assertFalse(accessService.findIsEnabledNotificationsByExternalUserId(DEFAULT_EXTERNAL_USER_ID))
-    }
+            // Advance clock past pauseUntil so the pause is expired.
+            getMutableClock().setTime("2025-06-15T15:00:00Z")
 
-    @Test
-    @DisplayName("updateNotificationSettings(): updates interval when it differs from current")
-    fun `successful updateNotificationSettings changes interval`() {
-        val newInterval = IntervalNotificationType.HALF_HOUR
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, null)
+                    },
+                )
 
-        val actual = assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, newInterval)
-            }
-        )
+            assertNull(actual.pauseUntil)
+            // Cancel is idempotent for already-expired pause: timer is not bumped.
+            assertEquals(timerWhilePaused, actual.timeOfLastNotification)
+        }
 
-        assertEquals(newInterval, actual.notificationInterval)
-    }
-
-    @Test
-    @DisplayName("updateNotificationSettings(): does not update when interval is the same")
-    fun `successful updateNotificationSettings same interval`() {
-        val sameInterval = IntervalNotificationType.TWO_HOURS
-
-        val actual = assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, sameInterval)
-            }
-        )
-
-        assertEquals(sameInterval, actual.notificationInterval)
-    }
-
-    @Test
-    @DisplayName("updateQuietMode(): persists quiet mode start and end times")
-    fun `successful updateQuietMode`() {
-        val expectedStart = LocalTime.of(22, 0)
-        val expectedEnd = LocalTime.of(8, 0)
-
-        assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updateQuietMode(DEFAULT_EXTERNAL_USER_ID, expectedStart, expectedEnd)
-            }
-        )
-
-        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
-        assertEquals(expectedStart, actual.quietModeStart)
-        assertEquals(expectedEnd, actual.quietModeEnd)
-    }
-
-    @Test
-    @DisplayName("updateQuietModeDisabled(): clears quiet mode start and end times")
-    fun `successful updateQuietModeDisabled`() {
-        accessService.updateQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
-
-        assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updateQuietModeDisabled(DEFAULT_EXTERNAL_USER_ID)
-            }
-        )
-
-        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
-        assertNull(actual.quietModeStart)
-        assertNull(actual.quietModeEnd)
-    }
-
-    @Test
-    @DisplayName("updateTimezone(): persists new timezone for existing user")
-    fun `successful updateTimezone`() {
-        val newTimezone = "America/New_York"
-
-        assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updateTimezone(DEFAULT_EXTERNAL_USER_ID, newTimezone)
-            }
-        )
-
-        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
-        assertEquals(newTimezone, actual.telegramUser.userTimeZone)
-    }
-
-    @Test
-    @DisplayName("updateTimezone(): throws IllegalArgumentException when user does not exist")
-    fun `failure updateTimezone not found`() {
-        assertThrows<IllegalArgumentException> {
-            accessService.updateTimezone(NOT_EXISTED_USER_ID, "Europe/Berlin")
+        companion object {
+            private const val DEFAULT_ID = 1L
+            private const val NOT_EXISTED_USER_ID = 0L
+            private const val DEFAULT_EXTERNAL_USER_ID = 1L
+            private const val DISABLED_EXTERNAL_USER_ID = 2L
+            private const val WITHOUT_NOTIFICATION_ATTEMPTS = 0
         }
     }
-
-    @Test
-    @DisplayName("findNotificationSettingByExternalUserId(): throws NotificationSettingsNotFoundException when record not found by externalUserId")
-    fun `failure findNotificationSettingByExternalUserId not found`() {
-        assertThrows<NotificationSettingsNotFoundException> { accessService.findNotificationSettingByExternalUserId(NOT_EXISTED_USER_ID) }
-    }
-
-    @Test
-    @DisplayName("updateTimeOfLastNotification(): throws NotificationSettingsNotFoundException when record not found by externalUserId")
-    fun `failure updateTimeOfLastNotification not found`() {
-        val time = LocalDateTime.now()
-        assertThrows<NotificationSettingsNotFoundException> { accessService.updateTimeOfLastNotification(NOT_EXISTED_USER_ID, time) }
-    }
-
-    @Test
-    @DisplayName("updateNotificationSettings(): resets timeOfLastNotification and notificationAttempts when interval changes")
-    fun `successful updateNotificationSettings resets timeOfLastNotification and notificationAttempts on interval change`() {
-        getMutableClock().setTime("2025-06-15T14:00:00Z")
-        val expectedTime = LocalDateTime.now(clock)
-
-        val actual = assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, IntervalNotificationType.HALF_HOUR)
-            }
-        )
-
-        assertEquals(IntervalNotificationType.HALF_HOUR, actual.notificationInterval)
-        assertEquals(expectedTime, actual.timeOfLastNotification)
-        assertEquals(WITHOUT_NOTIFICATION_ATTEMPTS, actual.notificationAttempts)
-    }
-
-    @Test
-    @DisplayName("updateNotificationSettings(): does not reset timeOfLastNotification and notificationAttempts when interval is the same")
-    fun `successful updateNotificationSettings does not reset timeOfLastNotification and notificationAttempts on same interval`() {
-        val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
-
-        val actual = assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, IntervalNotificationType.TWO_HOURS)
-            }
-        )
-
-        assertEquals(before.timeOfLastNotification, actual.timeOfLastNotification)
-        assertEquals(before.notificationAttempts, actual.notificationAttempts)
-    }
-
-    @Test
-    @DisplayName("updateNotificationSettings(): throws NotificationSettingsNotFoundException when record not found by externalUserId")
-    fun `failure updateNotificationSettings not found`() {
-        assertThrows<NotificationSettingsNotFoundException> {
-            accessService.updateNotificationSettings(NOT_EXISTED_USER_ID, IntervalNotificationType.HOUR)
-        }
-    }
-
-    @Test
-    @DisplayName("updateNotificationSettings(): clears active pauseUntil when interval changes")
-    fun `successful updateNotificationSettings clears pauseUntil on interval change`() {
-        getMutableClock().setTime("2025-06-15T10:00:00Z")
-        val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
-
-        val actual = assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updateNotificationSettings(DEFAULT_EXTERNAL_USER_ID, IntervalNotificationType.HALF_HOUR)
-            }
-        )
-
-        assertEquals(IntervalNotificationType.HALF_HOUR, actual.notificationInterval)
-        assertNull(actual.pauseUntil)
-        assertEquals(LocalDateTime.now(clock), actual.timeOfLastNotification)
-    }
-
-    @Test
-    @DisplayName("updatePause(): sets pauseUntil and shifts timeOfLastNotification to pauseUntil minus interval")
-    fun `successful updatePause sets pauseUntil and shifts timeOfLastNotification`() {
-        val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        // SQL fixture sets DEFAULT_EXTERNAL_USER_ID with TWO_HOURS interval (120 minutes)
-        val expectedTimeOfLastNotification = pauseUntil.minusMinutes(IntervalNotificationType.TWO_HOURS.minutes)
-
-        val actual = assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
-            }
-        )
-
-        assertEquals(pauseUntil, actual.pauseUntil)
-        assertEquals(expectedTimeOfLastNotification, actual.timeOfLastNotification)
-    }
-
-    @Test
-    @DisplayName("updatePause(): does NOT reset notificationAttempts when pause is set")
-    fun `successful updatePause keeps notificationAttempts`() {
-        val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        // SQL fixture seeds notification_attempts = 1 for DEFAULT_EXTERNAL_USER_ID
-        val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
-
-        val actual = assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
-            }
-        )
-
-        assertEquals(before.notificationAttempts, actual.notificationAttempts)
-    }
-
-    @Test
-    @DisplayName("updatePause(): with null pauseUntil resets pauseUntil to null and timeOfLastNotification to now")
-    fun `successful updatePause cancel resets to now`() {
-        getMutableClock().setTime("2025-06-15T14:00:00Z")
-        val expectedTime = LocalDateTime.now(clock)
-        // First put user into paused state
-        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, LocalDateTime.of(2025, 6, 15, 18, 0))
-
-        val actual = assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, null)
-            }
-        )
-
-        assertNull(actual.pauseUntil)
-        assertEquals(expectedTime, actual.timeOfLastNotification)
-    }
-
-    @Test
-    @DisplayName("updatePause(): cancel does NOT reset notificationAttempts")
-    fun `successful updatePause cancel keeps notificationAttempts`() {
-        val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
-
-        val actual = assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, null)
-            }
-        )
-
-        assertEquals(before.notificationAttempts, actual.notificationAttempts)
-    }
-
-    @Test
-    @DisplayName("updatePause(): re-pause overwrites previous pauseUntil and timeOfLastNotification")
-    fun `successful updatePause re-pause overwrites`() {
-        val firstPause = LocalDateTime.of(2025, 6, 15, 14, 0)
-        val secondPause = LocalDateTime.of(2025, 6, 15, 18, 0)
-        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, firstPause)
-
-        val actual = assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, secondPause)
-            }
-        )
-
-        assertEquals(secondPause, actual.pauseUntil)
-        assertEquals(
-            secondPause.minusMinutes(IntervalNotificationType.TWO_HOURS.minutes),
-            actual.timeOfLastNotification
-        )
-    }
-
-    @Test
-    @DisplayName("updatePause(): persists pauseUntil so subsequent reads return it")
-    fun `successful updatePause persists pauseUntil`() {
-        val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-
-        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
-
-        val reloaded = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
-        assertEquals(pauseUntil, reloaded.pauseUntil)
-    }
-
-    @Test
-    @DisplayName("updatePause(): throws NotificationSettingsNotFoundException when record not found by externalUserId")
-    fun `failure updatePause not found`() {
-        assertThrows<NotificationSettingsNotFoundException> {
-            accessService.updatePause(NOT_EXISTED_USER_ID, LocalDateTime.of(2025, 6, 15, 14, 0))
-        }
-    }
-
-    @Test
-    @DisplayName("updatePause(): throws NotificationSettingsNotFoundException when record not found by externalUserId on cancel")
-    fun `failure updatePause cancel not found`() {
-        assertThrows<NotificationSettingsNotFoundException> {
-            accessService.updatePause(NOT_EXISTED_USER_ID, null)
-        }
-    }
-
-    @Test
-    @DisplayName("updatePause(): throws NotificationSettingsNotFoundException for disabled user (filtered by @SQLRestriction)")
-    fun `failure updatePause disabled user`() {
-        assertThrows<NotificationSettingsNotFoundException> {
-            accessService.updatePause(DISABLED_EXTERNAL_USER_ID, LocalDateTime.of(2025, 6, 15, 14, 0))
-        }
-    }
-
-    @Test
-    @DisplayName("updateQuietMode(): clears active pauseUntil")
-    fun `updateQuietMode clears active pauseUntil`() {
-        val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
-
-        assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updateQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
-            }
-        )
-
-        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
-        assertNull(actual.pauseUntil)
-        assertEquals(LocalTime.of(22, 0), actual.quietModeStart)
-        assertEquals(LocalTime.of(8, 0), actual.quietModeEnd)
-    }
-
-    @Test
-    @DisplayName("updateQuietModeDisabled(): clears active pauseUntil")
-    fun `updateQuietModeDisabled clears active pauseUntil`() {
-        val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        accessService.updateQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
-        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
-
-        assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updateQuietModeDisabled(DEFAULT_EXTERNAL_USER_ID)
-            }
-        )
-
-        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
-        assertNull(actual.pauseUntil)
-        assertNull(actual.quietModeStart)
-        assertNull(actual.quietModeEnd)
-    }
-
-    @Test
-    @DisplayName("updateNotificationsDisabled(): clears active pauseUntil before disabling")
-    fun `updateNotificationsDisabled clears active pauseUntil`() {
-        val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
-
-        assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updateNotificationsDisabled(DEFAULT_EXTERNAL_USER_ID)
-            }
-        )
-        // While disabled the entity is filtered out by @SQLRestriction, so re-enable to read it.
-        accessService.updateNotificationsEnabled(DEFAULT_EXTERNAL_USER_ID)
-
-        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
-        assertNull(actual.pauseUntil)
-    }
-
-    @Test
-    @DisplayName("updateDailyGoal(): persists new daily goal for existing user")
-    fun `successful updateDailyGoal updates value`() {
-        val newGoalMl = 3000
-
-        assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updateDailyGoal(DEFAULT_EXTERNAL_USER_ID, newGoalMl)
-            }
-        )
-
-        val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
-        assertEquals(newGoalMl, actual.dailyGoalMl)
-    }
-
-    @Test
-    @DisplayName("updateDailyGoal(): does not throw when user does not exist (no-op update)")
-    fun `successful updateDailyGoal noop for missing user`() {
-        assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updateDailyGoal(NOT_EXISTED_USER_ID, 1500)
-            }
-        )
-    }
-
-    @Test
-    @DisplayName("updateDailyGoal(): does not affect dailyGoalMl of other users")
-    fun `successful updateDailyGoal does not affect other users`() {
-        val newGoalForFirst = 2500
-        val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
-        // DISABLED_EXTERNAL_USER_ID is filtered by @SQLRestriction, so re-enable to read it back.
-        accessService.updateNotificationsEnabled(DISABLED_EXTERNAL_USER_ID)
-        val secondBefore = accessService.findNotificationSettingByExternalUserId(DISABLED_EXTERNAL_USER_ID)
-
-        accessService.updateDailyGoal(DEFAULT_EXTERNAL_USER_ID, newGoalForFirst)
-
-        val firstAfter = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
-        val secondAfter = accessService.findNotificationSettingByExternalUserId(DISABLED_EXTERNAL_USER_ID)
-        assertNotEquals(before.dailyGoalMl, firstAfter.dailyGoalMl)
-        assertEquals(newGoalForFirst, firstAfter.dailyGoalMl)
-        assertEquals(secondBefore.dailyGoalMl, secondAfter.dailyGoalMl)
-    }
-
-    @Test
-    @DisplayName("updatePause(null): on already-expired pause, clears pauseUntil but does NOT reset timeOfLastNotification")
-    fun `updatePause cancel after pause expired keeps timeOfLastNotification`() {
-        getMutableClock().setTime("2025-06-15T10:00:00Z")
-        val pauseUntil = LocalDateTime.of(2025, 6, 15, 11, 0)
-        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
-        val timerWhilePaused = pauseUntil.minusMinutes(IntervalNotificationType.TWO_HOURS.minutes)
-
-        // Advance clock past pauseUntil so the pause is expired.
-        getMutableClock().setTime("2025-06-15T15:00:00Z")
-
-        val actual = assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, null)
-            }
-        )
-
-        assertNull(actual.pauseUntil)
-        // Cancel is idempotent for already-expired pause: timer is not bumped.
-        assertEquals(timerWhilePaused, actual.timeOfLastNotification)
-    }
-}

--- a/src/test/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessServiceTest.kt
@@ -164,25 +164,25 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("enableNotifications(): changed 'enabled' flag as true")
-    fun `successful enableNotifications`() {
+    @DisplayName("updateNotificationsEnabled(): changed 'enabled' flag as true")
+    fun `successful updateNotificationsEnabled`() {
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.enableNotifications(DISABLED_EXTERNAL_USER_ID)
+                accessService.updateNotificationsEnabled(DISABLED_EXTERNAL_USER_ID)
             }
         )
-        assertTrue(accessService.isEnabledNotifications(DISABLED_EXTERNAL_USER_ID))
+        assertTrue(accessService.findIsEnabledNotificationsByExternalUserId(DISABLED_EXTERNAL_USER_ID))
     }
 
     @Test
-    @DisplayName("disableNotifications(): changed 'enabled' flag as false")
-    fun `successful disableNotifications`() {
+    @DisplayName("updateNotificationsDisabled(): changed 'enabled' flag as false")
+    fun `successful updateNotificationsDisabled`() {
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.disableNotifications(DEFAULT_EXTERNAL_USER_ID)
+                accessService.updateNotificationsDisabled(DEFAULT_EXTERNAL_USER_ID)
             }
         )
-        assertFalse(accessService.isEnabledNotifications(DEFAULT_EXTERNAL_USER_ID))
+        assertFalse(accessService.findIsEnabledNotificationsByExternalUserId(DEFAULT_EXTERNAL_USER_ID))
     }
 
     @Test
@@ -214,14 +214,14 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("changeQuietMode(): persists quiet mode start and end times")
-    fun `successful changeQuietMode`() {
+    @DisplayName("updateQuietMode(): persists quiet mode start and end times")
+    fun `successful updateQuietMode`() {
         val expectedStart = LocalTime.of(22, 0)
         val expectedEnd = LocalTime.of(8, 0)
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.changeQuietMode(DEFAULT_EXTERNAL_USER_ID, expectedStart, expectedEnd)
+                accessService.updateQuietMode(DEFAULT_EXTERNAL_USER_ID, expectedStart, expectedEnd)
             }
         )
 
@@ -231,13 +231,13 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("disableQuietMode(): clears quiet mode start and end times")
-    fun `successful disableQuietMode`() {
-        accessService.changeQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
+    @DisplayName("updateQuietModeDisabled(): clears quiet mode start and end times")
+    fun `successful updateQuietModeDisabled`() {
+        accessService.updateQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.disableQuietMode(DEFAULT_EXTERNAL_USER_ID)
+                accessService.updateQuietModeDisabled(DEFAULT_EXTERNAL_USER_ID)
             }
         )
 
@@ -247,13 +247,13 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("changeTimezone(): persists new timezone for existing user")
-    fun `successful changeTimezone`() {
+    @DisplayName("updateTimezone(): persists new timezone for existing user")
+    fun `successful updateTimezone`() {
         val newTimezone = "America/New_York"
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.changeTimezone(DEFAULT_EXTERNAL_USER_ID, newTimezone)
+                accessService.updateTimezone(DEFAULT_EXTERNAL_USER_ID, newTimezone)
             }
         )
 
@@ -262,10 +262,10 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("changeTimezone(): throws IllegalArgumentException when user does not exist")
-    fun `failure changeTimezone not found`() {
+    @DisplayName("updateTimezone(): throws IllegalArgumentException when user does not exist")
+    fun `failure updateTimezone not found`() {
         assertThrows<IllegalArgumentException> {
-            accessService.changeTimezone(NOT_EXISTED_USER_ID, "Europe/Berlin")
+            accessService.updateTimezone(NOT_EXISTED_USER_ID, "Europe/Berlin")
         }
     }
 
@@ -327,7 +327,7 @@ class NotificationAccessServiceTest @Autowired constructor(
     fun `successful updateNotificationSettings clears pauseUntil on interval change`() {
         getMutableClock().setTime("2025-06-15T10:00:00Z")
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
+        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
@@ -341,15 +341,15 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("setPause(): sets pauseUntil and shifts timeOfLastNotification to pauseUntil minus interval")
-    fun `successful setPause sets pauseUntil and shifts timeOfLastNotification`() {
+    @DisplayName("updatePause(): sets pauseUntil and shifts timeOfLastNotification to pauseUntil minus interval")
+    fun `successful updatePause sets pauseUntil and shifts timeOfLastNotification`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
         // SQL fixture sets DEFAULT_EXTERNAL_USER_ID with TWO_HOURS interval (120 minutes)
         val expectedTimeOfLastNotification = pauseUntil.minusMinutes(IntervalNotificationType.TWO_HOURS.minutes)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
+                accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
             }
         )
 
@@ -358,15 +358,15 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("setPause(): does NOT reset notificationAttempts when pause is set")
-    fun `successful setPause keeps notificationAttempts`() {
+    @DisplayName("updatePause(): does NOT reset notificationAttempts when pause is set")
+    fun `successful updatePause keeps notificationAttempts`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
         // SQL fixture seeds notification_attempts = 1 for DEFAULT_EXTERNAL_USER_ID
         val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
+                accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
             }
         )
 
@@ -374,16 +374,16 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("setPause(): with null pauseUntil resets pauseUntil to null and timeOfLastNotification to now")
-    fun `successful setPause cancel resets to now`() {
+    @DisplayName("updatePause(): with null pauseUntil resets pauseUntil to null and timeOfLastNotification to now")
+    fun `successful updatePause cancel resets to now`() {
         getMutableClock().setTime("2025-06-15T14:00:00Z")
         val expectedTime = LocalDateTime.now(clock)
         // First put user into paused state
-        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, LocalDateTime.of(2025, 6, 15, 18, 0))
+        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, LocalDateTime.of(2025, 6, 15, 18, 0))
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, null)
+                accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, null)
             }
         )
 
@@ -392,13 +392,13 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("setPause(): cancel does NOT reset notificationAttempts")
-    fun `successful setPause cancel keeps notificationAttempts`() {
+    @DisplayName("updatePause(): cancel does NOT reset notificationAttempts")
+    fun `successful updatePause cancel keeps notificationAttempts`() {
         val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, null)
+                accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, null)
             }
         )
 
@@ -406,15 +406,15 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("setPause(): re-pause overwrites previous pauseUntil and timeOfLastNotification")
-    fun `successful setPause re-pause overwrites`() {
+    @DisplayName("updatePause(): re-pause overwrites previous pauseUntil and timeOfLastNotification")
+    fun `successful updatePause re-pause overwrites`() {
         val firstPause = LocalDateTime.of(2025, 6, 15, 14, 0)
         val secondPause = LocalDateTime.of(2025, 6, 15, 18, 0)
-        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, firstPause)
+        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, firstPause)
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, secondPause)
+                accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, secondPause)
             }
         )
 
@@ -426,49 +426,49 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("setPause(): persists pauseUntil so subsequent reads return it")
-    fun `successful setPause persists pauseUntil`() {
+    @DisplayName("updatePause(): persists pauseUntil so subsequent reads return it")
+    fun `successful updatePause persists pauseUntil`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
 
-        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
+        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
 
         val reloaded = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertEquals(pauseUntil, reloaded.pauseUntil)
     }
 
     @Test
-    @DisplayName("setPause(): throws NotificationSettingsNotFoundException when record not found by externalUserId")
-    fun `failure setPause not found`() {
+    @DisplayName("updatePause(): throws NotificationSettingsNotFoundException when record not found by externalUserId")
+    fun `failure updatePause not found`() {
         assertThrows<NotificationSettingsNotFoundException> {
-            accessService.setPause(NOT_EXISTED_USER_ID, LocalDateTime.of(2025, 6, 15, 14, 0))
+            accessService.updatePause(NOT_EXISTED_USER_ID, LocalDateTime.of(2025, 6, 15, 14, 0))
         }
     }
 
     @Test
-    @DisplayName("setPause(): throws NotificationSettingsNotFoundException when record not found by externalUserId on cancel")
-    fun `failure setPause cancel not found`() {
+    @DisplayName("updatePause(): throws NotificationSettingsNotFoundException when record not found by externalUserId on cancel")
+    fun `failure updatePause cancel not found`() {
         assertThrows<NotificationSettingsNotFoundException> {
-            accessService.setPause(NOT_EXISTED_USER_ID, null)
+            accessService.updatePause(NOT_EXISTED_USER_ID, null)
         }
     }
 
     @Test
-    @DisplayName("setPause(): throws NotificationSettingsNotFoundException for disabled user (filtered by @SQLRestriction)")
-    fun `failure setPause disabled user`() {
+    @DisplayName("updatePause(): throws NotificationSettingsNotFoundException for disabled user (filtered by @SQLRestriction)")
+    fun `failure updatePause disabled user`() {
         assertThrows<NotificationSettingsNotFoundException> {
-            accessService.setPause(DISABLED_EXTERNAL_USER_ID, LocalDateTime.of(2025, 6, 15, 14, 0))
+            accessService.updatePause(DISABLED_EXTERNAL_USER_ID, LocalDateTime.of(2025, 6, 15, 14, 0))
         }
     }
 
     @Test
-    @DisplayName("changeQuietMode(): clears active pauseUntil")
-    fun `changeQuietMode clears active pauseUntil`() {
+    @DisplayName("updateQuietMode(): clears active pauseUntil")
+    fun `updateQuietMode clears active pauseUntil`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
+        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.changeQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
+                accessService.updateQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
             }
         )
 
@@ -479,15 +479,15 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("disableQuietMode(): clears active pauseUntil")
-    fun `disableQuietMode clears active pauseUntil`() {
+    @DisplayName("updateQuietModeDisabled(): clears active pauseUntil")
+    fun `updateQuietModeDisabled clears active pauseUntil`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        accessService.changeQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
-        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
+        accessService.updateQuietMode(DEFAULT_EXTERNAL_USER_ID, LocalTime.of(22, 0), LocalTime.of(8, 0))
+        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.disableQuietMode(DEFAULT_EXTERNAL_USER_ID)
+                accessService.updateQuietModeDisabled(DEFAULT_EXTERNAL_USER_ID)
             }
         )
 
@@ -498,18 +498,18 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("disableNotifications(): clears active pauseUntil before disabling")
-    fun `disableNotifications clears active pauseUntil`() {
+    @DisplayName("updateNotificationsDisabled(): clears active pauseUntil before disabling")
+    fun `updateNotificationsDisabled clears active pauseUntil`() {
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
+        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
 
         assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.disableNotifications(DEFAULT_EXTERNAL_USER_ID)
+                accessService.updateNotificationsDisabled(DEFAULT_EXTERNAL_USER_ID)
             }
         )
         // While disabled the entity is filtered out by @SQLRestriction, so re-enable to read it.
-        accessService.enableNotifications(DEFAULT_EXTERNAL_USER_ID)
+        accessService.updateNotificationsEnabled(DEFAULT_EXTERNAL_USER_ID)
 
         val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         assertNull(actual.pauseUntil)
@@ -546,7 +546,7 @@ class NotificationAccessServiceTest @Autowired constructor(
         val newGoalForFirst = 2500
         val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
         // DISABLED_EXTERNAL_USER_ID is filtered by @SQLRestriction, so re-enable to read it back.
-        accessService.enableNotifications(DISABLED_EXTERNAL_USER_ID)
+        accessService.updateNotificationsEnabled(DISABLED_EXTERNAL_USER_ID)
         val secondBefore = accessService.findNotificationSettingByExternalUserId(DISABLED_EXTERNAL_USER_ID)
 
         accessService.updateDailyGoal(DEFAULT_EXTERNAL_USER_ID, newGoalForFirst)
@@ -559,11 +559,11 @@ class NotificationAccessServiceTest @Autowired constructor(
     }
 
     @Test
-    @DisplayName("setPause(null): on already-expired pause, clears pauseUntil but does NOT reset timeOfLastNotification")
-    fun `setPause cancel after pause expired keeps timeOfLastNotification`() {
+    @DisplayName("updatePause(null): on already-expired pause, clears pauseUntil but does NOT reset timeOfLastNotification")
+    fun `updatePause cancel after pause expired keeps timeOfLastNotification`() {
         getMutableClock().setTime("2025-06-15T10:00:00Z")
         val pauseUntil = LocalDateTime.of(2025, 6, 15, 11, 0)
-        accessService.setPause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
+        accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
         val timerWhilePaused = pauseUntil.minusMinutes(IntervalNotificationType.TWO_HOURS.minutes)
 
         // Advance clock past pauseUntil so the pause is expired.
@@ -571,7 +571,7 @@ class NotificationAccessServiceTest @Autowired constructor(
 
         val actual = assertDoesNotThrow(
             ThrowingSupplier {
-                accessService.setPause(DEFAULT_EXTERNAL_USER_ID, null)
+                accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, null)
             }
         )
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessServiceTest.kt
@@ -21,84 +21,87 @@ import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
 @Sql(
     scripts = ["classpath:sql/access/TelegramUserAccessService.sql"],
     config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
-    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
 )
 @Sql(
     scripts = ["classpath:sql/clear.sql"],
     config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
-    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
 )
-class TelegramUserAccessServiceTest @Autowired constructor(
-    private val accessService: TelegramUserAccessService,
-    private val telegramUserRepository: TelegramUserRepository,
-    private val cacheManager: CacheManager,
-) {
+class TelegramUserAccessServiceTest
+    @Autowired
+    constructor(
+        private val accessService: TelegramUserAccessService,
+        private val telegramUserRepository: TelegramUserRepository,
+        private val cacheManager: CacheManager,
+    ) {
+        @BeforeEach
+        fun clearCache() {
+            cacheManager.getCache(CacheConfig.USER_IS_ADMIN)?.clear()
+        }
 
-    private val ADMIN_USER_ID = 1L
-    private val NON_ADMIN_USER_ID = 2L
-    private val MISSING_USER_ID = 0L
+        @Test
+        @DisplayName("findIsAdminByExternalUserId(): admin user - returns true")
+        fun `returns true for admin`() {
+            assertTrue(accessService.findIsAdminByExternalUserId(ADMIN_USER_ID))
+        }
 
-    @BeforeEach
-    fun clearCache() {
-        cacheManager.getCache(CacheConfig.USER_IS_ADMIN)?.clear()
+        @Test
+        @DisplayName("findIsAdminByExternalUserId(): non-admin user - returns false")
+        fun `returns false for non-admin`() {
+            assertFalse(accessService.findIsAdminByExternalUserId(NON_ADMIN_USER_ID))
+        }
+
+        @Test
+        @DisplayName("findIsAdminByExternalUserId(): missing user - returns false")
+        fun `returns false for missing user`() {
+            assertFalse(accessService.findIsAdminByExternalUserId(MISSING_USER_ID))
+        }
+
+        @Test
+        @DisplayName("findIsAdminByExternalUserId(): caches result after first call")
+        fun `caches true result after first call`() {
+            val cache = cacheManager.getCache(CacheConfig.USER_IS_ADMIN)
+            assertNotNull(cache)
+            assertNull(cache!!.get(ADMIN_USER_ID))
+
+            accessService.findIsAdminByExternalUserId(ADMIN_USER_ID)
+
+            assertEquals(true, cache.get(ADMIN_USER_ID)?.get())
+        }
+
+        @Test
+        @DisplayName("findIsAdminByExternalUserId(): caches false for missing user")
+        fun `caches false result for missing user`() {
+            val cache = cacheManager.getCache(CacheConfig.USER_IS_ADMIN)!!
+
+            accessService.findIsAdminByExternalUserId(MISSING_USER_ID)
+
+            assertEquals(false, cache.get(MISSING_USER_ID)?.get())
+        }
+
+        @Test
+        @DisplayName("findIsAdminByExternalUserId(): returns stale value from cache after DB change until eviction")
+        fun `returns stale value from cache after db change`() {
+            assertTrue(accessService.findIsAdminByExternalUserId(ADMIN_USER_ID))
+
+            val entity = telegramUserRepository.findByExternalUserId(ADMIN_USER_ID)!!
+            entity.isAdmin = false
+            telegramUserRepository.saveAndFlush(entity)
+
+            assertTrue(
+                accessService.findIsAdminByExternalUserId(ADMIN_USER_ID),
+                "Expected stale cached value (true) before manual cache eviction",
+            )
+
+            cacheManager.getCache(CacheConfig.USER_IS_ADMIN)?.clear()
+
+            assertFalse(accessService.findIsAdminByExternalUserId(ADMIN_USER_ID))
+        }
+
+        companion object {
+            private const val ADMIN_USER_ID = 1L
+            private const val NON_ADMIN_USER_ID = 2L
+            private const val MISSING_USER_ID = 0L
+        }
     }
-
-    @Test
-    @DisplayName("findIsAdminByExternalUserId(): admin user - returns true")
-    fun `returns true for admin`() {
-        assertTrue(accessService.findIsAdminByExternalUserId(ADMIN_USER_ID))
-    }
-
-    @Test
-    @DisplayName("findIsAdminByExternalUserId(): non-admin user - returns false")
-    fun `returns false for non-admin`() {
-        assertFalse(accessService.findIsAdminByExternalUserId(NON_ADMIN_USER_ID))
-    }
-
-    @Test
-    @DisplayName("findIsAdminByExternalUserId(): missing user - returns false")
-    fun `returns false for missing user`() {
-        assertFalse(accessService.findIsAdminByExternalUserId(MISSING_USER_ID))
-    }
-
-    @Test
-    @DisplayName("findIsAdminByExternalUserId(): caches result after first call")
-    fun `caches true result after first call`() {
-        val cache = cacheManager.getCache(CacheConfig.USER_IS_ADMIN)
-        assertNotNull(cache)
-        assertNull(cache!!.get(ADMIN_USER_ID))
-
-        accessService.findIsAdminByExternalUserId(ADMIN_USER_ID)
-
-        assertEquals(true, cache.get(ADMIN_USER_ID)?.get())
-    }
-
-    @Test
-    @DisplayName("findIsAdminByExternalUserId(): caches false for missing user")
-    fun `caches false result for missing user`() {
-        val cache = cacheManager.getCache(CacheConfig.USER_IS_ADMIN)!!
-
-        accessService.findIsAdminByExternalUserId(MISSING_USER_ID)
-
-        assertEquals(false, cache.get(MISSING_USER_ID)?.get())
-    }
-
-    @Test
-    @DisplayName("findIsAdminByExternalUserId(): returns stale value from cache after DB change until eviction")
-    fun `returns stale value from cache after db change`() {
-        assertTrue(accessService.findIsAdminByExternalUserId(ADMIN_USER_ID))
-
-        val entity = telegramUserRepository.findByExternalUserId(ADMIN_USER_ID)!!
-        entity.isAdmin = false
-        telegramUserRepository.saveAndFlush(entity)
-
-        assertTrue(
-            accessService.findIsAdminByExternalUserId(ADMIN_USER_ID),
-            "Expected stale cached value (true) before manual cache eviction"
-        )
-
-        cacheManager.getCache(CacheConfig.USER_IS_ADMIN)?.clear()
-
-        assertFalse(accessService.findIsAdminByExternalUserId(ADMIN_USER_ID))
-    }
-}

--- a/src/test/kotlin/ru/illine/drinking/ponies/dao/access/WaterStatisticAccessServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/dao/access/WaterStatisticAccessServiceTest.kt
@@ -1,6 +1,10 @@
 package ru.illine.drinking.ponies.dao.access
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -19,336 +23,358 @@ import java.time.LocalDateTime
 @Sql(
     scripts = ["classpath:sql/access/WaterStatisticAccessService.sql"],
     config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
-    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
 )
 @Sql(
     scripts = ["classpath:sql/clear.sql"],
     config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
-    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
 )
-class WaterStatisticAccessServiceTest @Autowired constructor(
-    private val accessService: WaterStatisticAccessService,
-) {
+class WaterStatisticAccessServiceTest
+    @Autowired
+    constructor(
+        private val accessService: WaterStatisticAccessService,
+    ) {
+        @Test
+        @DisplayName("save(): returns a saved record with id")
+        fun `successful save`() {
+            val expectedWaterAmount = WaterAmountType.ML_150.amountMl
+            val dto =
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    waterAmountMl = expectedWaterAmount,
+                )
 
-    private val DEFAULT_EXTERNAL_USER_ID = 1L
-    private val SECOND_EXTERNAL_USER_ID = 2L
-    private val NOT_EXISTED_USER_ID = 0L
+            val actual = assertDoesNotThrow(ThrowingSupplier { accessService.save(dto) })
 
-    @Test
-    @DisplayName("save(): returns a saved record with id")
-    fun `successful save`() {
-        val expectedWaterAmount = WaterAmountType.ML_150.amountMl
-        val dto = DtoGenerator.generateWaterStatisticDto(
-            externalUserId = DEFAULT_EXTERNAL_USER_ID,
-            waterAmountMl = expectedWaterAmount
-        )
+            assertNotNull(actual.id)
+            assertNotNull(actual.eventTime)
+            assertEquals(DEFAULT_EXTERNAL_USER_ID, actual.telegramUser.externalUserId)
+            assertEquals(AnswerNotificationType.YES, actual.eventType)
+            assertEquals(expectedWaterAmount, actual.waterAmountMl)
+        }
 
-        val actual = assertDoesNotThrow(ThrowingSupplier { accessService.save(dto) })
+        @Test
+        @DisplayName("save(): throws IllegalArgumentException when user not found")
+        fun `failure save user not found`() {
+            val dto = DtoGenerator.generateWaterStatisticDto(externalUserId = NOT_EXISTED_USER_ID)
 
-        assertNotNull(actual.id)
-        assertNotNull(actual.eventTime)
-        assertEquals(DEFAULT_EXTERNAL_USER_ID, actual.telegramUser.externalUserId)
-        assertEquals(AnswerNotificationType.YES, actual.eventType)
-        assertEquals(expectedWaterAmount, actual.waterAmountMl)
-    }
+            assertThrows<IllegalArgumentException> { accessService.save(dto) }
+        }
 
-    @Test
-    @DisplayName("save(): throws IllegalArgumentException when user not found")
-    fun `failure save user not found`() {
-        val dto = DtoGenerator.generateWaterStatisticDto(externalUserId = NOT_EXISTED_USER_ID)
+        @Test
+        @DisplayName("saveAll(): returns a list of saved records with correct data")
+        fun `successful saveAll`() {
+            val statistics =
+                listOf(
+                    DtoGenerator.generateWaterStatisticDto(
+                        externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                        eventType = AnswerNotificationType.YES,
+                        waterAmountMl = 250,
+                    ),
+                    DtoGenerator.generateWaterStatisticDto(
+                        externalUserId = SECOND_EXTERNAL_USER_ID,
+                        eventType = AnswerNotificationType.CANCEL,
+                        waterAmountMl = 0,
+                    ),
+                )
 
-        assertThrows<IllegalArgumentException> { accessService.save(dto) }
-    }
+            val actual = assertDoesNotThrow(ThrowingSupplier { accessService.saveAll(statistics) })
 
-    @Test
-    @DisplayName("saveAll(): returns a list of saved records with correct data")
-    fun `successful saveAll`() {
-        val statistics = listOf(
-            DtoGenerator.generateWaterStatisticDto(externalUserId = DEFAULT_EXTERNAL_USER_ID, eventType = AnswerNotificationType.YES, waterAmountMl = 250),
-            DtoGenerator.generateWaterStatisticDto(externalUserId = SECOND_EXTERNAL_USER_ID, eventType = AnswerNotificationType.CANCEL, waterAmountMl = 0)
-        )
+            assertEquals(2, actual.size)
 
-        val actual = assertDoesNotThrow(ThrowingSupplier { accessService.saveAll(statistics) })
+            val sorted = actual.sortedBy { it.telegramUser.externalUserId }
 
-        assertEquals(2, actual.size)
+            assertEquals(DEFAULT_EXTERNAL_USER_ID, sorted[0].telegramUser.externalUserId)
+            assertEquals(AnswerNotificationType.YES, sorted[0].eventType)
+            assertEquals(250, sorted[0].waterAmountMl)
+            assertEquals(SECOND_EXTERNAL_USER_ID, sorted[1].telegramUser.externalUserId)
+            assertEquals(AnswerNotificationType.CANCEL, sorted[1].eventType)
+            assertEquals(0, sorted[1].waterAmountMl)
+        }
 
-        val sorted = actual.sortedBy { it.telegramUser.externalUserId }
-        
-        assertEquals(DEFAULT_EXTERNAL_USER_ID, sorted[0].telegramUser.externalUserId)
-        assertEquals(AnswerNotificationType.YES, sorted[0].eventType)
-        assertEquals(250, sorted[0].waterAmountMl)
-        assertEquals(SECOND_EXTERNAL_USER_ID, sorted[1].telegramUser.externalUserId)
-        assertEquals(AnswerNotificationType.CANCEL, sorted[1].eventType)
-        assertEquals(0, sorted[1].waterAmountMl)
-    }
+        @Test
+        @DisplayName("saveAll(): returns empty list for empty input")
+        fun `successful saveAll empty`() {
+            val actual = assertDoesNotThrow(ThrowingSupplier<List<*>> { accessService.saveAll(emptyList()) })
 
-    @Test
-    @DisplayName("saveAll(): returns empty list for empty input")
-    fun `successful saveAll empty`() {
-        val actual = assertDoesNotThrow(ThrowingSupplier<List<*>> { accessService.saveAll(emptyList()) })
+            assertTrue(actual.isEmpty())
+        }
 
-        assertTrue(actual.isEmpty())
-    }
+        @Test
+        @DisplayName("saveAll(): skips unknown users and returns empty list")
+        fun `successful saveAll skips unknown users`() {
+            val statistics = listOf(DtoGenerator.generateWaterStatisticDto(externalUserId = NOT_EXISTED_USER_ID))
 
-    @Test
-    @DisplayName("saveAll(): skips unknown users and returns empty list")
-    fun `successful saveAll skips unknown users`() {
-        val statistics = listOf(DtoGenerator.generateWaterStatisticDto(externalUserId = NOT_EXISTED_USER_ID))
+            val actual = assertDoesNotThrow(ThrowingSupplier<List<*>> { accessService.saveAll(statistics) })
 
-        val actual = assertDoesNotThrow(ThrowingSupplier<List<*>> { accessService.saveAll(statistics) })
+            assertTrue(actual.isEmpty())
+        }
 
-        assertTrue(actual.isEmpty())
-    }
+        @Test
+        @DisplayName("saveAll(): saves only known users and skips unknown")
+        fun `successful saveAll partial`() {
+            val statistics =
+                listOf(
+                    DtoGenerator.generateWaterStatisticDto(externalUserId = DEFAULT_EXTERNAL_USER_ID),
+                    DtoGenerator.generateWaterStatisticDto(externalUserId = NOT_EXISTED_USER_ID),
+                )
 
-    @Test
-    @DisplayName("saveAll(): saves only known users and skips unknown")
-    fun `successful saveAll partial`() {
-        val statistics = listOf(
-            DtoGenerator.generateWaterStatisticDto(externalUserId = DEFAULT_EXTERNAL_USER_ID),
-            DtoGenerator.generateWaterStatisticDto(externalUserId = NOT_EXISTED_USER_ID)
-        )
+            val actual = assertDoesNotThrow(ThrowingSupplier { accessService.saveAll(statistics) })
 
-        val actual = assertDoesNotThrow(ThrowingSupplier { accessService.saveAll(statistics) })
+            assertEquals(1, actual.size)
+            assertEquals(DEFAULT_EXTERNAL_USER_ID, actual[0].telegramUser.externalUserId)
+        }
 
-        assertEquals(1, actual.size)
-        assertEquals(DEFAULT_EXTERNAL_USER_ID, actual[0].telegramUser.externalUserId)
-    }
-
-    @Test
-    @DisplayName("findByUserAndEventTimeBetween(): returns records inside the half-open range")
-    fun `successful findByUserAndEventTimeBetween returns records inside range`() {
-        val baseTime = LocalDateTime.of(2025, 6, 15, 10, 0)
-        accessService.save(
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = DEFAULT_EXTERNAL_USER_ID,
-                eventTime = baseTime,
-                waterAmountMl = WaterAmountType.ML_150.amountMl
+        @Test
+        @DisplayName("findByUserAndEventTimeBetween(): returns records inside the half-open range")
+        fun `successful findByUserAndEventTimeBetween returns records inside range`() {
+            val baseTime = LocalDateTime.of(2025, 6, 15, 10, 0)
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    eventTime = baseTime,
+                    waterAmountMl = WaterAmountType.ML_150.amountMl,
+                ),
             )
-        )
-        accessService.save(
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = DEFAULT_EXTERNAL_USER_ID,
-                eventTime = baseTime.plusHours(2),
-                waterAmountMl = WaterAmountType.ML_250.amountMl
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    eventTime = baseTime.plusHours(2),
+                    waterAmountMl = WaterAmountType.ML_250.amountMl,
+                ),
             )
-        )
 
-        val actual = assertDoesNotThrow(
-            ThrowingSupplier {
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.findByUserAndEventTimeBetween(
+                            DEFAULT_EXTERNAL_USER_ID,
+                            baseTime,
+                            baseTime.plusHours(3),
+                        )
+                    },
+                )
+
+            assertEquals(2, actual.size)
+            assertEquals(WaterAmountType.ML_150.amountMl, actual[0].waterAmountMl)
+            assertEquals(WaterAmountType.ML_250.amountMl, actual[1].waterAmountMl)
+            assertEquals(DEFAULT_EXTERNAL_USER_ID, actual[0].telegramUser.externalUserId)
+        }
+
+        @Test
+        @DisplayName("findByUserAndEventTimeBetween(): excludes records on endExclusive boundary")
+        fun `successful findByUserAndEventTimeBetween excludes endExclusive`() {
+            val start = LocalDateTime.of(2025, 6, 15, 10, 0)
+            val end = LocalDateTime.of(2025, 6, 15, 12, 0)
+            // exactly at endExclusive - must be excluded
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    eventTime = end,
+                ),
+            )
+            // before endExclusive - must be included
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    eventTime = end.minusSeconds(1),
+                ),
+            )
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.findByUserAndEventTimeBetween(DEFAULT_EXTERNAL_USER_ID, start, end)
+                    },
+                )
+
+            assertEquals(1, actual.size)
+            assertEquals(end.minusSeconds(1), actual[0].eventTime)
+        }
+
+        @Test
+        @DisplayName("findByUserAndEventTimeBetween(): returns empty list when no records match")
+        fun `successful findByUserAndEventTimeBetween returns empty when out of range`() {
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    eventTime = LocalDateTime.of(2025, 6, 15, 10, 0),
+                ),
+            )
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.findByUserAndEventTimeBetween(
+                            DEFAULT_EXTERNAL_USER_ID,
+                            LocalDateTime.of(2025, 7, 1, 0, 0),
+                            LocalDateTime.of(2025, 7, 2, 0, 0),
+                        )
+                    },
+                )
+
+            assertTrue(actual.isEmpty())
+        }
+
+        @Test
+        @DisplayName("findByUserAndEventTimeBetween(): returns only records of the requested user")
+        fun `successful findByUserAndEventTimeBetween filters by user`() {
+            val time = LocalDateTime.of(2025, 6, 15, 10, 0)
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    eventTime = time,
+                ),
+            )
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = SECOND_EXTERNAL_USER_ID,
+                    eventTime = time,
+                ),
+            )
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.findByUserAndEventTimeBetween(
+                            DEFAULT_EXTERNAL_USER_ID,
+                            time.minusMinutes(1),
+                            time.plusMinutes(1),
+                        )
+                    },
+                )
+
+            assertEquals(1, actual.size)
+            assertEquals(DEFAULT_EXTERNAL_USER_ID, actual[0].telegramUser.externalUserId)
+        }
+
+        @Test
+        @DisplayName("findByUserAndEventTimeBetween(): returns empty list for unknown user")
+        fun `successful findByUserAndEventTimeBetween unknown user`() {
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.findByUserAndEventTimeBetween(
+                            NOT_EXISTED_USER_ID,
+                            LocalDateTime.of(2025, 6, 15, 0, 0),
+                            LocalDateTime.of(2025, 6, 16, 0, 0),
+                        )
+                    },
+                )
+
+            assertTrue(actual.isEmpty())
+        }
+
+        @Test
+        @DisplayName("findByUserAndEventTimeBetween(): returns records ordered by eventTime asc")
+        fun `successful findByUserAndEventTimeBetween orders ascending`() {
+            val baseTime = LocalDateTime.of(2025, 6, 15, 10, 0)
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    eventTime = baseTime.plusHours(2),
+                    waterAmountMl = WaterAmountType.ML_450.amountMl,
+                ),
+            )
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    eventTime = baseTime,
+                    waterAmountMl = WaterAmountType.ML_150.amountMl,
+                ),
+            )
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    eventTime = baseTime.plusHours(1),
+                    waterAmountMl = WaterAmountType.ML_250.amountMl,
+                ),
+            )
+
+            val actual =
                 accessService.findByUserAndEventTimeBetween(
                     DEFAULT_EXTERNAL_USER_ID,
                     baseTime,
-                    baseTime.plusHours(3)
+                    baseTime.plusHours(3),
                 )
-            }
-        )
 
-        assertEquals(2, actual.size)
-        assertEquals(WaterAmountType.ML_150.amountMl, actual[0].waterAmountMl)
-        assertEquals(WaterAmountType.ML_250.amountMl, actual[1].waterAmountMl)
-        assertEquals(DEFAULT_EXTERNAL_USER_ID, actual[0].telegramUser.externalUserId)
+            assertEquals(3, actual.size)
+            assertEquals(baseTime, actual[0].eventTime)
+            assertEquals(baseTime.plusHours(1), actual[1].eventTime)
+            assertEquals(baseTime.plusHours(2), actual[2].eventTime)
+        }
+
+        @Test
+        @DisplayName("findEarliestEventTimeByUser(): returns the minimum eventTime for the user")
+        fun `findEarliestEventTimeByUser returns min`() {
+            val earliest = LocalDateTime.of(2025, 1, 5, 9, 30)
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    eventTime = LocalDateTime.of(2025, 6, 15, 10, 0),
+                ),
+            )
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    eventTime = earliest,
+                ),
+            )
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    eventTime = LocalDateTime.of(2025, 3, 10, 8, 0),
+                ),
+            )
+
+            val actual = accessService.findEarliestEventTimeByUser(DEFAULT_EXTERNAL_USER_ID)
+
+            assertEquals(earliest, actual)
+        }
+
+        @Test
+        @DisplayName("findEarliestEventTimeByUser(): returns null when user has no records")
+        fun `findEarliestEventTimeByUser returns null when no records`() {
+            val actual = accessService.findEarliestEventTimeByUser(DEFAULT_EXTERNAL_USER_ID)
+
+            assertNull(actual)
+        }
+
+        @Test
+        @DisplayName("findEarliestEventTimeByUser(): isolates by user (does not pick events of another user)")
+        fun `findEarliestEventTimeByUser isolates per user`() {
+            val mine = LocalDateTime.of(2025, 6, 15, 10, 0)
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    eventTime = mine,
+                ),
+            )
+            // Earlier event for a different user must NOT be returned for DEFAULT user.
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = SECOND_EXTERNAL_USER_ID,
+                    eventTime = LocalDateTime.of(2024, 1, 1, 0, 0),
+                ),
+            )
+
+            val actual = accessService.findEarliestEventTimeByUser(DEFAULT_EXTERNAL_USER_ID)
+
+            assertEquals(mine, actual)
+        }
+
+        @Test
+        @DisplayName("findEarliestEventTimeByUser(): unknown user -> null")
+        fun `findEarliestEventTimeByUser unknown user`() {
+            val actual = accessService.findEarliestEventTimeByUser(NOT_EXISTED_USER_ID)
+
+            assertNull(actual)
+        }
+
+        companion object {
+            private const val DEFAULT_EXTERNAL_USER_ID = 1L
+            private const val SECOND_EXTERNAL_USER_ID = 2L
+            private const val NOT_EXISTED_USER_ID = 0L
+        }
     }
-
-    @Test
-    @DisplayName("findByUserAndEventTimeBetween(): excludes records on endExclusive boundary")
-    fun `successful findByUserAndEventTimeBetween excludes endExclusive`() {
-        val start = LocalDateTime.of(2025, 6, 15, 10, 0)
-        val end = LocalDateTime.of(2025, 6, 15, 12, 0)
-        // exactly at endExclusive - must be excluded
-        accessService.save(
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = DEFAULT_EXTERNAL_USER_ID,
-                eventTime = end
-            )
-        )
-        // before endExclusive - must be included
-        accessService.save(
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = DEFAULT_EXTERNAL_USER_ID,
-                eventTime = end.minusSeconds(1)
-            )
-        )
-
-        val actual = assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.findByUserAndEventTimeBetween(DEFAULT_EXTERNAL_USER_ID, start, end)
-            }
-        )
-
-        assertEquals(1, actual.size)
-        assertEquals(end.minusSeconds(1), actual[0].eventTime)
-    }
-
-    @Test
-    @DisplayName("findByUserAndEventTimeBetween(): returns empty list when no records match")
-    fun `successful findByUserAndEventTimeBetween returns empty when out of range`() {
-        accessService.save(
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = DEFAULT_EXTERNAL_USER_ID,
-                eventTime = LocalDateTime.of(2025, 6, 15, 10, 0)
-            )
-        )
-
-        val actual = assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.findByUserAndEventTimeBetween(
-                    DEFAULT_EXTERNAL_USER_ID,
-                    LocalDateTime.of(2025, 7, 1, 0, 0),
-                    LocalDateTime.of(2025, 7, 2, 0, 0)
-                )
-            }
-        )
-
-        assertTrue(actual.isEmpty())
-    }
-
-    @Test
-    @DisplayName("findByUserAndEventTimeBetween(): returns only records of the requested user")
-    fun `successful findByUserAndEventTimeBetween filters by user`() {
-        val time = LocalDateTime.of(2025, 6, 15, 10, 0)
-        accessService.save(
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = DEFAULT_EXTERNAL_USER_ID,
-                eventTime = time
-            )
-        )
-        accessService.save(
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = SECOND_EXTERNAL_USER_ID,
-                eventTime = time
-            )
-        )
-
-        val actual = assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.findByUserAndEventTimeBetween(
-                    DEFAULT_EXTERNAL_USER_ID,
-                    time.minusMinutes(1),
-                    time.plusMinutes(1)
-                )
-            }
-        )
-
-        assertEquals(1, actual.size)
-        assertEquals(DEFAULT_EXTERNAL_USER_ID, actual[0].telegramUser.externalUserId)
-    }
-
-    @Test
-    @DisplayName("findByUserAndEventTimeBetween(): returns empty list for unknown user")
-    fun `successful findByUserAndEventTimeBetween unknown user`() {
-        val actual = assertDoesNotThrow(
-            ThrowingSupplier {
-                accessService.findByUserAndEventTimeBetween(
-                    NOT_EXISTED_USER_ID,
-                    LocalDateTime.of(2025, 6, 15, 0, 0),
-                    LocalDateTime.of(2025, 6, 16, 0, 0)
-                )
-            }
-        )
-
-        assertTrue(actual.isEmpty())
-    }
-
-    @Test
-    @DisplayName("findByUserAndEventTimeBetween(): returns records ordered by eventTime asc")
-    fun `successful findByUserAndEventTimeBetween orders ascending`() {
-        val baseTime = LocalDateTime.of(2025, 6, 15, 10, 0)
-        accessService.save(
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = DEFAULT_EXTERNAL_USER_ID,
-                eventTime = baseTime.plusHours(2),
-                waterAmountMl = WaterAmountType.ML_450.amountMl
-            )
-        )
-        accessService.save(
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = DEFAULT_EXTERNAL_USER_ID,
-                eventTime = baseTime,
-                waterAmountMl = WaterAmountType.ML_150.amountMl
-            )
-        )
-        accessService.save(
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = DEFAULT_EXTERNAL_USER_ID,
-                eventTime = baseTime.plusHours(1),
-                waterAmountMl = WaterAmountType.ML_250.amountMl
-            )
-        )
-
-        val actual = accessService.findByUserAndEventTimeBetween(
-            DEFAULT_EXTERNAL_USER_ID, baseTime, baseTime.plusHours(3)
-        )
-
-        assertEquals(3, actual.size)
-        assertEquals(baseTime, actual[0].eventTime)
-        assertEquals(baseTime.plusHours(1), actual[1].eventTime)
-        assertEquals(baseTime.plusHours(2), actual[2].eventTime)
-    }
-
-    @Test
-    @DisplayName("findEarliestEventTimeByUser(): returns the minimum eventTime for the user")
-    fun `findEarliestEventTimeByUser returns min`() {
-        val earliest = LocalDateTime.of(2025, 1, 5, 9, 30)
-        accessService.save(
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = DEFAULT_EXTERNAL_USER_ID,
-                eventTime = LocalDateTime.of(2025, 6, 15, 10, 0)
-            )
-        )
-        accessService.save(
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = DEFAULT_EXTERNAL_USER_ID,
-                eventTime = earliest
-            )
-        )
-        accessService.save(
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = DEFAULT_EXTERNAL_USER_ID,
-                eventTime = LocalDateTime.of(2025, 3, 10, 8, 0)
-            )
-        )
-
-        val actual = accessService.findEarliestEventTimeByUser(DEFAULT_EXTERNAL_USER_ID)
-
-        assertEquals(earliest, actual)
-    }
-
-    @Test
-    @DisplayName("findEarliestEventTimeByUser(): returns null when user has no records")
-    fun `findEarliestEventTimeByUser returns null when no records`() {
-        val actual = accessService.findEarliestEventTimeByUser(DEFAULT_EXTERNAL_USER_ID)
-
-        assertNull(actual)
-    }
-
-    @Test
-    @DisplayName("findEarliestEventTimeByUser(): isolates by user (does not pick events of another user)")
-    fun `findEarliestEventTimeByUser isolates per user`() {
-        val mine = LocalDateTime.of(2025, 6, 15, 10, 0)
-        accessService.save(
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = DEFAULT_EXTERNAL_USER_ID,
-                eventTime = mine
-            )
-        )
-        // Earlier event for a different user must NOT be returned for DEFAULT user.
-        accessService.save(
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = SECOND_EXTERNAL_USER_ID,
-                eventTime = LocalDateTime.of(2024, 1, 1, 0, 0)
-            )
-        )
-
-        val actual = accessService.findEarliestEventTimeByUser(DEFAULT_EXTERNAL_USER_ID)
-
-        assertEquals(mine, actual)
-    }
-
-    @Test
-    @DisplayName("findEarliestEventTimeByUser(): unknown user -> null")
-    fun `findEarliestEventTimeByUser unknown user`() {
-        val actual = accessService.findEarliestEventTimeByUser(NOT_EXISTED_USER_ID)
-
-        assertNull(actual)
-    }
-}

--- a/src/test/kotlin/ru/illine/drinking/ponies/mapper/StatisticsMapperTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/mapper/StatisticsMapperTest.kt
@@ -1,6 +1,9 @@
 package ru.illine.drinking.ponies.mapper
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import ru.illine.drinking.ponies.model.dto.BestDayDto
@@ -16,22 +19,23 @@ import kotlin.reflect.full.memberProperties
 @UnitTest
 @DisplayName("StatisticsMapper Unit Test")
 class StatisticsMapperTest {
-
     @Test
     @DisplayName("toResponse(): maps every field from StatisticsDto to StatisticsResponse")
     fun `toResponse maps every field`() {
-        val dto = StatisticsDto(
-            points = listOf(
-                StatisticsPointDto("2026-05-04", 1800),
-                StatisticsPointDto("2026-05-05", 2100),
-            ),
-            dailyGoalMl = 2000,
-            averageMlPerDay = 1950,
-            bestDay = BestDayDto(LocalDate.of(2026, 5, 5), 2100, DayOfWeek.TUESDAY),
-            currentStreakDays = 3,
-            insightText = "Котик, ты пьёшь водицу 3 дней подряд - так держать!",
-            firstEntryAt = Instant.parse("2026-04-15T10:30:00Z"),
-        )
+        val dto =
+            StatisticsDto(
+                points =
+                    listOf(
+                        StatisticsPointDto("2026-05-04", 1800),
+                        StatisticsPointDto("2026-05-05", 2100),
+                    ),
+                dailyGoalMl = 2000,
+                averageMlPerDay = 1950,
+                bestDay = BestDayDto(LocalDate.of(2026, 5, 5), 2100, DayOfWeek.TUESDAY),
+                currentStreakDays = 3,
+                insightText = "Котик, ты пьёшь водицу 3 дней подряд - так держать!",
+                firstEntryAt = Instant.parse("2026-04-15T10:30:00Z"),
+            )
 
         val response = StatisticsMapper.toResponse(dto)
 
@@ -55,15 +59,16 @@ class StatisticsMapperTest {
     @Test
     @DisplayName("toResponse(): null firstEntryAt maps through as null")
     fun `toResponse preserves null firstEntryAt`() {
-        val dto = StatisticsDto(
-            points = emptyList(),
-            dailyGoalMl = 2000,
-            averageMlPerDay = 0,
-            bestDay = null,
-            currentStreakDays = 0,
-            insightText = "Здесь пока пусто, котик. Сделай первый глоток.",
-            firstEntryAt = null,
-        )
+        val dto =
+            StatisticsDto(
+                points = emptyList(),
+                dailyGoalMl = 2000,
+                averageMlPerDay = 0,
+                bestDay = null,
+                currentStreakDays = 0,
+                insightText = "Здесь пока пусто, котик. Сделай первый глоток.",
+                firstEntryAt = null,
+            )
 
         val response = StatisticsMapper.toResponse(dto)
 
@@ -88,15 +93,16 @@ class StatisticsMapperTest {
     @Test
     @DisplayName("toResponse(): null bestDay maps through as null")
     fun `toResponse preserves null bestDay`() {
-        val dto = StatisticsDto(
-            points = emptyList(),
-            dailyGoalMl = 2000,
-            averageMlPerDay = 0,
-            bestDay = null,
-            currentStreakDays = 0,
-            insightText = "Здесь пока пусто, котик. Сделай первый глоток.",
-            firstEntryAt = null,
-        )
+        val dto =
+            StatisticsDto(
+                points = emptyList(),
+                dailyGoalMl = 2000,
+                averageMlPerDay = 0,
+                bestDay = null,
+                currentStreakDays = 0,
+                insightText = "Здесь пока пусто, котик. Сделай первый глоток.",
+                firstEntryAt = null,
+            )
 
         val response = StatisticsMapper.toResponse(dto)
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/mapper/StatisticsMapperTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/mapper/StatisticsMapperTest.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.builder
+package ru.illine.drinking.ponies.mapper
 
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
@@ -14,8 +14,8 @@ import java.time.LocalDate
 import kotlin.reflect.full.memberProperties
 
 @UnitTest
-@DisplayName("StatisticsBuilder Unit Test")
-class StatisticsBuilderTest {
+@DisplayName("StatisticsMapper Unit Test")
+class StatisticsMapperTest {
 
     @Test
     @DisplayName("toResponse(): maps every field from StatisticsDto to StatisticsResponse")
@@ -33,7 +33,7 @@ class StatisticsBuilderTest {
             firstEntryAt = Instant.parse("2026-04-15T10:30:00Z"),
         )
 
-        val response = StatisticsBuilder.toResponse(dto)
+        val response = StatisticsMapper.toResponse(dto)
 
         assertEquals(2, response.points.size)
         assertEquals("2026-05-04", response.points[0].label)
@@ -65,7 +65,7 @@ class StatisticsBuilderTest {
             firstEntryAt = null,
         )
 
-        val response = StatisticsBuilder.toResponse(dto)
+        val response = StatisticsMapper.toResponse(dto)
 
         assertNull(response.firstEntryAt)
     }
@@ -98,7 +98,7 @@ class StatisticsBuilderTest {
             firstEntryAt = null,
         )
 
-        val response = StatisticsBuilder.toResponse(dto)
+        val response = StatisticsMapper.toResponse(dto)
 
         assertNull(response.bestDay)
         assertEquals(0, response.points.size)

--- a/src/test/kotlin/ru/illine/drinking/ponies/model/base/AnswerNotificationTypeTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/model/base/AnswerNotificationTypeTest.kt
@@ -3,8 +3,9 @@ package ru.illine.drinking.ponies.model.base
 import org.junit.jupiter.api.DisplayName
 
 @DisplayName("AnswerNotificationType Unit Test")
-class AnswerNotificationTypeTest : EnumTypeOfTest<AnswerNotificationType>(
-    AnswerNotificationType.entries,
-    AnswerNotificationType::typeOf,
-    AnswerNotificationType::queryData
-)
+class AnswerNotificationTypeTest :
+    EnumTypeOfTest<AnswerNotificationType>(
+        AnswerNotificationType.entries,
+        AnswerNotificationType::typeOf,
+        AnswerNotificationType::queryData,
+    )

--- a/src/test/kotlin/ru/illine/drinking/ponies/model/base/EnumTypeOfTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/model/base/EnumTypeOfTest.kt
@@ -4,15 +4,14 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import ru.illine.drinking.ponies.test.tag.UnitTest
-import java.util.*
+import java.util.UUID
 
 @UnitTest
 abstract class EnumTypeOfTest<T>(
     private val entries: List<T>,
     private val typeOf: (String) -> T?,
-    private val queryData: (T) -> UUID
+    private val queryData: (T) -> UUID,
 ) {
-
     @Test
     fun `typeOf returns entry for known queryData`() {
         entries.forEach { entry ->

--- a/src/test/kotlin/ru/illine/drinking/ponies/model/base/SnoozeNotificationTypeTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/model/base/SnoozeNotificationTypeTest.kt
@@ -3,8 +3,9 @@ package ru.illine.drinking.ponies.model.base
 import org.junit.jupiter.api.DisplayName
 
 @DisplayName("SnoozeNotificationType Unit Test")
-class SnoozeNotificationTypeTest : EnumTypeOfTest<SnoozeNotificationType>(
-    SnoozeNotificationType.entries,
-    SnoozeNotificationType::typeOf,
-    SnoozeNotificationType::queryData
-)
+class SnoozeNotificationTypeTest :
+    EnumTypeOfTest<SnoozeNotificationType>(
+        SnoozeNotificationType.entries,
+        SnoozeNotificationType::typeOf,
+        SnoozeNotificationType::queryData,
+    )

--- a/src/test/kotlin/ru/illine/drinking/ponies/model/base/TelegramCommandTypeTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/model/base/TelegramCommandTypeTest.kt
@@ -10,7 +10,6 @@ import ru.illine.drinking.ponies.test.tag.UnitTest
 @UnitTest
 @DisplayName("TelegramCommandType Unit Test")
 class TelegramCommandTypeTest {
-
     @Test
     @DisplayName("toString(): returns command value for each entry")
     fun `toString returns command`() {

--- a/src/test/kotlin/ru/illine/drinking/ponies/model/base/WaterAmountTypeTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/model/base/WaterAmountTypeTest.kt
@@ -3,8 +3,9 @@ package ru.illine.drinking.ponies.model.base
 import org.junit.jupiter.api.DisplayName
 
 @DisplayName("WaterAmountType Unit Test")
-class WaterAmountTypeTest : EnumTypeOfTest<WaterAmountType>(
-    WaterAmountType.entries,
-    WaterAmountType::typeOf,
-    WaterAmountType::queryData
-)
+class WaterAmountTypeTest :
+    EnumTypeOfTest<WaterAmountType>(
+        WaterAmountType.entries,
+        WaterAmountType::typeOf,
+        WaterAmountType::queryData,
+    )

--- a/src/test/kotlin/ru/illine/drinking/ponies/scheduler/NotificationSchedulerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/scheduler/NotificationSchedulerTest.kt
@@ -3,7 +3,12 @@ package ru.illine.drinking.ponies.scheduler
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import ru.illine.drinking.ponies.service.notification.NotificationSenderService
 import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.notification.NotificationTimeService
@@ -21,88 +26,88 @@ class NotificationSchedulerTest {
 
     @BeforeEach
     fun setUp() {
-        notificationSettingsService = mock(NotificationSettingsService::class.java)
-        notificationSenderService = mock(NotificationSenderService::class.java)
-        notificationTimeService = mock(NotificationTimeService::class.java)
+        notificationSettingsService = mock<NotificationSettingsService>()
+        notificationSenderService = mock<NotificationSenderService>()
+        notificationTimeService = mock<NotificationTimeService>()
         scheduler = NotificationScheduler(notificationSettingsService, notificationSenderService, notificationTimeService)
     }
 
     @Test
     @DisplayName("sendDrinkingReminders(): no interactions when no notifications exist")
     fun `sendDrinkingReminders does nothing when no notifications`() {
-        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(emptySet())
+        whenever(notificationSettingsService.getAllNotificationSettings()).thenReturn(emptySet())
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationSenderService, never()).sendNotifications(anyCollection())
-        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(any())
+        verify(notificationSenderService, never()).suspendNotifications(any())
     }
 
     @Test
     @DisplayName("sendDrinkingReminders(): skips disabled notifications")
     fun `sendDrinkingReminders filters out disabled notifications`() {
         val disabled = DtoGenerator.generateNotificationDto().copy(enabled = false)
-        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(disabled))
+        whenever(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(disabled))
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationSenderService, never()).sendNotifications(anyCollection())
-        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(any())
+        verify(notificationSenderService, never()).suspendNotifications(any())
     }
 
     @Test
     @DisplayName("sendDrinkingReminders(): skips notifications inside quiet time")
     fun `sendDrinkingReminders filters out quiet time notifications`() {
         val dto = DtoGenerator.generateNotificationDto()
-        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
-        doReturn(false).`when`(notificationTimeService).isOutsideQuietTime(dto)
+        whenever(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
+        doReturn(false).whenever(notificationTimeService).isOutsideQuietTime(dto)
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationSenderService, never()).sendNotifications(anyCollection())
-        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(any())
+        verify(notificationSenderService, never()).suspendNotifications(any())
     }
 
     @Test
     @DisplayName("sendDrinkingReminders(): skips notifications not yet due")
     fun `sendDrinkingReminders filters out not due notifications`() {
         val dto = DtoGenerator.generateNotificationDto()
-        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
-        doReturn(true).`when`(notificationTimeService).isOutsideQuietTime(dto)
-        doReturn(false).`when`(notificationTimeService).isNotificationDue(dto)
+        whenever(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
+        doReturn(true).whenever(notificationTimeService).isOutsideQuietTime(dto)
+        doReturn(false).whenever(notificationTimeService).isNotificationDue(dto)
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationSenderService, never()).sendNotifications(anyCollection())
-        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(any())
+        verify(notificationSenderService, never()).suspendNotifications(any())
     }
 
     @Test
     @DisplayName("sendDrinkingReminders(): sends active notification (attempts < 3)")
     fun `sendDrinkingReminders sends active notification`() {
         val dto = DtoGenerator.generateNotificationDto(notificationAttempts = 0)
-        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
-        doReturn(true).`when`(notificationTimeService).isOutsideQuietTime(dto)
-        doReturn(true).`when`(notificationTimeService).isNotificationDue(dto)
+        whenever(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
+        doReturn(true).whenever(notificationTimeService).isOutsideQuietTime(dto)
+        doReturn(true).whenever(notificationTimeService).isNotificationDue(dto)
 
         scheduler.sendDrinkingReminders()
 
         verify(notificationSenderService).sendNotifications(listOf(dto))
-        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).suspendNotifications(any())
     }
 
     @Test
     @DisplayName("sendDrinkingReminders(): suspends exhausted notification (attempts == 3)")
     fun `sendDrinkingReminders suspends exhausted notification`() {
         val dto = DtoGenerator.generateNotificationDto(notificationAttempts = 3)
-        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
-        doReturn(true).`when`(notificationTimeService).isOutsideQuietTime(dto)
-        doReturn(true).`when`(notificationTimeService).isNotificationDue(dto)
+        whenever(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(dto))
+        doReturn(true).whenever(notificationTimeService).isOutsideQuietTime(dto)
+        doReturn(true).whenever(notificationTimeService).isNotificationDue(dto)
 
         scheduler.sendDrinkingReminders()
 
         verify(notificationSenderService).suspendNotifications(listOf(dto))
-        verify(notificationSenderService, never()).sendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(any())
     }
 
     @Test
@@ -110,11 +115,11 @@ class NotificationSchedulerTest {
     fun `sendDrinkingReminders partitions exhausted and active`() {
         val active = DtoGenerator.generateNotificationDto(notificationAttempts = 1)
         val exhausted = DtoGenerator.generateNotificationDto(notificationAttempts = 3)
-        `when`(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(active, exhausted))
-        doReturn(true).`when`(notificationTimeService).isOutsideQuietTime(active)
-        doReturn(true).`when`(notificationTimeService).isOutsideQuietTime(exhausted)
-        doReturn(true).`when`(notificationTimeService).isNotificationDue(active)
-        doReturn(true).`when`(notificationTimeService).isNotificationDue(exhausted)
+        whenever(notificationSettingsService.getAllNotificationSettings()).thenReturn(setOf(active, exhausted))
+        doReturn(true).whenever(notificationTimeService).isOutsideQuietTime(active)
+        doReturn(true).whenever(notificationTimeService).isOutsideQuietTime(exhausted)
+        doReturn(true).whenever(notificationTimeService).isNotificationDue(active)
+        doReturn(true).whenever(notificationTimeService).isNotificationDue(exhausted)
 
         scheduler.sendDrinkingReminders()
 
@@ -125,11 +130,11 @@ class NotificationSchedulerTest {
     @Test
     @DisplayName("sendDrinkingReminders(): throws an error")
     fun `scheduler failed`() {
-        `when`(notificationSettingsService.getAllNotificationSettings()).thenThrow(RuntimeException("Scheduler Failed"))
+        whenever(notificationSettingsService.getAllNotificationSettings()).thenThrow(RuntimeException("Scheduler Failed"))
 
         scheduler.sendDrinkingReminders()
 
-        verify(notificationSenderService, never()).sendNotifications(anyCollection())
-        verify(notificationSenderService, never()).suspendNotifications(anyCollection())
+        verify(notificationSenderService, never()).sendNotifications(any())
+        verify(notificationSenderService, never()).suspendNotifications(any())
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/scheduler/NotificationSchedulerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/scheduler/NotificationSchedulerTest.kt
@@ -18,7 +18,6 @@ import ru.illine.drinking.ponies.test.tag.UnitTest
 @UnitTest
 @DisplayName("NotificationScheduler Unit Test")
 class NotificationSchedulerTest {
-
     private lateinit var notificationSettingsService: NotificationSettingsService
     private lateinit var notificationSenderService: NotificationSenderService
     private lateinit var notificationTimeService: NotificationTimeService
@@ -29,7 +28,8 @@ class NotificationSchedulerTest {
         notificationSettingsService = mock<NotificationSettingsService>()
         notificationSenderService = mock<NotificationSenderService>()
         notificationTimeService = mock<NotificationTimeService>()
-        scheduler = NotificationScheduler(notificationSettingsService, notificationSenderService, notificationTimeService)
+        scheduler =
+            NotificationScheduler(notificationSettingsService, notificationSenderService, notificationTimeService)
     }
 
     @Test
@@ -130,7 +130,9 @@ class NotificationSchedulerTest {
     @Test
     @DisplayName("sendDrinkingReminders(): throws an error")
     fun `scheduler failed`() {
-        whenever(notificationSettingsService.getAllNotificationSettings()).thenThrow(RuntimeException("Scheduler Failed"))
+        whenever(
+            notificationSettingsService.getAllNotificationSettings(),
+        ).thenThrow(RuntimeException("Scheduler Failed"))
 
         scheduler.sendDrinkingReminders()
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactoryTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactoryTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.mockito.Mockito.mock
+import org.mockito.kotlin.mock
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
@@ -29,17 +29,17 @@ class ReplyButtonFactoryTest {
     @BeforeEach
     fun setUp() {
         val snoozeStrategy = SnoozeApplyReplyButtonStrategy(
-            mock(TelegramClient::class.java),
-            mock(NotificationSettingsService::class.java),
-            mock(WaterStatisticService::class.java),
-            mock(MessageEditorService::class.java),
+            mock<TelegramClient>(),
+            mock<NotificationSettingsService>(),
+            mock<WaterStatisticService>(),
+            mock<MessageEditorService>(),
             Clock.systemUTC()
         )
         val waterAmountStrategy = WaterAmountApplyReplyButtonStrategy(
-            mock(TelegramClient::class.java),
-            mock(NotificationSettingsService::class.java),
-            mock(WaterStatisticService::class.java),
-            mock(MessageEditorService::class.java),
+            mock<TelegramClient>(),
+            mock<NotificationSettingsService>(),
+            mock<WaterStatisticService>(),
+            mock<MessageEditorService>(),
             Clock.systemUTC()
         )
         factory = ReplyButtonFactoryImpl(listOf(snoozeStrategy, waterAmountStrategy))

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactoryTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/ReplyButtonFactoryTest.kt
@@ -9,12 +9,12 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.kotlin.mock
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
 import ru.illine.drinking.ponies.model.base.WaterAmountType
 import ru.illine.drinking.ponies.service.button.impl.ReplyButtonFactoryImpl
 import ru.illine.drinking.ponies.service.button.strategy.snooze.SnoozeApplyReplyButtonStrategy
 import ru.illine.drinking.ponies.service.button.strategy.wateramount.WaterAmountApplyReplyButtonStrategy
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.tag.UnitTest
@@ -23,25 +23,26 @@ import java.time.Clock
 @UnitTest
 @DisplayName("ReplyButtonFactory Unit Test")
 class ReplyButtonFactoryTest {
-
     private lateinit var factory: ReplyButtonFactory
 
     @BeforeEach
     fun setUp() {
-        val snoozeStrategy = SnoozeApplyReplyButtonStrategy(
-            mock<TelegramClient>(),
-            mock<NotificationSettingsService>(),
-            mock<WaterStatisticService>(),
-            mock<MessageEditorService>(),
-            Clock.systemUTC()
-        )
-        val waterAmountStrategy = WaterAmountApplyReplyButtonStrategy(
-            mock<TelegramClient>(),
-            mock<NotificationSettingsService>(),
-            mock<WaterStatisticService>(),
-            mock<MessageEditorService>(),
-            Clock.systemUTC()
-        )
+        val snoozeStrategy =
+            SnoozeApplyReplyButtonStrategy(
+                mock<TelegramClient>(),
+                mock<NotificationSettingsService>(),
+                mock<WaterStatisticService>(),
+                mock<MessageEditorService>(),
+                Clock.systemUTC(),
+            )
+        val waterAmountStrategy =
+            WaterAmountApplyReplyButtonStrategy(
+                mock<TelegramClient>(),
+                mock<NotificationSettingsService>(),
+                mock<WaterStatisticService>(),
+                mock<MessageEditorService>(),
+                Clock.systemUTC(),
+            )
         factory = ReplyButtonFactoryImpl(listOf(snoozeStrategy, waterAmountStrategy))
     }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategyTest.kt
@@ -1,6 +1,8 @@
 package ru.illine.drinking.ponies.service.button.strategy.notification
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -17,8 +19,8 @@ import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
@@ -31,7 +33,6 @@ import java.time.ZoneOffset
 @UnitTest
 @DisplayName("CancelAnswerNotificationReplyButtonStrategy Unit Test")
 class CancelAnswerNotificationReplyButtonStrategyTest {
-
     private val externalUserId = 1L
     private val chatId = 2L
     private val messageId = 3
@@ -50,25 +51,29 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
         messageEditorService = mock<MessageEditorService>()
         notificationSettingsService = mock<NotificationSettingsService>()
         waterStatisticService = mock<WaterStatisticService>()
-        strategy = CancelAnswerNotificationReplyButtonStrategy(
-            sender,
-            messageEditorService,
-            notificationSettingsService,
-            waterStatisticService,
-            fixedClock
-        )
+        strategy =
+            CancelAnswerNotificationReplyButtonStrategy(
+                sender,
+                messageEditorService,
+                notificationSettingsService,
+                waterStatisticService,
+                fixedClock,
+            )
     }
 
     @Test
     @DisplayName("reply(): edits original message with CANCEL display name")
     fun `reply edits original message`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow),
+        ).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
-        val expectedText = TelegramMessageConstants.NOTIFICATION_QUESTION_EDITED_MESSAGE_PATTERN
-            .format(AnswerNotificationType.CANCEL.displayName)
+        val expectedText =
+            TelegramMessageConstants.NOTIFICATION_QUESTION_EDITED_MESSAGE_PATTERN
+                .format(AnswerNotificationType.CANCEL.displayName)
         verify(messageEditorService).editReplyMarkup(expectedText, chatId, messageId, true)
     }
 
@@ -76,7 +81,9 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): updates last notification time to now(clock)")
     fun `reply updates notification time`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow),
+        ).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
@@ -87,7 +94,9 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): records water statistic with CANCEL event type")
     fun `reply records statistic`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow),
+        ).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
@@ -98,7 +107,9 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): sends CANCEL confirmation message")
     fun `reply sends confirmation message`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow),
+        ).thenReturn(notificationDto)
 
         val captor = argumentCaptor<SendMessage>()
         strategy.reply(buildCallbackQuery())
@@ -135,8 +146,11 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): sends CANCEL confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
-        doThrow(RuntimeException("statistic error")).whenever(waterStatisticService)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow),
+        ).thenReturn(notificationDto)
+        doThrow(RuntimeException("statistic error"))
+            .whenever(waterStatisticService)
             .recordEvent(any(), any(), any<Int>())
 
         val captor = argumentCaptor<SendMessage>()

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategyTest.kt
@@ -29,7 +29,7 @@ import java.time.ZoneOffset
 @DisplayName("CancelAnswerNotificationReplyButtonStrategy Unit Test")
 class CancelAnswerNotificationReplyButtonStrategyTest {
 
-    private val userId = 1L
+    private val externalUserId = 1L
     private val chatId = 2L
     private val messageId = 3
     private val fixedNow = LocalDateTime.of(2025, 1, 1, 14, 0, 0)
@@ -59,8 +59,8 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): edits original message with CANCEL display name")
     fun `reply edits original message`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
@@ -72,19 +72,19 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): updates last notification time to now(clock)")
     fun `reply updates notification time`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
-        verify(notificationSettingsService).resetNotificationTimer(userId, fixedNow)
+        verify(notificationSettingsService).resetNotificationTimer(externalUserId, fixedNow)
     }
 
     @Test
     @DisplayName("reply(): records water statistic with CANCEL event type")
     fun `reply records statistic`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
@@ -94,8 +94,8 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): sends CANCEL confirmation message")
     fun `reply sends confirmation message`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
         strategy.reply(buildCallbackQuery())
@@ -131,8 +131,8 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): sends CANCEL confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
         doThrow(RuntimeException("statistic error")).`when`(waterStatisticService)
             .recordEvent(any(), any(), anyInt())
 
@@ -147,7 +147,7 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
 
     private fun buildCallbackQuery(): CallbackQuery {
         val user = mock(User::class.java)
-        `when`(user.id).thenReturn(userId)
+        `when`(user.id).thenReturn(externalUserId)
 
         val message = mock(Message::class.java)
         `when`(message.chatId).thenReturn(chatId)

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategyTest.kt
@@ -6,9 +6,12 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
@@ -43,10 +46,10 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
-        messageEditorService = mock(MessageEditorService::class.java)
-        notificationSettingsService = mock(NotificationSettingsService::class.java)
-        waterStatisticService = mock(WaterStatisticService::class.java)
+        sender = mock<TelegramClient>()
+        messageEditorService = mock<MessageEditorService>()
+        notificationSettingsService = mock<NotificationSettingsService>()
+        waterStatisticService = mock<WaterStatisticService>()
         strategy = CancelAnswerNotificationReplyButtonStrategy(
             sender,
             messageEditorService,
@@ -60,7 +63,7 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): edits original message with CANCEL display name")
     fun `reply edits original message`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
@@ -73,7 +76,7 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): updates last notification time to now(clock)")
     fun `reply updates notification time`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
@@ -84,7 +87,7 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): records water statistic with CANCEL event type")
     fun `reply records statistic`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery())
 
@@ -95,13 +98,13 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): sends CANCEL confirmation message")
     fun `reply sends confirmation message`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
-        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        val captor = argumentCaptor<SendMessage>()
         strategy.reply(buildCallbackQuery())
 
         verify(sender).execute(captor.capture())
-        val sent = captor.value
+        val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(TelegramMessageConstants.NOTIFICATION_ANSWER_CANCEL_MESSAGE, sent.text)
     }
@@ -132,30 +135,30 @@ class CancelAnswerNotificationReplyButtonStrategyTest {
     @DisplayName("reply(): sends CANCEL confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
-        doThrow(RuntimeException("statistic error")).`when`(waterStatisticService)
-            .recordEvent(any(), any(), anyInt())
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        doThrow(RuntimeException("statistic error")).whenever(waterStatisticService)
+            .recordEvent(any(), any(), any<Int>())
 
-        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        val captor = argumentCaptor<SendMessage>()
         strategy.reply(buildCallbackQuery())
 
         verify(sender).execute(captor.capture())
-        val sent = captor.value
+        val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(TelegramMessageConstants.NOTIFICATION_ANSWER_CANCEL_MESSAGE, sent.text)
     }
 
     private fun buildCallbackQuery(): CallbackQuery {
-        val user = mock(User::class.java)
-        `when`(user.id).thenReturn(externalUserId)
+        val user = mock<User>()
+        whenever(user.id).thenReturn(externalUserId)
 
-        val message = mock(Message::class.java)
-        `when`(message.chatId).thenReturn(chatId)
-        `when`(message.messageId).thenReturn(messageId)
+        val message = mock<Message>()
+        whenever(message.chatId).thenReturn(chatId)
+        whenever(message.messageId).thenReturn(messageId)
 
-        val callbackQuery = mock(CallbackQuery::class.java)
-        `when`(callbackQuery.from).thenReturn(user)
-        `when`(callbackQuery.message).thenReturn(message)
+        val callbackQuery = mock<CallbackQuery>()
+        whenever(callbackQuery.from).thenReturn(user)
+        whenever(callbackQuery.message).thenReturn(message)
         return callbackQuery
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategyTest.kt
@@ -1,6 +1,8 @@
 package ru.illine.drinking.ponies.service.button.strategy.notification
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -27,7 +29,6 @@ import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
 @UnitTest
 @DisplayName("YesAnswerNotificationReplyButtonStrategy Unit Test")
 class YesAnswerNotificationReplyButtonStrategyTest {
-
     private val chatId = 1L
     private val messageId = 2
 
@@ -47,8 +48,9 @@ class YesAnswerNotificationReplyButtonStrategyTest {
     fun `reply edits original message`() {
         strategy.reply(buildCallbackQuery())
 
-        val expectedText = TelegramMessageConstants.NOTIFICATION_QUESTION_EDITED_MESSAGE_PATTERN
-            .format(AnswerNotificationType.YES.displayName)
+        val expectedText =
+            TelegramMessageConstants.NOTIFICATION_QUESTION_EDITED_MESSAGE_PATTERN
+                .format(AnswerNotificationType.YES.displayName)
         verify(messageEditorService).editReplyMarkup(expectedText, chatId, messageId, true)
     }
 
@@ -72,7 +74,9 @@ class YesAnswerNotificationReplyButtonStrategyTest {
     fun `reply has no side effects beyond menu display`() {
         strategy.reply(buildCallbackQuery())
 
-        verify(messageEditorService).editReplyMarkup(any<String>(), any<Long>(), any<Int>(), any<Boolean>(), anyOrNull())
+        verify(
+            messageEditorService,
+        ).editReplyMarkup(any<String>(), any<Long>(), any<Int>(), any<Boolean>(), anyOrNull())
         verify(sender).execute(any<SendMessage>())
         verifyNoMoreInteractions(messageEditorService)
         verifyNoMoreInteractions(sender)

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategyTest.kt
@@ -6,10 +6,13 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.message.Message
@@ -34,8 +37,8 @@ class YesAnswerNotificationReplyButtonStrategyTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
-        messageEditorService = mock(MessageEditorService::class.java)
+        sender = mock<TelegramClient>()
+        messageEditorService = mock<MessageEditorService>()
         strategy = YesAnswerNotificationReplyButtonStrategy(sender, messageEditorService)
     }
 
@@ -52,12 +55,12 @@ class YesAnswerNotificationReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): sends water amount menu message with buttons")
     fun `reply sends water amount menu message`() {
-        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        val captor = argumentCaptor<SendMessage>()
 
         strategy.reply(buildCallbackQuery())
 
         verify(sender).execute(captor.capture())
-        val sent = captor.value
+        val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(TelegramMessageConstants.NOTIFICATION_WATER_AMOUNT_MENU_MESSAGE, sent.text)
         val buttons = (sent.replyMarkup as InlineKeyboardMarkup).keyboard
@@ -98,12 +101,12 @@ class YesAnswerNotificationReplyButtonStrategyTest {
     }
 
     private fun buildCallbackQuery(): CallbackQuery {
-        val message = mock(Message::class.java)
-        `when`(message.chatId).thenReturn(chatId)
-        `when`(message.messageId).thenReturn(messageId)
+        val message = mock<Message>()
+        whenever(message.chatId).thenReturn(chatId)
+        whenever(message.messageId).thenReturn(messageId)
 
-        val callbackQuery = mock(CallbackQuery::class.java)
-        `when`(callbackQuery.message).thenReturn(message)
+        val callbackQuery = mock<CallbackQuery>()
+        whenever(callbackQuery.message).thenReturn(message)
         return callbackQuery
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategyTest.kt
@@ -6,9 +6,13 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
@@ -44,10 +48,10 @@ class SnoozeApplyReplyButtonStrategyTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
-        notificationSettingsService = mock(NotificationSettingsService::class.java)
-        messageEditorService = mock(MessageEditorService::class.java)
-        waterStatisticService = mock(WaterStatisticService::class.java)
+        sender = mock<TelegramClient>()
+        notificationSettingsService = mock<NotificationSettingsService>()
+        messageEditorService = mock<MessageEditorService>()
+        waterStatisticService = mock<WaterStatisticService>()
         strategy = SnoozeApplyReplyButtonStrategy(
             sender,
             notificationSettingsService,
@@ -62,8 +66,8 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): deletes reply markup on original message")
     fun `reply deletes reply markup`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
+        whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         strategy.reply(callbackQuery)
@@ -76,8 +80,8 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): next notification fires exactly snoozeMinutes from now")
     fun `reply updates notification time`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
+        whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         strategy.reply(callbackQuery)
@@ -92,16 +96,16 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): sends confirmation message with snooze display name")
     fun `reply sends confirmation message`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
+        whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
-        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        val captor = argumentCaptor<SendMessage>()
 
         strategy.reply(callbackQuery)
 
         verify(sender).execute(captor.capture())
-        val sent = captor.value
+        val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(
             TelegramMessageConstants.NOTIFICATION_SUSPEND_MESSAGE.format(snoozeType.displayName),
@@ -113,8 +117,8 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): falls back to TEN_MINS when queryData doesn't match any SnoozeNotificationType")
     fun `reply falls back to TEN_MINS for unknown queryData`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
+        whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery("00000000-0000-0000-0000-000000000000")
         strategy.reply(callbackQuery)
@@ -129,8 +133,8 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): records water statistic with SNOOZE event type")
     fun `reply records statistic any type`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
+        whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
 
@@ -165,33 +169,33 @@ class SnoozeApplyReplyButtonStrategyTest {
     @DisplayName("reply(): sends snooze confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(any(), any())).thenReturn(notificationDto)
-        doThrow(RuntimeException("statistic error")).`when`(waterStatisticService)
-            .recordEvent(any(), any(), anyInt())
+        whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(any(), any())).thenReturn(notificationDto)
+        doThrow(RuntimeException("statistic error")).whenever(waterStatisticService)
+            .recordEvent(any(), any(), any<Int>())
 
         val snoozeType = SnoozeNotificationType.TEN_MINS
-        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        val captor = argumentCaptor<SendMessage>()
         strategy.reply(buildCallbackQuery(snoozeType.queryData.toString()))
 
         verify(sender).execute(captor.capture())
-        val sent = captor.value
+        val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(TelegramMessageConstants.NOTIFICATION_SUSPEND_MESSAGE.format(snoozeType.displayName), sent.text)
     }
 
     private fun buildCallbackQuery(queryData: String): CallbackQuery {
-        val user = mock(User::class.java)
-        `when`(user.id).thenReturn(externalUserId)
+        val user = mock<User>()
+        whenever(user.id).thenReturn(externalUserId)
 
-        val message = mock(Message::class.java)
-        `when`(message.chatId).thenReturn(chatId)
-        `when`(message.messageId).thenReturn(messageId)
+        val message = mock<Message>()
+        whenever(message.chatId).thenReturn(chatId)
+        whenever(message.messageId).thenReturn(messageId)
 
-        val callbackQuery = mock(CallbackQuery::class.java)
-        `when`(callbackQuery.from).thenReturn(user)
-        `when`(callbackQuery.message).thenReturn(message)
-        `when`(callbackQuery.data).thenReturn(queryData)
+        val callbackQuery = mock<CallbackQuery>()
+        whenever(callbackQuery.from).thenReturn(user)
+        whenever(callbackQuery.message).thenReturn(message)
+        whenever(callbackQuery.data).thenReturn(queryData)
         return callbackQuery
     }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategyTest.kt
@@ -1,6 +1,8 @@
 package ru.illine.drinking.ponies.service.button.strategy.snooze
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -18,9 +20,9 @@ import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
@@ -33,7 +35,6 @@ import java.time.ZoneOffset
 @UnitTest
 @DisplayName("SnoozeApplyReplyButtonStrategy Unit Test")
 class SnoozeApplyReplyButtonStrategyTest {
-
     private val externalUserId = 1L
     private val chatId = 2L
     private val messageId = 3
@@ -52,13 +53,14 @@ class SnoozeApplyReplyButtonStrategyTest {
         notificationSettingsService = mock<NotificationSettingsService>()
         messageEditorService = mock<MessageEditorService>()
         waterStatisticService = mock<WaterStatisticService>()
-        strategy = SnoozeApplyReplyButtonStrategy(
-            sender,
-            notificationSettingsService,
-            waterStatisticService,
-            messageEditorService,
-            fixedClock
-        )
+        strategy =
+            SnoozeApplyReplyButtonStrategy(
+                sender,
+                notificationSettingsService,
+                waterStatisticService,
+                messageEditorService,
+                fixedClock,
+            )
     }
 
     @ParameterizedTest
@@ -67,7 +69,9 @@ class SnoozeApplyReplyButtonStrategyTest {
     fun `reply deletes reply markup`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
         whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        whenever(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(eq(externalUserId), any()),
+        ).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         strategy.reply(callbackQuery)
@@ -81,7 +85,9 @@ class SnoozeApplyReplyButtonStrategyTest {
     fun `reply updates notification time`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
         whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        whenever(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(eq(externalUserId), any()),
+        ).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         strategy.reply(callbackQuery)
@@ -97,7 +103,9 @@ class SnoozeApplyReplyButtonStrategyTest {
     fun `reply sends confirmation message`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
         whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        whenever(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(eq(externalUserId), any()),
+        ).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         val captor = argumentCaptor<SendMessage>()
@@ -109,7 +117,7 @@ class SnoozeApplyReplyButtonStrategyTest {
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(
             TelegramMessageConstants.NOTIFICATION_SUSPEND_MESSAGE.format(snoozeType.displayName),
-            sent.text
+            sent.text,
         )
     }
 
@@ -118,7 +126,9 @@ class SnoozeApplyReplyButtonStrategyTest {
     fun `reply falls back to TEN_MINS for unknown queryData`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
         whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        whenever(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(eq(externalUserId), any()),
+        ).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery("00000000-0000-0000-0000-000000000000")
         strategy.reply(callbackQuery)
@@ -134,7 +144,9 @@ class SnoozeApplyReplyButtonStrategyTest {
     fun `reply records statistic any type`(snoozeType: SnoozeNotificationType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
         whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
-        whenever(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(eq(externalUserId), any()),
+        ).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
 
@@ -171,7 +183,8 @@ class SnoozeApplyReplyButtonStrategyTest {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
         whenever(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
         whenever(notificationSettingsService.resetNotificationTimer(any(), any())).thenReturn(notificationDto)
-        doThrow(RuntimeException("statistic error")).whenever(waterStatisticService)
+        doThrow(RuntimeException("statistic error"))
+            .whenever(waterStatisticService)
             .recordEvent(any(), any(), any<Int>())
 
         val snoozeType = SnoozeNotificationType.TEN_MINS
@@ -198,5 +211,4 @@ class SnoozeApplyReplyButtonStrategyTest {
         whenever(callbackQuery.data).thenReturn(queryData)
         return callbackQuery
     }
-
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategyTest.kt
@@ -30,7 +30,7 @@ import java.time.ZoneOffset
 @DisplayName("SnoozeApplyReplyButtonStrategy Unit Test")
 class SnoozeApplyReplyButtonStrategyTest {
 
-    private val userId = 1L
+    private val externalUserId = 1L
     private val chatId = 2L
     private val messageId = 3
     private val fixedNow = LocalDateTime.of(2025, 1, 1, 14, 0, 0)
@@ -61,9 +61,9 @@ class SnoozeApplyReplyButtonStrategyTest {
     @EnumSource(SnoozeNotificationType::class)
     @DisplayName("reply(): deletes reply markup on original message")
     fun `reply deletes reply markup`(snoozeType: SnoozeNotificationType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(userId), any())).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         strategy.reply(callbackQuery)
@@ -75,25 +75,25 @@ class SnoozeApplyReplyButtonStrategyTest {
     @EnumSource(SnoozeNotificationType::class)
     @DisplayName("reply(): next notification fires exactly snoozeMinutes from now")
     fun `reply updates notification time`(snoozeType: SnoozeNotificationType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(userId), any())).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         strategy.reply(callbackQuery)
 
         val interval = notificationDto.notificationInterval.minutes
         val expectedTime = fixedNow.minusMinutes(interval).plusMinutes(snoozeType.minutes)
-        verify(notificationSettingsService).resetNotificationTimer(userId, expectedTime)
+        verify(notificationSettingsService).resetNotificationTimer(externalUserId, expectedTime)
     }
 
     @ParameterizedTest
     @EnumSource(SnoozeNotificationType::class)
     @DisplayName("reply(): sends confirmation message with snooze display name")
     fun `reply sends confirmation message`(snoozeType: SnoozeNotificationType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(userId), any())).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
@@ -112,25 +112,25 @@ class SnoozeApplyReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): falls back to TEN_MINS when queryData doesn't match any SnoozeNotificationType")
     fun `reply falls back to TEN_MINS for unknown queryData`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(userId), any())).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery("00000000-0000-0000-0000-000000000000")
         strategy.reply(callbackQuery)
 
         val interval = notificationDto.notificationInterval.minutes
         val expectedTime = fixedNow.minusMinutes(interval).plusMinutes(SnoozeNotificationType.TEN_MINS.minutes)
-        verify(notificationSettingsService).resetNotificationTimer(userId, expectedTime)
+        verify(notificationSettingsService).resetNotificationTimer(externalUserId, expectedTime)
     }
 
     @ParameterizedTest
     @EnumSource(SnoozeNotificationType::class)
     @DisplayName("reply(): records water statistic with SNOOZE event type")
     fun `reply records statistic any type`(snoozeType: SnoozeNotificationType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
-        `when`(notificationSettingsService.resetNotificationTimer(eq(userId), any())).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
+        `when`(notificationSettingsService.resetNotificationTimer(eq(externalUserId), any())).thenReturn(notificationDto)
 
         val callbackQuery = buildCallbackQuery(snoozeType.queryData.toString())
 
@@ -164,8 +164,8 @@ class SnoozeApplyReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): sends snooze confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.getNotificationSettings(userId)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.getNotificationSettings(externalUserId)).thenReturn(notificationDto)
         `when`(notificationSettingsService.resetNotificationTimer(any(), any())).thenReturn(notificationDto)
         doThrow(RuntimeException("statistic error")).`when`(waterStatisticService)
             .recordEvent(any(), any(), anyInt())
@@ -182,7 +182,7 @@ class SnoozeApplyReplyButtonStrategyTest {
 
     private fun buildCallbackQuery(queryData: String): CallbackQuery {
         val user = mock(User::class.java)
-        `when`(user.id).thenReturn(userId)
+        `when`(user.id).thenReturn(externalUserId)
 
         val message = mock(Message::class.java)
         `when`(message.chatId).thenReturn(chatId)

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeMenuReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeMenuReplyButtonStrategyTest.kt
@@ -1,6 +1,8 @@
 package ru.illine.drinking.ponies.service.button.strategy.snooze
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -23,7 +25,6 @@ import ru.illine.drinking.ponies.util.telegram.TelegramMessageConstants
 @UnitTest
 @DisplayName("SnoozeMenuReplyButtonStrategy Unit Test")
 class SnoozeMenuReplyButtonStrategyTest {
-
     private val chatId = 1L
     private val messageId = 2
 
@@ -45,8 +46,9 @@ class SnoozeMenuReplyButtonStrategyTest {
 
         strategy.reply(callbackQuery)
 
-        val expectedText = TelegramMessageConstants.NOTIFICATION_QUESTION_EDITED_MESSAGE_PATTERN
-            .format(AnswerNotificationType.SNOOZE.displayName)
+        val expectedText =
+            TelegramMessageConstants.NOTIFICATION_QUESTION_EDITED_MESSAGE_PATTERN
+                .format(AnswerNotificationType.SNOOZE.displayName)
         verify(messageEditorService).editReplyMarkup(expectedText, chatId, messageId, true)
     }
 
@@ -62,7 +64,9 @@ class SnoozeMenuReplyButtonStrategyTest {
         val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(TelegramMessageConstants.NOTIFICATION_SNOOZE_MENU_MESSAGE, sent.text)
-        val buttons = (sent.replyMarkup as org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup).keyboard
+        val buttons =
+            (sent.replyMarkup as org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup)
+                .keyboard
         assertEquals(SnoozeNotificationType.entries.size, buttons.size)
     }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeMenuReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeMenuReplyButtonStrategyTest.kt
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.*
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.message.Message
@@ -31,8 +33,8 @@ class SnoozeMenuReplyButtonStrategyTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
-        messageEditorService = mock(MessageEditorService::class.java)
+        sender = mock<TelegramClient>()
+        messageEditorService = mock<MessageEditorService>()
         strategy = SnoozeMenuReplyButtonStrategy(sender, messageEditorService)
     }
 
@@ -52,12 +54,12 @@ class SnoozeMenuReplyButtonStrategyTest {
     @DisplayName("reply(): sends snooze menu message with buttons")
     fun `reply sends snooze menu message`() {
         val callbackQuery = buildCallbackQuery()
-        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        val captor = argumentCaptor<SendMessage>()
 
         strategy.reply(callbackQuery)
 
         verify(sender).execute(captor.capture())
-        val sent = captor.value
+        val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(TelegramMessageConstants.NOTIFICATION_SNOOZE_MENU_MESSAGE, sent.text)
         val buttons = (sent.replyMarkup as org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup).keyboard
@@ -87,12 +89,12 @@ class SnoozeMenuReplyButtonStrategyTest {
     }
 
     private fun buildCallbackQuery(): CallbackQuery {
-        val message = mock(Message::class.java)
-        `when`(message.chatId).thenReturn(chatId)
-        `when`(message.messageId).thenReturn(messageId)
+        val message = mock<Message>()
+        whenever(message.chatId).thenReturn(chatId)
+        whenever(message.messageId).thenReturn(messageId)
 
-        val callbackQuery = mock(CallbackQuery::class.java)
-        `when`(callbackQuery.message).thenReturn(message)
+        val callbackQuery = mock<CallbackQuery>()
+        whenever(callbackQuery.message).thenReturn(message)
         return callbackQuery
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
@@ -30,7 +30,7 @@ import java.time.ZoneOffset
 @DisplayName("WaterAmountApplyReplyButtonStrategy Unit Test")
 class WaterAmountApplyReplyButtonStrategyTest {
 
-    private val userId = 1L
+    private val externalUserId = 1L
     private val chatId = 2L
     private val messageId = 3
     private val fixedNow = LocalDateTime.of(2025, 1, 1, 14, 0, 0)
@@ -61,8 +61,8 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @EnumSource(WaterAmountType::class)
     @DisplayName("reply(): deletes reply markup on original message")
     fun `reply deletes reply markup`(waterAmountType: WaterAmountType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
@@ -73,20 +73,20 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @EnumSource(WaterAmountType::class)
     @DisplayName("reply(): updates last notification time to now()")
     fun `reply updates notification time`(waterAmountType: WaterAmountType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
-        verify(notificationSettingsService).resetNotificationTimer(userId, fixedNow)
+        verify(notificationSettingsService).resetNotificationTimer(externalUserId, fixedNow)
     }
 
     @ParameterizedTest
     @EnumSource(WaterAmountType::class)
     @DisplayName("reply(): sends YES confirmation message")
     fun `reply sends confirmation message`(waterAmountType: WaterAmountType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         val captor = ArgumentCaptor.forClass(SendMessage::class.java)
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
@@ -101,8 +101,8 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @EnumSource(WaterAmountType::class)
     @DisplayName("reply(): records water statistic with correct water amount")
     fun `reply records statistic with correct water amount`(waterAmountType: WaterAmountType) {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
@@ -116,8 +116,8 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): falls back to ML_250 when queryData doesn't match any WaterAmountType")
     fun `reply falls back to ML_250 for unknown queryData`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery("00000000-0000-0000-0000-000000000000"))
 
@@ -131,14 +131,14 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): executes operations in correct order")
     fun `reply executes in correct order`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(WaterAmountType.ML_250.queryData.toString()))
 
         val inOrder = inOrder(messageEditorService, notificationSettingsService, waterStatisticService, sender)
         inOrder.verify(messageEditorService).deleteReplyMarkup(chatId, messageId)
-        inOrder.verify(notificationSettingsService).resetNotificationTimer(userId, fixedNow)
+        inOrder.verify(notificationSettingsService).resetNotificationTimer(externalUserId, fixedNow)
         inOrder.verify(waterStatisticService).recordEvent(
             notificationDto.telegramUser,
             AnswerNotificationType.YES,
@@ -172,8 +172,8 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @Test
     @DisplayName("reply(): sends YES confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
-        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationSettingsService.resetNotificationTimer(userId, fixedNow)).thenReturn(notificationDto)
+        val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
         doThrow(RuntimeException("statistic error")).`when`(waterStatisticService)
             .recordEvent(any(), any(), anyInt())
 
@@ -188,7 +188,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
 
     private fun buildCallbackQuery(queryData: String): CallbackQuery {
         val user = mock(User::class.java)
-        `when`(user.id).thenReturn(userId)
+        `when`(user.id).thenReturn(externalUserId)
 
         val message = mock(Message::class.java)
         `when`(message.chatId).thenReturn(chatId)

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
@@ -1,6 +1,8 @@
 package ru.illine.drinking.ponies.service.button.strategy.wateramount
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -18,9 +20,9 @@ import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.generics.TelegramClient
-import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.WaterAmountType
+import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
@@ -33,7 +35,6 @@ import java.time.ZoneOffset
 @UnitTest
 @DisplayName("WaterAmountApplyReplyButtonStrategy Unit Test")
 class WaterAmountApplyReplyButtonStrategyTest {
-
     private val externalUserId = 1L
     private val chatId = 2L
     private val messageId = 3
@@ -52,13 +53,14 @@ class WaterAmountApplyReplyButtonStrategyTest {
         notificationSettingsService = mock<NotificationSettingsService>()
         waterStatisticService = mock<WaterStatisticService>()
         messageEditorService = mock<MessageEditorService>()
-        strategy = WaterAmountApplyReplyButtonStrategy(
-            sender,
-            notificationSettingsService,
-            waterStatisticService,
-            messageEditorService,
-            fixedClock
-        )
+        strategy =
+            WaterAmountApplyReplyButtonStrategy(
+                sender,
+                notificationSettingsService,
+                waterStatisticService,
+                messageEditorService,
+                fixedClock,
+            )
     }
 
     @ParameterizedTest
@@ -66,7 +68,9 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): deletes reply markup on original message")
     fun `reply deletes reply markup`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow),
+        ).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
@@ -78,7 +82,9 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): updates last notification time to now()")
     fun `reply updates notification time`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow),
+        ).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
@@ -90,7 +96,9 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): sends YES confirmation message")
     fun `reply sends confirmation message`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow),
+        ).thenReturn(notificationDto)
 
         val captor = argumentCaptor<SendMessage>()
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
@@ -106,14 +114,16 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): records water statistic with correct water amount")
     fun `reply records statistic with correct water amount`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow),
+        ).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
         verify(waterStatisticService).recordEvent(
             notificationDto.telegramUser,
             AnswerNotificationType.YES,
-            waterAmountType.amountMl
+            waterAmountType.amountMl,
         )
     }
 
@@ -121,14 +131,16 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): falls back to ML_250 when queryData doesn't match any WaterAmountType")
     fun `reply falls back to ML_250 for unknown queryData`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow),
+        ).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery("00000000-0000-0000-0000-000000000000"))
 
         verify(waterStatisticService).recordEvent(
             notificationDto.telegramUser,
             AnswerNotificationType.YES,
-            WaterAmountType.ML_250.amountMl
+            WaterAmountType.ML_250.amountMl,
         )
     }
 
@@ -136,7 +148,9 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): executes operations in correct order")
     fun `reply executes in correct order`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow),
+        ).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(WaterAmountType.ML_250.queryData.toString()))
 
@@ -146,7 +160,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
         inOrder.verify(waterStatisticService).recordEvent(
             notificationDto.telegramUser,
             AnswerNotificationType.YES,
-            WaterAmountType.ML_250.amountMl
+            WaterAmountType.ML_250.amountMl,
         )
         inOrder.verify(sender).execute(any<SendMessage>())
     }
@@ -177,8 +191,11 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): sends YES confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
-        doThrow(RuntimeException("statistic error")).whenever(waterStatisticService)
+        whenever(
+            notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow),
+        ).thenReturn(notificationDto)
+        doThrow(RuntimeException("statistic error"))
+            .whenever(waterStatisticService)
             .recordEvent(any(), any(), any<Int>())
 
         val captor = argumentCaptor<SendMessage>()
@@ -204,5 +221,4 @@ class WaterAmountApplyReplyButtonStrategyTest {
         whenever(callbackQuery.data).thenReturn(queryData)
         return callbackQuery
     }
-
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategyTest.kt
@@ -6,9 +6,13 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.User
@@ -44,10 +48,10 @@ class WaterAmountApplyReplyButtonStrategyTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
-        notificationSettingsService = mock(NotificationSettingsService::class.java)
-        waterStatisticService = mock(WaterStatisticService::class.java)
-        messageEditorService = mock(MessageEditorService::class.java)
+        sender = mock<TelegramClient>()
+        notificationSettingsService = mock<NotificationSettingsService>()
+        waterStatisticService = mock<WaterStatisticService>()
+        messageEditorService = mock<MessageEditorService>()
         strategy = WaterAmountApplyReplyButtonStrategy(
             sender,
             notificationSettingsService,
@@ -62,7 +66,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): deletes reply markup on original message")
     fun `reply deletes reply markup`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
@@ -74,7 +78,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): updates last notification time to now()")
     fun `reply updates notification time`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
@@ -86,13 +90,13 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): sends YES confirmation message")
     fun `reply sends confirmation message`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
-        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        val captor = argumentCaptor<SendMessage>()
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
         verify(sender).execute(captor.capture())
-        val sent = captor.value
+        val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(TelegramMessageConstants.NOTIFICATION_ANSWER_YES_MESSAGE, sent.text)
     }
@@ -102,7 +106,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): records water statistic with correct water amount")
     fun `reply records statistic with correct water amount`(waterAmountType: WaterAmountType) {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(waterAmountType.queryData.toString()))
 
@@ -117,7 +121,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): falls back to ML_250 when queryData doesn't match any WaterAmountType")
     fun `reply falls back to ML_250 for unknown queryData`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery("00000000-0000-0000-0000-000000000000"))
 
@@ -132,7 +136,7 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): executes operations in correct order")
     fun `reply executes in correct order`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
 
         strategy.reply(buildCallbackQuery(WaterAmountType.ML_250.queryData.toString()))
 
@@ -173,31 +177,31 @@ class WaterAmountApplyReplyButtonStrategyTest {
     @DisplayName("reply(): sends YES confirmation message even when recordEvent throws an exception")
     fun `reply sends confirmation message when recordEvent throws`() {
         val notificationDto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
-        doThrow(RuntimeException("statistic error")).`when`(waterStatisticService)
-            .recordEvent(any(), any(), anyInt())
+        whenever(notificationSettingsService.resetNotificationTimer(externalUserId, fixedNow)).thenReturn(notificationDto)
+        doThrow(RuntimeException("statistic error")).whenever(waterStatisticService)
+            .recordEvent(any(), any(), any<Int>())
 
-        val captor = ArgumentCaptor.forClass(SendMessage::class.java)
+        val captor = argumentCaptor<SendMessage>()
         strategy.reply(buildCallbackQuery(WaterAmountType.ML_250.queryData.toString()))
 
         verify(sender).execute(captor.capture())
-        val sent = captor.value
+        val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals(TelegramMessageConstants.NOTIFICATION_ANSWER_YES_MESSAGE, sent.text)
     }
 
     private fun buildCallbackQuery(queryData: String): CallbackQuery {
-        val user = mock(User::class.java)
-        `when`(user.id).thenReturn(externalUserId)
+        val user = mock<User>()
+        whenever(user.id).thenReturn(externalUserId)
 
-        val message = mock(Message::class.java)
-        `when`(message.chatId).thenReturn(chatId)
-        `when`(message.messageId).thenReturn(messageId)
+        val message = mock<Message>()
+        whenever(message.chatId).thenReturn(chatId)
+        whenever(message.messageId).thenReturn(messageId)
 
-        val callbackQuery = mock(CallbackQuery::class.java)
-        `when`(callbackQuery.from).thenReturn(user)
-        `when`(callbackQuery.message).thenReturn(message)
-        `when`(callbackQuery.data).thenReturn(queryData)
+        val callbackQuery = mock<CallbackQuery>()
+        whenever(callbackQuery.from).thenReturn(user)
+        whenever(callbackQuery.message).thenReturn(message)
+        whenever(callbackQuery.data).thenReturn(queryData)
         return callbackQuery
     }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/command/CommandServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/command/CommandServiceTest.kt
@@ -19,7 +19,6 @@ import ru.illine.drinking.ponies.util.telegram.TelegramMenuConstants
 @UnitTest
 @DisplayName("CommandService Unit Test")
 class CommandServiceTest {
-
     private lateinit var sender: TelegramClient
 
     @BeforeEach
@@ -53,13 +52,14 @@ class CommandServiceTest {
     }
 
     private fun buildService(autoUpdateTelegramConfig: Boolean): CommandServiceImpl {
-        val properties = TelegramBotProperties(
-            token = "token",
-            username = "username",
-            miniAppUrl = MINI_APP_URL,
-            autoUpdateTelegramConfig = autoUpdateTelegramConfig,
-            http = TelegramBotProperties.Http(connectionTimeToLiveInSec = 30, maxConnectionTotal = 10)
-        )
+        val properties =
+            TelegramBotProperties(
+                token = "token",
+                username = "username",
+                miniAppUrl = MINI_APP_URL,
+                autoUpdateTelegramConfig = autoUpdateTelegramConfig,
+                http = TelegramBotProperties.Http(connectionTimeToLiveInSec = 30, maxConnectionTotal = 10),
+            )
         return CommandServiceImpl(properties, sender)
     }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/command/CommandServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/command/CommandServiceTest.kt
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.telegram.telegrambots.meta.api.methods.menubutton.SetChatMenuButton
 import org.telegram.telegrambots.meta.api.objects.menubutton.MenuButtonWebApp
 import org.telegram.telegrambots.meta.generics.TelegramClient
@@ -24,7 +24,7 @@ class CommandServiceTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
+        sender = mock<TelegramClient>()
     }
 
     @Test
@@ -34,10 +34,10 @@ class CommandServiceTest {
 
         service.register()
 
-        val menuCaptor = ArgumentCaptor.forClass(SetChatMenuButton::class.java)
+        val menuCaptor = argumentCaptor<SetChatMenuButton>()
         verify(sender).execute(menuCaptor.capture())
 
-        val menuButton = menuCaptor.value.menuButton as MenuButtonWebApp
+        val menuButton = menuCaptor.firstValue.menuButton as MenuButtonWebApp
         assertEquals(TelegramMenuConstants.MENU_BUTTON_TEXT, menuButton.text)
         assertEquals(MINI_APP_URL, menuButton.webAppInfo.url)
     }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/message/LocalMessageProviderTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/message/LocalMessageProviderTest.kt
@@ -1,6 +1,9 @@
 package ru.illine.drinking.ponies.service.message
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -16,7 +19,6 @@ import kotlin.random.Random
 @UnitTest
 @DisplayName("LocalMessageProvider Unit Test")
 class LocalMessageProviderTest {
-
     private lateinit var provider: MessageProvider
 
     @BeforeEach
@@ -29,10 +31,14 @@ class LocalMessageProviderTest {
     fun `streak small bucket contains number and word`() {
         // All rules (specific + fallback) compete with equal priority, so specific phrasing
         // is reachable but not guaranteed on every seed.
-        val outcomes = (0L until 50L).map { seed ->
-            LocalMessageProvider(Random(seed))
-                .getMessage(MessageSpec.InsightStats, DtoGenerator.generateInsightStatsContext(currentStreakDays = 3)).text
-        }
+        val outcomes =
+            (0L until 50L).map { seed ->
+                LocalMessageProvider(Random(seed))
+                    .getMessage(
+                        MessageSpec.InsightStats,
+                        DtoGenerator.generateInsightStatsContext(currentStreakDays = 3),
+                    ).text
+            }
         assertTrue(outcomes.any { it.contains("3") }, "expected streak number 3 at least once")
         assertTrue(outcomes.any { it.contains("подряд") }, "expected 'подряд' phrasing at least once")
     }
@@ -40,10 +46,12 @@ class LocalMessageProviderTest {
     @Test
     @DisplayName("getMessage(): streak boundary streak=2 triggers the 2..6 rule")
     fun `streak boundary two`() {
-        val result = provider.getMessage(
-            MessageSpec.InsightStats,
-            DtoGenerator.generateInsightStatsContext(currentStreakDays = 2)
-        ).text
+        val result =
+            provider
+                .getMessage(
+                    MessageSpec.InsightStats,
+                    DtoGenerator.generateInsightStatsContext(currentStreakDays = 2),
+                ).text
 
         assertTrue(result.contains("2"), "expected streak number 2, got: $result")
     }
@@ -51,27 +59,35 @@ class LocalMessageProviderTest {
     @Test
     @DisplayName("getMessage(): streak in 7..13 references the streak (no off-by-one in bucket boundary)")
     fun `streak medium bucket`() {
-        val outcomes = (0L until 50L).map { seed ->
-            LocalMessageProvider(Random(seed))
-                .getMessage(MessageSpec.InsightStats, DtoGenerator.generateInsightStatsContext(currentStreakDays = 7)).text
-        }
+        val outcomes =
+            (0L until 50L).map { seed ->
+                LocalMessageProvider(Random(seed))
+                    .getMessage(
+                        MessageSpec.InsightStats,
+                        DtoGenerator.generateInsightStatsContext(currentStreakDays = 7),
+                    ).text
+            }
         // streak number must be present in at least one template; the other refers to it implicitly.
         assertTrue(
             outcomes.any { it.contains("7") || it.contains("привычка") },
-            "expected medium streak phrasing, sample: ${outcomes.first()}"
+            "expected medium streak phrasing, sample: ${outcomes.first()}",
         )
     }
 
     @Test
     @DisplayName("getMessage(): streak >= 14 long-bucket phrasing is reachable")
     fun `streak long bucket`() {
-        val outcomes = (0L until 50L).map { seed ->
-            LocalMessageProvider(Random(seed))
-                .getMessage(MessageSpec.InsightStats, DtoGenerator.generateInsightStatsContext(currentStreakDays = 30)).text
-        }
+        val outcomes =
+            (0L until 50L).map { seed ->
+                LocalMessageProvider(Random(seed))
+                    .getMessage(
+                        MessageSpec.InsightStats,
+                        DtoGenerator.generateInsightStatsContext(currentStreakDays = 30),
+                    ).text
+            }
         assertTrue(
             outcomes.any { it.contains("30") || it.contains("ритуал") },
-            "long streak phrasing must be reachable across seeds"
+            "long streak phrasing must be reachable across seeds",
         )
     }
 
@@ -79,34 +95,46 @@ class LocalMessageProviderTest {
     @DisplayName("getMessage(): streak phrase includes correct russian plural form (1 -> день, 2 -> дня, 5 -> дней)")
     fun `streak pluralization`() {
         // streak=2 -> "дня"
-        val outcomes2 = (0L until 30L).map { seed ->
-            LocalMessageProvider(Random(seed))
-                .getMessage(MessageSpec.InsightStats, DtoGenerator.generateInsightStatsContext(currentStreakDays = 2)).text
-        }
+        val outcomes2 =
+            (0L until 30L).map { seed ->
+                LocalMessageProvider(Random(seed))
+                    .getMessage(
+                        MessageSpec.InsightStats,
+                        DtoGenerator.generateInsightStatsContext(currentStreakDays = 2),
+                    ).text
+            }
         assertTrue(outcomes2.any { it.contains("2 дня") }, "expected '2 дня' at least once, got: ${outcomes2.first()}")
 
         // streak=5 -> "дней"
-        val outcomes5 = (0L until 30L).map { seed ->
-            LocalMessageProvider(Random(seed))
-                .getMessage(MessageSpec.InsightStats, DtoGenerator.generateInsightStatsContext(currentStreakDays = 5)).text
-        }
-        assertTrue(outcomes5.any { it.contains("5 дней") }, "expected '5 дней' at least once, got: ${outcomes5.first()}")
+        val outcomes5 =
+            (0L until 30L).map { seed ->
+                LocalMessageProvider(Random(seed))
+                    .getMessage(
+                        MessageSpec.InsightStats,
+                        DtoGenerator.generateInsightStatsContext(currentStreakDays = 5),
+                    ).text
+            }
+        assertTrue(
+            outcomes5.any { it.contains("5 дней") },
+            "expected '5 дней' at least once, got: ${outcomes5.first()}",
+        )
     }
 
     @Test
     @DisplayName("getMessage(): avg >= goal produces AVG_GOOD phrasing in specific bucket")
     fun `avg above goal triggers specific bucket`() {
-        val outcomes = (0L until 50L).map { seed ->
-            LocalMessageProvider(Random(seed))
-                .getMessage(
-                    MessageSpec.InsightStats,
-                    DtoGenerator.generateInsightStatsContext(avgMlPerDay = 2200, dailyGoalMl = 2000)
-                ).text
-        }
+        val outcomes =
+            (0L until 50L).map { seed ->
+                LocalMessageProvider(Random(seed))
+                    .getMessage(
+                        MessageSpec.InsightStats,
+                        DtoGenerator.generateInsightStatsContext(avgMlPerDay = 2200, dailyGoalMl = 2000),
+                    ).text
+            }
         // AVG_GOOD competes with the fallback rule on equal footing - must be reachable, not exclusive.
         assertTrue(
             outcomes.any { it.contains("выше цели") || it.contains("перебирает") },
-            "expected AVG_GOOD phrasing at least once across seeds"
+            "expected AVG_GOOD phrasing at least once across seeds",
         )
     }
 
@@ -116,23 +144,24 @@ class LocalMessageProviderTest {
         // Predicate is `avgMlPerDay >= dailyGoalMl && dailyGoalMl > 0`.
         // With dailyGoalMl=0 the first part is true (0 >= 0) but the guard `> 0` must veto the AVG_GOOD rule,
         // so only the fallback bucket may surface - never the "выше цели"/"перебирает" phrasing.
-        val outcomes = (0L until 100L).map { seed ->
-            LocalMessageProvider(Random(seed))
-                .getMessage(
-                    MessageSpec.InsightStats,
-                    DtoGenerator.generateInsightStatsContext(
-                        currentStreakDays = 0,
-                        avgMlPerDay = 0,
-                        dailyGoalMl = 0,
-                        bestDay = null,
-                    )
-                ).text
-        }
+        val outcomes =
+            (0L until 100L).map { seed ->
+                LocalMessageProvider(Random(seed))
+                    .getMessage(
+                        MessageSpec.InsightStats,
+                        DtoGenerator.generateInsightStatsContext(
+                            currentStreakDays = 0,
+                            avgMlPerDay = 0,
+                            dailyGoalMl = 0,
+                            bestDay = null,
+                        ),
+                    ).text
+            }
 
         outcomes.forEach { text ->
             assertFalse(
                 text.contains("выше цели") || text.contains("перебирает"),
-                "AVG_GOOD must not trigger when dailyGoalMl <= 0, got: $text"
+                "AVG_GOOD must not trigger when dailyGoalMl <= 0, got: $text",
             )
             assertTrue(text.isNotBlank(), "fallback must produce non-empty text")
         }
@@ -141,19 +170,21 @@ class LocalMessageProviderTest {
     @Test
     @DisplayName("getMessage(): bestDay set with valueMl > 0 renders BEST_DAY phrasing reachably")
     fun `bestDay rule surfaces value`() {
-        val outcomes = (0L until 100L).map { seed ->
-            LocalMessageProvider(Random(seed))
-                .getMessage(
-                    MessageSpec.InsightStats,
-                    DtoGenerator.generateInsightStatsContext(
-                        bestDay = DtoGenerator.generateBestDayDto(
-                            date = LocalDate.of(2026, 5, 6),
-                            valueMl = 2400,
-                            weekday = DayOfWeek.WEDNESDAY,
-                        )
-                    )
-                ).text
-        }
+        val outcomes =
+            (0L until 100L).map { seed ->
+                LocalMessageProvider(Random(seed))
+                    .getMessage(
+                        MessageSpec.InsightStats,
+                        DtoGenerator.generateInsightStatsContext(
+                            bestDay =
+                                DtoGenerator.generateBestDayDto(
+                                    date = LocalDate.of(2026, 5, 6),
+                                    valueMl = 2400,
+                                    weekday = DayOfWeek.WEDNESDAY,
+                                ),
+                        ),
+                    ).text
+            }
         // BEST_DAY competes with the fallback rule on equal footing - must surface, not dominate.
         assertTrue(outcomes.any { it.contains("2400") }, "expected bestDay value 2400 at least once")
     }
@@ -163,59 +194,74 @@ class LocalMessageProviderTest {
     fun `specific and fallback mix when streak matches`() {
         // streak=5 -> streak 2..6 rule matches; fallback `{ true }` also matches.
         // All matching rules compete with equal priority, so both should be reachable across seeds.
-        val outcomes = (0L until 100L).map { seed ->
-            LocalMessageProvider(Random(seed))
-                .getMessage(MessageSpec.InsightStats, DtoGenerator.generateInsightStatsContext(currentStreakDays = 5)).text
-        }
-        val fallbackMarkers = listOf("довольны", "тебе кивает", "сердечко", "почки", "Кактусы", "стараешься", "прогресс", "молодец")
+        val outcomes =
+            (0L until 100L).map { seed ->
+                LocalMessageProvider(Random(seed))
+                    .getMessage(
+                        MessageSpec.InsightStats,
+                        DtoGenerator.generateInsightStatsContext(currentStreakDays = 5),
+                    ).text
+            }
+        val fallbackMarkers =
+            listOf("довольны", "тебе кивает", "сердечко", "почки", "Кактусы", "стараешься", "прогресс", "молодец")
         assertTrue(outcomes.any { it.contains("5") }, "expected streak phrasing at least once")
         assertTrue(
             outcomes.any { text -> fallbackMarkers.any { text.contains(it) } },
-            "expected fallback phrasing at least once (rules compete with equal priority)"
+            "expected fallback phrasing at least once (rules compete with equal priority)",
         )
     }
 
     @Test
     @DisplayName("getMessage(): fallback bucket wins when no specific rule matches (streak=0, avg<goal, bestDay=null)")
     fun `fallback when nothing specific matches`() {
-        val outcomes = (0L until 100L).map { seed ->
-            LocalMessageProvider(Random(seed))
-                .getMessage(
-                    MessageSpec.InsightStats,
-                    DtoGenerator.generateInsightStatsContext(currentStreakDays = 0, avgMlPerDay = 0, bestDay = null)
-                ).text
-        }
+        val outcomes =
+            (0L until 100L).map { seed ->
+                LocalMessageProvider(Random(seed))
+                    .getMessage(
+                        MessageSpec.InsightStats,
+                        DtoGenerator.generateInsightStatsContext(
+                            currentStreakDays = 0,
+                            avgMlPerDay = 0,
+                            bestDay = null,
+                        ),
+                    ).text
+            }
         // None of the specific markers must surface
         val specificMarkers = listOf("подряд", "выше цели", "перебирает", "Лучший день", "размах")
         outcomes.forEach { text ->
             assertFalse(
                 specificMarkers.any { it in text },
-                "specific phrasing leaked into fallback context: $text"
+                "specific phrasing leaked into fallback context: $text",
             )
             assertTrue(text.isNotBlank(), "fallback must produce non-empty text")
         }
     }
 
     @Test
-    @DisplayName("getMessage(): bestDay with valueMl=0 still matches specific bucket (rule only checks non-null bestDay)")
+    @DisplayName(
+        "getMessage(): bestDay with valueMl=0 still matches specific bucket (rule only checks non-null bestDay)",
+    )
     fun `bestDay zero value still matches specific bucket`() {
         // Predicate is `bestDay != null` (no valueMl check); ensure we land in the specific bucket.
         // The template references bestDay!!.valueMl so it will render "0 мл".
-        val text = provider.getMessage(
-            MessageSpec.InsightStats,
-            DtoGenerator.generateInsightStatsContext(
-                bestDay = DtoGenerator.generateBestDayDto(
-                    date = LocalDate.of(2026, 5, 6),
-                    valueMl = 0,
-                    weekday = DayOfWeek.WEDNESDAY,
-                )
-            )
-        ).text
+        val text =
+            provider
+                .getMessage(
+                    MessageSpec.InsightStats,
+                    DtoGenerator.generateInsightStatsContext(
+                        bestDay =
+                            DtoGenerator.generateBestDayDto(
+                                date = LocalDate.of(2026, 5, 6),
+                                valueMl = 0,
+                                weekday = DayOfWeek.WEDNESDAY,
+                            ),
+                    ),
+                ).text
 
         // Must be a BEST_DAY template (since it is the only matching specific rule):
         assertTrue(
             text.contains("0 мл") || text.contains("День с 0"),
-            "expected BEST_DAY phrasing with 0 ml, got: $text"
+            "expected BEST_DAY phrasing with 0 ml, got: $text",
         )
     }
 
@@ -250,10 +296,12 @@ class LocalMessageProviderTest {
         // Since LocalMessageProvider is sealed in private state, instead exercise the error path by
         // verifying that the existing InsightStats spec ALWAYS produces output - the `{ true }` fallback
         // bucket guarantees this. We assert on a context that would otherwise match nothing specific.
-        val text = provider.getMessage(
-            MessageSpec.InsightStats,
-            DtoGenerator.generateInsightStatsContext(currentStreakDays = 0, avgMlPerDay = 0, bestDay = null)
-        ).text
+        val text =
+            provider
+                .getMessage(
+                    MessageSpec.InsightStats,
+                    DtoGenerator.generateInsightStatsContext(currentStreakDays = 0, avgMlPerDay = 0, bestDay = null),
+                ).text
 
         assertTrue(text.isNotBlank(), "fallback bucket must always produce text")
         // Sanity smoke: explicit type for the assertion below
@@ -267,30 +315,33 @@ class LocalMessageProviderTest {
     @DisplayName("getMessage(): rendered text never contains unfilled {placeholder} markers")
     fun `no unfilled placeholders`() {
         val unfilled = Regex("\\{[^}]+}")
-        val bestDay = DtoGenerator.generateBestDayDto(
-            date = LocalDate.of(2026, 5, 6),
-            valueMl = 2400,
-            weekday = DayOfWeek.WEDNESDAY,
-        )
+        val bestDay =
+            DtoGenerator.generateBestDayDto(
+                date = LocalDate.of(2026, 5, 6),
+                valueMl = 2400,
+                weekday = DayOfWeek.WEDNESDAY,
+            )
 
-        val contexts = listOf(
-            DtoGenerator.generateInsightStatsContext(),
-            DtoGenerator.generateInsightStatsContext(currentStreakDays = 1),
-            DtoGenerator.generateInsightStatsContext(currentStreakDays = 5),
-            DtoGenerator.generateInsightStatsContext(currentStreakDays = 10),
-            DtoGenerator.generateInsightStatsContext(currentStreakDays = 30),
-            DtoGenerator.generateInsightStatsContext(avgMlPerDay = 2200),
-            DtoGenerator.generateInsightStatsContext(avgMlPerDay = 1000),
-            DtoGenerator.generateInsightStatsContext(bestDay = bestDay),
-            DtoGenerator.generateInsightStatsContext(currentStreakDays = 5, bestDay = bestDay, avgMlPerDay = 2200),
-            DtoGenerator.generateInsightStatsContext(
-                bestDay = DtoGenerator.generateBestDayDto(
-                    date = LocalDate.of(2026, 5, 6),
-                    valueMl = 0,
-                    weekday = DayOfWeek.WEDNESDAY,
-                )
-            ),
-        )
+        val contexts =
+            listOf(
+                DtoGenerator.generateInsightStatsContext(),
+                DtoGenerator.generateInsightStatsContext(currentStreakDays = 1),
+                DtoGenerator.generateInsightStatsContext(currentStreakDays = 5),
+                DtoGenerator.generateInsightStatsContext(currentStreakDays = 10),
+                DtoGenerator.generateInsightStatsContext(currentStreakDays = 30),
+                DtoGenerator.generateInsightStatsContext(avgMlPerDay = 2200),
+                DtoGenerator.generateInsightStatsContext(avgMlPerDay = 1000),
+                DtoGenerator.generateInsightStatsContext(bestDay = bestDay),
+                DtoGenerator.generateInsightStatsContext(currentStreakDays = 5, bestDay = bestDay, avgMlPerDay = 2200),
+                DtoGenerator.generateInsightStatsContext(
+                    bestDay =
+                        DtoGenerator.generateBestDayDto(
+                            date = LocalDate.of(2026, 5, 6),
+                            valueMl = 0,
+                            weekday = DayOfWeek.WEDNESDAY,
+                        ),
+                ),
+            )
 
         contexts.forEach { c ->
             val text = provider.getMessage(MessageSpec.InsightStats, c).text

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/message/LocalMessageProviderTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/message/LocalMessageProviderTest.kt
@@ -111,6 +111,34 @@ class LocalMessageProviderTest {
     }
 
     @Test
+    @DisplayName("getMessage(): avg >= goal but goal <= 0 does NOT trigger AVG_GOOD (guards against bogus daily goal)")
+    fun `avg above non-positive goal does not trigger specific bucket`() {
+        // Predicate is `avgMlPerDay >= dailyGoalMl && dailyGoalMl > 0`.
+        // With dailyGoalMl=0 the first part is true (0 >= 0) but the guard `> 0` must veto the AVG_GOOD rule,
+        // so only the fallback bucket may surface - never the "выше цели"/"перебирает" phrasing.
+        val outcomes = (0L until 100L).map { seed ->
+            LocalMessageProvider(Random(seed))
+                .getMessage(
+                    MessageSpec.InsightStats,
+                    DtoGenerator.generateInsightStatsContext(
+                        currentStreakDays = 0,
+                        avgMlPerDay = 0,
+                        dailyGoalMl = 0,
+                        bestDay = null,
+                    )
+                ).text
+        }
+
+        outcomes.forEach { text ->
+            assertFalse(
+                text.contains("выше цели") || text.contains("перебирает"),
+                "AVG_GOOD must not trigger when dailyGoalMl <= 0, got: $text"
+            )
+            assertTrue(text.isNotBlank(), "fallback must produce non-empty text")
+        }
+    }
+
+    @Test
     @DisplayName("getMessage(): bestDay set with valueMl > 0 renders BEST_DAY phrasing reachably")
     fun `bestDay rule surfaces value`() {
         val outcomes = (0L until 100L).map { seed ->

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
@@ -4,9 +4,14 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException
@@ -51,11 +56,10 @@ class NotificationSenderServiceTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
-        messageEditorService = mock(MessageEditorService::class.java)
-        notificationAccessService = mock(NotificationAccessService::class.java)
-        @Suppress("UNCHECKED_CAST")
-        waterStatisticService = mock(WaterStatisticService::class.java)
+        sender = mock<TelegramClient>()
+        messageEditorService = mock<MessageEditorService>()
+        notificationAccessService = mock<NotificationAccessService>()
+        waterStatisticService = mock<WaterStatisticService>()
         clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)
         service = NotificationSenderServiceImpl(
             sender,
@@ -86,9 +90,9 @@ class NotificationSenderServiceTest {
             notificationAttempts = 0,
             previousNotificationMessageId = 10
         )
-        val returnedMessage = mock(Message::class.java)
-        `when`(returnedMessage.messageId).thenReturn(2)
-        doReturn(returnedMessage).`when`(sender).execute(any<SendMessage>())
+        val returnedMessage = mock<Message>()
+        whenever(returnedMessage.messageId).thenReturn(2)
+        doReturn(returnedMessage).whenever(sender).execute(any<SendMessage>())
 
         service.sendNotifications(listOf(dto))
 
@@ -96,9 +100,9 @@ class NotificationSenderServiceTest {
             .minusMinutes(IntervalNotificationType.HOUR.minutes)
             .plusMinutes(retryIntervalMinutes)
 
-        verify(messageEditorService).deleteMessages(anyCollection())
+        verify(messageEditorService).deleteMessages(any())
         verify(sender).execute(any<SendMessage>())
-        verify(notificationAccessService).updateNotificationSettings(anyCollection())
+        verify(notificationAccessService).updateNotificationSettings(any())
         assertEquals(1, dto.notificationAttempts)
         assertEquals(2, dto.telegramChat.previousNotificationMessageId)
         assertEquals(expectedTimeOfLastNotification, dto.timeOfLastNotification)
@@ -108,14 +112,14 @@ class NotificationSenderServiceTest {
     @DisplayName("sendNotifications(): 403 error - disables user and excludes from settings update")
     fun `sendNotifications on 403 disables notifications`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
-        val exception = mock(TelegramApiRequestException::class.java)
-        `when`(exception.errorCode).thenReturn(403)
-        doThrow(exception).`when`(sender).execute(any<SendMessage>())
+        val exception = mock<TelegramApiRequestException>()
+        whenever(exception.errorCode).thenReturn(403)
+        doThrow(exception).whenever(sender).execute(any<SendMessage>())
 
         service.sendNotifications(listOf(dto))
 
         verify(notificationAccessService).updateNotificationsDisabled(externalUserId)
-        verify(notificationAccessService).updateNotificationSettings(anyCollection())
+        verify(notificationAccessService).updateNotificationSettings(any())
     }
 
     @Test
@@ -140,9 +144,9 @@ class NotificationSenderServiceTest {
 
         service.suspendNotifications(listOf(dto))
 
-        verify(messageEditorService).deleteMessages(anyCollection())
+        verify(messageEditorService).deleteMessages(any())
         verify(sender).execute(any<SendMessage>())
-        verify(notificationAccessService).updateNotificationSettings(anyCollection())
+        verify(notificationAccessService).updateNotificationSettings(any())
         assertEquals(0, dto.notificationAttempts)
         assertNull(dto.telegramChat.previousNotificationMessageId)
     }
@@ -161,23 +165,23 @@ class NotificationSenderServiceTest {
     @DisplayName("suspendNotifications(): 403 error - disables user and excludes from settings update")
     fun `suspendNotifications on 403 disables notifications`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
-        val exception = mock(TelegramApiRequestException::class.java)
-        `when`(exception.errorCode).thenReturn(403)
-        doThrow(exception).`when`(sender).execute(any<SendMessage>())
+        val exception = mock<TelegramApiRequestException>()
+        whenever(exception.errorCode).thenReturn(403)
+        doThrow(exception).whenever(sender).execute(any<SendMessage>())
 
         service.suspendNotifications(listOf(dto))
 
         verify(notificationAccessService).updateNotificationsDisabled(externalUserId)
-        verify(notificationAccessService).updateNotificationSettings(anyCollection())
+        verify(notificationAccessService).updateNotificationSettings(any())
     }
 
     @Test
     @DisplayName("sendNotifications(): non-403 error - rethrows exception")
     fun `sendNotifications rethrows non-403 exception`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
-        val exception = mock(TelegramApiRequestException::class.java)
-        `when`(exception.errorCode).thenReturn(500)
-        doThrow(exception).`when`(sender).execute(any<SendMessage>())
+        val exception = mock<TelegramApiRequestException>()
+        whenever(exception.errorCode).thenReturn(500)
+        doThrow(exception).whenever(sender).execute(any<SendMessage>())
 
         assertThrows(TelegramApiRequestException::class.java) {
             service.sendNotifications(listOf(dto))
@@ -188,9 +192,9 @@ class NotificationSenderServiceTest {
     @DisplayName("sendNotifications(): null errorCode - rethrows exception")
     fun `sendNotifications rethrows null errorCode exception`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
-        val exception = mock(TelegramApiRequestException::class.java)
-        doReturn(null).`when`(exception).errorCode
-        doThrow(exception).`when`(sender).execute(any<SendMessage>())
+        val exception = mock<TelegramApiRequestException>()
+        doReturn(null).whenever(exception).errorCode
+        doThrow(exception).whenever(sender).execute(any<SendMessage>())
 
         assertThrows(TelegramApiRequestException::class.java) {
             service.sendNotifications(listOf(dto))
@@ -201,9 +205,9 @@ class NotificationSenderServiceTest {
     @DisplayName("suspendNotifications(): non-403 error - rethrows exception")
     fun `suspendNotifications rethrows non-403 exception`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
-        val exception = mock(TelegramApiRequestException::class.java)
-        `when`(exception.errorCode).thenReturn(500)
-        doThrow(exception).`when`(sender).execute(any<SendMessage>())
+        val exception = mock<TelegramApiRequestException>()
+        whenever(exception.errorCode).thenReturn(500)
+        doThrow(exception).whenever(sender).execute(any<SendMessage>())
 
         assertThrows(TelegramApiRequestException::class.java) {
             service.suspendNotifications(listOf(dto))

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
@@ -114,7 +114,7 @@ class NotificationSenderServiceTest {
 
         service.sendNotifications(listOf(dto))
 
-        verify(notificationAccessService).disableNotifications(externalUserId)
+        verify(notificationAccessService).updateNotificationsDisabled(externalUserId)
         verify(notificationAccessService).updateNotificationSettings(anyCollection())
     }
 
@@ -167,7 +167,7 @@ class NotificationSenderServiceTest {
 
         service.suspendNotifications(listOf(dto))
 
-        verify(notificationAccessService).disableNotifications(externalUserId)
+        verify(notificationAccessService).updateNotificationsDisabled(externalUserId)
         verify(notificationAccessService).updateNotificationSettings(anyCollection())
     }
 
@@ -208,6 +208,6 @@ class NotificationSenderServiceTest {
         assertThrows(TelegramApiRequestException::class.java) {
             service.suspendNotifications(listOf(dto))
         }
-        verify(notificationAccessService, never()).disableNotifications(any())
+        verify(notificationAccessService, never()).updateNotificationsDisabled(any())
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
@@ -1,6 +1,8 @@
 package ru.illine.drinking.ponies.service.notification
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -33,19 +35,19 @@ import java.time.ZoneOffset
 @UnitTest
 @DisplayName("NotificationSenderService Unit Test")
 class NotificationSenderServiceTest {
-
     private val externalUserId = 1L
     private val chatId = 2L
 
     private val retryIntervalMinutes = 1L
-    private val botProperties = TelegramBotProperties(
-        token = "token",
-        username = "username",
-        miniAppUrl = "https://t.me/Test/app",
-        autoUpdateTelegramConfig = true,
-        http = TelegramBotProperties.Http(connectionTimeToLiveInSec = 30, maxConnectionTotal = 10),
-        notification = TelegramBotProperties.Notification(retryIntervalMinutes = retryIntervalMinutes)
-    )
+    private val botProperties =
+        TelegramBotProperties(
+            token = "token",
+            username = "username",
+            miniAppUrl = "https://t.me/Test/app",
+            autoUpdateTelegramConfig = true,
+            http = TelegramBotProperties.Http(connectionTimeToLiveInSec = 30, maxConnectionTotal = 10),
+            notification = TelegramBotProperties.Notification(retryIntervalMinutes = retryIntervalMinutes),
+        )
 
     private lateinit var sender: TelegramClient
     private lateinit var messageEditorService: MessageEditorService
@@ -61,14 +63,15 @@ class NotificationSenderServiceTest {
         notificationAccessService = mock<NotificationAccessService>()
         waterStatisticService = mock<WaterStatisticService>()
         clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)
-        service = NotificationSenderServiceImpl(
-            sender,
-            messageEditorService,
-            notificationAccessService,
-            botProperties,
-            waterStatisticService,
-            clock
-        )
+        service =
+            NotificationSenderServiceImpl(
+                sender,
+                messageEditorService,
+                notificationAccessService,
+                botProperties,
+                waterStatisticService,
+                clock,
+            )
     }
 
     @Test
@@ -84,21 +87,24 @@ class NotificationSenderServiceTest {
     @Test
     @DisplayName("sendNotifications(): sends notification messages, increments attempts, updates settings")
     fun `sendNotifications sends and updates`() {
-        val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = externalUserId,
-            externalChatId = chatId,
-            notificationAttempts = 0,
-            previousNotificationMessageId = 10
-        )
+        val dto =
+            DtoGenerator.generateNotificationDto(
+                externalUserId = externalUserId,
+                externalChatId = chatId,
+                notificationAttempts = 0,
+                previousNotificationMessageId = 10,
+            )
         val returnedMessage = mock<Message>()
         whenever(returnedMessage.messageId).thenReturn(2)
         doReturn(returnedMessage).whenever(sender).execute(any<SendMessage>())
 
         service.sendNotifications(listOf(dto))
 
-        val expectedTimeOfLastNotification = LocalDateTime.now(clock)
-            .minusMinutes(IntervalNotificationType.HOUR.minutes)
-            .plusMinutes(retryIntervalMinutes)
+        val expectedTimeOfLastNotification =
+            LocalDateTime
+                .now(clock)
+                .minusMinutes(IntervalNotificationType.HOUR.minutes)
+                .plusMinutes(retryIntervalMinutes)
 
         verify(messageEditorService).deleteMessages(any())
         verify(sender).execute(any<SendMessage>())
@@ -135,12 +141,13 @@ class NotificationSenderServiceTest {
     @Test
     @DisplayName("suspendNotifications(): sends suspend message, resets attempts and time, updates settings")
     fun `suspendNotifications sends and updates`() {
-        val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = externalUserId,
-            externalChatId = chatId,
-            notificationAttempts = 3,
-            previousNotificationMessageId = 10
-        )
+        val dto =
+            DtoGenerator.generateNotificationDto(
+                externalUserId = externalUserId,
+                externalChatId = chatId,
+                notificationAttempts = 3,
+                previousNotificationMessageId = 10,
+            )
 
         service.suspendNotifications(listOf(dto))
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
@@ -29,7 +29,7 @@ import java.time.ZoneOffset
 @DisplayName("NotificationSenderService Unit Test")
 class NotificationSenderServiceTest {
 
-    private val userId = 1L
+    private val externalUserId = 1L
     private val chatId = 2L
 
     private val retryIntervalMinutes = 1L
@@ -81,7 +81,7 @@ class NotificationSenderServiceTest {
     @DisplayName("sendNotifications(): sends notification messages, increments attempts, updates settings")
     fun `sendNotifications sends and updates`() {
         val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
+            externalUserId = externalUserId,
             externalChatId = chatId,
             notificationAttempts = 0,
             previousNotificationMessageId = 10
@@ -107,14 +107,14 @@ class NotificationSenderServiceTest {
     @Test
     @DisplayName("sendNotifications(): 403 error - disables user and excludes from settings update")
     fun `sendNotifications on 403 disables notifications`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
         val exception = mock(TelegramApiRequestException::class.java)
         `when`(exception.errorCode).thenReturn(403)
         doThrow(exception).`when`(sender).execute(any<SendMessage>())
 
         service.sendNotifications(listOf(dto))
 
-        verify(notificationAccessService).disableNotifications(userId)
+        verify(notificationAccessService).disableNotifications(externalUserId)
         verify(notificationAccessService).updateNotificationSettings(anyCollection())
     }
 
@@ -132,7 +132,7 @@ class NotificationSenderServiceTest {
     @DisplayName("suspendNotifications(): sends suspend message, resets attempts and time, updates settings")
     fun `suspendNotifications sends and updates`() {
         val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
+            externalUserId = externalUserId,
             externalChatId = chatId,
             notificationAttempts = 3,
             previousNotificationMessageId = 10
@@ -150,7 +150,7 @@ class NotificationSenderServiceTest {
     @Test
     @DisplayName("suspendNotifications(): records water statistic events for each sent notification")
     fun `suspendNotifications records water statistics`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
 
         service.suspendNotifications(listOf(dto))
 
@@ -160,21 +160,21 @@ class NotificationSenderServiceTest {
     @Test
     @DisplayName("suspendNotifications(): 403 error - disables user and excludes from settings update")
     fun `suspendNotifications on 403 disables notifications`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
         val exception = mock(TelegramApiRequestException::class.java)
         `when`(exception.errorCode).thenReturn(403)
         doThrow(exception).`when`(sender).execute(any<SendMessage>())
 
         service.suspendNotifications(listOf(dto))
 
-        verify(notificationAccessService).disableNotifications(userId)
+        verify(notificationAccessService).disableNotifications(externalUserId)
         verify(notificationAccessService).updateNotificationSettings(anyCollection())
     }
 
     @Test
     @DisplayName("sendNotifications(): non-403 error - rethrows exception")
     fun `sendNotifications rethrows non-403 exception`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
         val exception = mock(TelegramApiRequestException::class.java)
         `when`(exception.errorCode).thenReturn(500)
         doThrow(exception).`when`(sender).execute(any<SendMessage>())
@@ -187,7 +187,7 @@ class NotificationSenderServiceTest {
     @Test
     @DisplayName("sendNotifications(): null errorCode - rethrows exception")
     fun `sendNotifications rethrows null errorCode exception`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
         val exception = mock(TelegramApiRequestException::class.java)
         doReturn(null).`when`(exception).errorCode
         doThrow(exception).`when`(sender).execute(any<SendMessage>())
@@ -200,7 +200,7 @@ class NotificationSenderServiceTest {
     @Test
     @DisplayName("suspendNotifications(): non-403 error - rethrows exception")
     fun `suspendNotifications rethrows non-403 exception`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, externalChatId = chatId)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
         val exception = mock(TelegramApiRequestException::class.java)
         `when`(exception.errorCode).thenReturn(500)
         doThrow(exception).`when`(sender).execute(any<SendMessage>())

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
@@ -19,7 +19,7 @@ import ru.illine.drinking.ponies.test.tag.UnitTest
 @DisplayName("NotificationService Unit Test")
 class NotificationServiceTest {
 
-    private val userId = 1L
+    private val externalUserId = 1L
     private val chatId = 2L
 
     private lateinit var sender: TelegramClient
@@ -39,34 +39,34 @@ class NotificationServiceTest {
     @Test
     @DisplayName("start(): existing user - sends greeting and default settings, finds existing settings")
     fun `start existing user`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        doReturn(true).`when`(notificationAccessService).existsByTelegramUserId(userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        doReturn(true).`when`(notificationAccessService).existsByExternalUserId(externalUserId)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         service.start(buildMessageContext())
 
         verify(sender, times(2)).execute(any<SendMessage>())
-        verify(notificationAccessService).findNotificationSettingByTelegramUserId(userId)
+        verify(notificationAccessService).findNotificationSettingByExternalUserId(externalUserId)
         verify(notificationAccessService, never()).save(any(), any(), any())
     }
 
     @Test
     @DisplayName("start(): new user - creates user, saves settings, sends default settings message")
     fun `start new user`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        doReturn(false).`when`(notificationAccessService).existsByTelegramUserId(userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        doReturn(false).`when`(notificationAccessService).existsByExternalUserId(externalUserId)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         service.start(buildMessageContext())
 
         verify(notificationAccessService).save(any(), any(), any())
-        verify(notificationAccessService).findNotificationSettingByTelegramUserId(userId)
+        verify(notificationAccessService).findNotificationSettingByExternalUserId(externalUserId)
         verify(sender, times(2)).execute(any<SendMessage>())
     }
 
     private fun buildMessageContext(): MessageContext {
         val user = mock(User::class.java)
-        `when`(user.id).thenReturn(userId)
+        `when`(user.id).thenReturn(externalUserId)
         `when`(user.userName).thenReturn("testUser")
 
         val context = mock(MessageContext::class.java)

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
@@ -3,9 +3,13 @@ package ru.illine.drinking.ponies.service.notification
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.abilitybots.api.objects.MessageContext
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.User
@@ -28,8 +32,8 @@ class NotificationServiceTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
-        notificationAccessService = mock(NotificationAccessService::class.java)
+        sender = mock<TelegramClient>()
+        notificationAccessService = mock<NotificationAccessService>()
         service = NotificationServiceImpl(
             sender,
             notificationAccessService
@@ -40,8 +44,8 @@ class NotificationServiceTest {
     @DisplayName("start(): existing user - sends greeting and default settings, finds existing settings")
     fun `start existing user`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        doReturn(true).`when`(notificationAccessService).existsByExternalUserId(externalUserId)
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        doReturn(true).whenever(notificationAccessService).existsByExternalUserId(externalUserId)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         service.start(buildMessageContext())
 
@@ -54,8 +58,8 @@ class NotificationServiceTest {
     @DisplayName("start(): new user - creates user, saves settings, sends default settings message")
     fun `start new user`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        doReturn(false).`when`(notificationAccessService).existsByExternalUserId(externalUserId)
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        doReturn(false).whenever(notificationAccessService).existsByExternalUserId(externalUserId)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         service.start(buildMessageContext())
 
@@ -65,13 +69,13 @@ class NotificationServiceTest {
     }
 
     private fun buildMessageContext(): MessageContext {
-        val user = mock(User::class.java)
-        `when`(user.id).thenReturn(externalUserId)
-        `when`(user.userName).thenReturn("testUser")
+        val user = mock<User>()
+        whenever(user.id).thenReturn(externalUserId)
+        whenever(user.userName).thenReturn("testUser")
 
-        val context = mock(MessageContext::class.java)
-        `when`(context.user()).thenReturn(user)
-        `when`(context.chatId()).thenReturn(chatId)
+        val context = mock<MessageContext>()
+        whenever(context.user()).thenReturn(user)
+        whenever(context.chatId()).thenReturn(chatId)
         return context
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
@@ -22,7 +22,6 @@ import ru.illine.drinking.ponies.test.tag.UnitTest
 @UnitTest
 @DisplayName("NotificationService Unit Test")
 class NotificationServiceTest {
-
     private val externalUserId = 1L
     private val chatId = 2L
 
@@ -34,10 +33,11 @@ class NotificationServiceTest {
     fun setUp() {
         sender = mock<TelegramClient>()
         notificationAccessService = mock<NotificationAccessService>()
-        service = NotificationServiceImpl(
-            sender,
-            notificationAccessService
-        )
+        service =
+            NotificationServiceImpl(
+                sender,
+                notificationAccessService,
+            )
     }
 
     @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsServiceTest.kt
@@ -7,7 +7,12 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import org.mockito.Mockito.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.service.notification.impl.NotificationSettingsServiceImpl
@@ -28,8 +33,8 @@ class NotificationSettingsServiceTest {
 
     @BeforeEach
     fun setUp() {
-        notificationAccessService = mock(NotificationAccessService::class.java)
-        notificationTimeService = mock(NotificationTimeService::class.java)
+        notificationAccessService = mock<NotificationAccessService>()
+        notificationTimeService = mock<NotificationTimeService>()
         clock = Clock.fixed(Instant.parse("2025-01-01T12:00:00Z"), ZoneOffset.UTC)
         service = NotificationSettingsServiceImpl(notificationAccessService, notificationTimeService, clock)
     }
@@ -67,7 +72,7 @@ class NotificationSettingsServiceTest {
     @DisplayName("getNotificationSettings(): delegates to access service")
     fun `getNotificationSettings delegates to access service`() {
         val expected = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(expected)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(expected)
 
         val result = service.getNotificationSettings(externalUserId)
 
@@ -79,7 +84,7 @@ class NotificationSettingsServiceTest {
     @DisplayName("getAllNotificationSettings(): delegates to access service")
     fun `getAllNotificationSettings delegates to access service`() {
         val expected = setOf(DtoGenerator.generateNotificationDto())
-        `when`(notificationAccessService.findAllNotificationSettings()).thenReturn(expected)
+        whenever(notificationAccessService.findAllNotificationSettings()).thenReturn(expected)
 
         val result = service.getAllNotificationSettings()
 
@@ -92,7 +97,7 @@ class NotificationSettingsServiceTest {
     fun `resetNotificationTimer delegates to access service`() {
         val time = LocalDateTime.of(2026, 4, 5, 12, 0)
         val expected = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(externalUserId, time)).thenReturn(expected)
+        whenever(notificationAccessService.updateTimeOfLastNotification(externalUserId, time)).thenReturn(expected)
 
         val result = service.resetNotificationTimer(externalUserId, time)
 
@@ -103,7 +108,7 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("isEnabledNotifications(): delegates to access service")
     fun `isEnabledNotifications delegates to access service`() {
-        `when`(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(true)
+        whenever(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(true)
 
         val result = service.isEnabledNotifications(externalUserId)
 
@@ -114,7 +119,7 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("isEnabledNotifications(): returns false when disabled")
     fun `isEnabledNotifications returns false when disabled`() {
-        `when`(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(false)
+        whenever(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(false)
 
         val result = service.isEnabledNotifications(externalUserId)
 
@@ -127,7 +132,7 @@ class NotificationSettingsServiceTest {
     fun `changeInterval delegates to access service`() {
         val interval = IntervalNotificationType.TWO_HOURS
         val expected = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
-        `when`(notificationAccessService.updateNotificationSettings(externalUserId, interval)).thenReturn(expected)
+        whenever(notificationAccessService.updateNotificationSettings(externalUserId, interval)).thenReturn(expected)
 
         val result = service.changeInterval(externalUserId, interval)
 
@@ -145,7 +150,7 @@ class NotificationSettingsServiceTest {
             quietModeStart = expectedStart,
             quietModeEnd = expectedEnd
         )
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         val result = service.getQuietMode(externalUserId)
 
@@ -161,7 +166,7 @@ class NotificationSettingsServiceTest {
             quietModeStart = null,
             quietModeEnd = LocalTime.of(8, 0)
         )
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         assertThrows(IllegalStateException::class.java) {
             service.getQuietMode(externalUserId)
@@ -176,7 +181,7 @@ class NotificationSettingsServiceTest {
             quietModeStart = LocalTime.of(23, 0),
             quietModeEnd = null
         )
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         assertThrows(IllegalStateException::class.java) {
             service.getQuietMode(externalUserId)
@@ -189,7 +194,7 @@ class NotificationSettingsServiceTest {
         service.changeNotificationStatus(externalUserId, true)
 
         verify(notificationAccessService).updateNotificationsEnabled(externalUserId)
-        verify(notificationAccessService, never()).updateNotificationsDisabled(anyLong())
+        verify(notificationAccessService, never()).updateNotificationsDisabled(any<Long>())
     }
 
     @Test
@@ -198,7 +203,7 @@ class NotificationSettingsServiceTest {
         service.changeNotificationStatus(externalUserId, false)
 
         verify(notificationAccessService).updateNotificationsDisabled(externalUserId)
-        verify(notificationAccessService, never()).updateNotificationsEnabled(anyLong())
+        verify(notificationAccessService, never()).updateNotificationsEnabled(any<Long>())
     }
 
     @Test
@@ -219,7 +224,7 @@ class NotificationSettingsServiceTest {
             service.changeTimezone(externalUserId, timezone)
         }
 
-        verify(notificationAccessService, never()).updateTimezone(anyLong(), anyString())
+        verify(notificationAccessService, never()).updateTimezone(any<Long>(), any<String>())
     }
 
     @Test
@@ -227,8 +232,8 @@ class NotificationSettingsServiceTest {
     fun `getNextNotificationAt delegates to time service`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
         val expectedInstant = Instant.parse("2025-01-01T11:00:00Z")
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
-        `when`(notificationTimeService.calculateNextNotificationAt(dto)).thenReturn(expectedInstant)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationTimeService.calculateNextNotificationAt(dto)).thenReturn(expectedInstant)
 
         val result = service.getNextNotificationAt(externalUserId)
 
@@ -240,7 +245,7 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("getAllSettings(): returns SettingDto with all fields when notifications are enabled")
     fun `getAllSettings returns full dto when enabled`() {
-        `when`(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(true)
+        whenever(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(true)
         val notificationDto = DtoGenerator.generateNotificationDto(
             externalUserId = externalUserId,
             notificationInterval = IntervalNotificationType.HOUR,
@@ -248,7 +253,7 @@ class NotificationSettingsServiceTest {
             quietModeStart = LocalTime.of(23, 0),
             quietModeEnd = LocalTime.of(8, 0),
         )
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(notificationDto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(notificationDto)
 
         val result = service.getAllSettings(externalUserId)
 
@@ -267,7 +272,7 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("getAllSettings(): returns SettingDto with only notificationActive=false when notifications are disabled")
     fun `getAllSettings returns minimal dto when disabled`() {
-        `when`(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(false)
+        whenever(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(false)
 
         val result = service.getAllSettings(externalUserId)
 
@@ -280,7 +285,7 @@ class NotificationSettingsServiceTest {
         assertEquals(null, result.timezone)
         assertEquals(null, result.dailyGoalMl)
         verify(notificationAccessService).findIsEnabledNotificationsByExternalUserId(externalUserId)
-        verify(notificationAccessService, never()).findNotificationSettingByExternalUserId(anyLong())
+        verify(notificationAccessService, never()).findNotificationSettingByExternalUserId(any<Long>())
     }
 
     @Test
@@ -302,7 +307,7 @@ class NotificationSettingsServiceTest {
             service.pauseNotifications(externalUserId, minutes)
         }
 
-        verify(notificationAccessService, never()).updatePause(anyLong(), any())
+        verify(notificationAccessService, never()).updatePause(any<Long>(), anyOrNull())
     }
 
     @Test
@@ -318,7 +323,7 @@ class NotificationSettingsServiceTest {
     fun `getPauseState returns paused true when active`() {
         val pauseUntil = LocalDateTime.of(2025, 1, 1, 13, 0)
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, pauseUntil = pauseUntil)
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         val result = service.getPauseState(externalUserId)
 
@@ -331,7 +336,7 @@ class NotificationSettingsServiceTest {
     fun `getPauseState returns paused false when pauseUntil expired`() {
         val pauseUntil = LocalDateTime.of(2025, 1, 1, 11, 0)
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, pauseUntil = pauseUntil)
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         val result = service.getPauseState(externalUserId)
 
@@ -343,7 +348,7 @@ class NotificationSettingsServiceTest {
     @DisplayName("getPauseState(): returns paused=false and null pauseUntil when pauseUntil is null")
     fun `getPauseState returns paused false when pauseUntil null`() {
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, pauseUntil = null)
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         val result = service.getPauseState(externalUserId)
 
@@ -356,7 +361,7 @@ class NotificationSettingsServiceTest {
     fun `getPauseState returns paused false when pauseUntil equals now`() {
         val pauseUntil = LocalDateTime.of(2025, 1, 1, 12, 0)
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, pauseUntil = pauseUntil)
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         val result = service.getPauseState(externalUserId)
 
@@ -404,7 +409,7 @@ class NotificationSettingsServiceTest {
             service.changeDailyGoal(externalUserId, goalMl)
         }
 
-        verify(notificationAccessService, never()).updateDailyGoal(anyLong(), anyInt())
+        verify(notificationAccessService, never()).updateDailyGoal(any<Long>(), any<Int>())
     }
 
     @Test
@@ -416,7 +421,7 @@ class NotificationSettingsServiceTest {
             pauseUntil = pauseUntil,
             notificationAttempts = 3
         )
-        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         val result = service.getPauseState(externalUserId)
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsServiceTest.kt
@@ -42,7 +42,7 @@ class NotificationSettingsServiceTest {
 
         service.changeQuietMode(externalUserId, start, end)
 
-        verify(notificationAccessService).changeQuietMode(externalUserId, start, end)
+        verify(notificationAccessService).updateQuietMode(externalUserId, start, end)
     }
 
     @Test
@@ -60,7 +60,7 @@ class NotificationSettingsServiceTest {
     fun `disableQuietMode disables quiet mode`() {
         service.disableQuietMode(externalUserId)
 
-        verify(notificationAccessService).disableQuietMode(externalUserId)
+        verify(notificationAccessService).updateQuietModeDisabled(externalUserId)
     }
 
     @Test
@@ -103,23 +103,23 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("isEnabledNotifications(): delegates to access service")
     fun `isEnabledNotifications delegates to access service`() {
-        `when`(notificationAccessService.isEnabledNotifications(externalUserId)).thenReturn(true)
+        `when`(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(true)
 
         val result = service.isEnabledNotifications(externalUserId)
 
         assertEquals(true, result)
-        verify(notificationAccessService).isEnabledNotifications(externalUserId)
+        verify(notificationAccessService).findIsEnabledNotificationsByExternalUserId(externalUserId)
     }
 
     @Test
     @DisplayName("isEnabledNotifications(): returns false when disabled")
     fun `isEnabledNotifications returns false when disabled`() {
-        `when`(notificationAccessService.isEnabledNotifications(externalUserId)).thenReturn(false)
+        `when`(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(false)
 
         val result = service.isEnabledNotifications(externalUserId)
 
         assertEquals(false, result)
-        verify(notificationAccessService).isEnabledNotifications(externalUserId)
+        verify(notificationAccessService).findIsEnabledNotificationsByExternalUserId(externalUserId)
     }
 
     @Test
@@ -188,8 +188,8 @@ class NotificationSettingsServiceTest {
     fun `changeNotificationStatus enables when active true`() {
         service.changeNotificationStatus(externalUserId, true)
 
-        verify(notificationAccessService).enableNotifications(externalUserId)
-        verify(notificationAccessService, never()).disableNotifications(anyLong())
+        verify(notificationAccessService).updateNotificationsEnabled(externalUserId)
+        verify(notificationAccessService, never()).updateNotificationsDisabled(anyLong())
     }
 
     @Test
@@ -197,8 +197,8 @@ class NotificationSettingsServiceTest {
     fun `changeNotificationStatus disables when active false`() {
         service.changeNotificationStatus(externalUserId, false)
 
-        verify(notificationAccessService).disableNotifications(externalUserId)
-        verify(notificationAccessService, never()).enableNotifications(anyLong())
+        verify(notificationAccessService).updateNotificationsDisabled(externalUserId)
+        verify(notificationAccessService, never()).updateNotificationsEnabled(anyLong())
     }
 
     @Test
@@ -208,7 +208,7 @@ class NotificationSettingsServiceTest {
 
         service.changeTimezone(externalUserId, timezone)
 
-        verify(notificationAccessService).changeTimezone(externalUserId, timezone)
+        verify(notificationAccessService).updateTimezone(externalUserId, timezone)
     }
 
     @ParameterizedTest
@@ -219,7 +219,7 @@ class NotificationSettingsServiceTest {
             service.changeTimezone(externalUserId, timezone)
         }
 
-        verify(notificationAccessService, never()).changeTimezone(anyLong(), anyString())
+        verify(notificationAccessService, never()).updateTimezone(anyLong(), anyString())
     }
 
     @Test
@@ -240,7 +240,7 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("getAllSettings(): returns SettingDto with all fields when notifications are enabled")
     fun `getAllSettings returns full dto when enabled`() {
-        `when`(notificationAccessService.isEnabledNotifications(externalUserId)).thenReturn(true)
+        `when`(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(true)
         val notificationDto = DtoGenerator.generateNotificationDto(
             externalUserId = externalUserId,
             notificationInterval = IntervalNotificationType.HOUR,
@@ -260,14 +260,14 @@ class NotificationSettingsServiceTest {
         assertEquals("08:00", result.quietModeEnd)
         assertEquals("Europe/Moscow", result.timezone)
         assertEquals(2000, result.dailyGoalMl)
-        verify(notificationAccessService).isEnabledNotifications(externalUserId)
+        verify(notificationAccessService).findIsEnabledNotificationsByExternalUserId(externalUserId)
         verify(notificationAccessService).findNotificationSettingByExternalUserId(externalUserId)
     }
 
     @Test
     @DisplayName("getAllSettings(): returns SettingDto with only notificationActive=false when notifications are disabled")
     fun `getAllSettings returns minimal dto when disabled`() {
-        `when`(notificationAccessService.isEnabledNotifications(externalUserId)).thenReturn(false)
+        `when`(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(false)
 
         val result = service.getAllSettings(externalUserId)
 
@@ -279,7 +279,7 @@ class NotificationSettingsServiceTest {
         assertEquals(null, result.quietModeEnd)
         assertEquals(null, result.timezone)
         assertEquals(null, result.dailyGoalMl)
-        verify(notificationAccessService).isEnabledNotifications(externalUserId)
+        verify(notificationAccessService).findIsEnabledNotificationsByExternalUserId(externalUserId)
         verify(notificationAccessService, never()).findNotificationSettingByExternalUserId(anyLong())
     }
 
@@ -291,7 +291,7 @@ class NotificationSettingsServiceTest {
 
         service.pauseNotifications(externalUserId, minutes)
 
-        verify(notificationAccessService).setPause(externalUserId, expectedPauseUntil)
+        verify(notificationAccessService).updatePause(externalUserId, expectedPauseUntil)
     }
 
     @ParameterizedTest
@@ -302,7 +302,7 @@ class NotificationSettingsServiceTest {
             service.pauseNotifications(externalUserId, minutes)
         }
 
-        verify(notificationAccessService, never()).setPause(anyLong(), any())
+        verify(notificationAccessService, never()).updatePause(anyLong(), any())
     }
 
     @Test
@@ -310,7 +310,7 @@ class NotificationSettingsServiceTest {
     fun `cancelPause delegates with null`() {
         service.cancelPause(externalUserId)
 
-        verify(notificationAccessService).setPause(externalUserId, null)
+        verify(notificationAccessService).updatePause(externalUserId, null)
     }
 
     @Test
@@ -375,8 +375,8 @@ class NotificationSettingsServiceTest {
         service.pauseNotifications(externalUserId, firstMinutes)
         service.pauseNotifications(externalUserId, secondMinutes)
 
-        verify(notificationAccessService).setPause(externalUserId, firstExpected)
-        verify(notificationAccessService).setPause(externalUserId, secondExpected)
+        verify(notificationAccessService).updatePause(externalUserId, firstExpected)
+        verify(notificationAccessService).updatePause(externalUserId, secondExpected)
     }
 
     @Test
@@ -384,7 +384,7 @@ class NotificationSettingsServiceTest {
     fun `pauseNotifications does not cancel`() {
         service.pauseNotifications(externalUserId, 30L)
 
-        verify(notificationAccessService, never()).setPause(externalUserId, null)
+        verify(notificationAccessService, never()).updatePause(externalUserId, null)
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsServiceTest.kt
@@ -19,7 +19,7 @@ import java.time.*
 @DisplayName("NotificationSettingsService Unit Test")
 class NotificationSettingsServiceTest {
 
-    private val userId = 1L
+    private val externalUserId = 1L
 
     private lateinit var notificationAccessService: NotificationAccessService
     private lateinit var notificationTimeService: NotificationTimeService
@@ -40,9 +40,9 @@ class NotificationSettingsServiceTest {
         val start = LocalTime.of(22, 0)
         val end = LocalTime.of(8, 0)
 
-        service.changeQuietMode(userId, start, end)
+        service.changeQuietMode(externalUserId, start, end)
 
-        verify(notificationAccessService).changeQuietMode(userId, start, end)
+        verify(notificationAccessService).changeQuietMode(externalUserId, start, end)
     }
 
     @Test
@@ -51,28 +51,28 @@ class NotificationSettingsServiceTest {
         val time = LocalTime.of(10, 0)
 
         assertThrows(IllegalArgumentException::class.java) {
-            service.changeQuietMode(userId, time, time)
+            service.changeQuietMode(externalUserId, time, time)
         }
     }
 
     @Test
     @DisplayName("disableQuietMode(): disables quiet mode via access service")
     fun `disableQuietMode disables quiet mode`() {
-        service.disableQuietMode(userId)
+        service.disableQuietMode(externalUserId)
 
-        verify(notificationAccessService).disableQuietMode(userId)
+        verify(notificationAccessService).disableQuietMode(externalUserId)
     }
 
     @Test
     @DisplayName("getNotificationSettings(): delegates to access service")
     fun `getNotificationSettings delegates to access service`() {
-        val expected = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(expected)
+        val expected = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(expected)
 
-        val result = service.getNotificationSettings(userId)
+        val result = service.getNotificationSettings(externalUserId)
 
         assertEquals(expected, result)
-        verify(notificationAccessService).findNotificationSettingByTelegramUserId(userId)
+        verify(notificationAccessService).findNotificationSettingByExternalUserId(externalUserId)
     }
 
     @Test
@@ -91,48 +91,48 @@ class NotificationSettingsServiceTest {
     @DisplayName("resetNotificationTimer(): delegates to access service and returns DTO")
     fun `resetNotificationTimer delegates to access service`() {
         val time = LocalDateTime.of(2026, 4, 5, 12, 0)
-        val expected = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateTimeOfLastNotification(userId, time)).thenReturn(expected)
+        val expected = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationAccessService.updateTimeOfLastNotification(externalUserId, time)).thenReturn(expected)
 
-        val result = service.resetNotificationTimer(userId, time)
+        val result = service.resetNotificationTimer(externalUserId, time)
 
         assertEquals(expected, result)
-        verify(notificationAccessService).updateTimeOfLastNotification(userId, time)
+        verify(notificationAccessService).updateTimeOfLastNotification(externalUserId, time)
     }
 
     @Test
     @DisplayName("isEnabledNotifications(): delegates to access service")
     fun `isEnabledNotifications delegates to access service`() {
-        `when`(notificationAccessService.isEnabledNotifications(userId)).thenReturn(true)
+        `when`(notificationAccessService.isEnabledNotifications(externalUserId)).thenReturn(true)
 
-        val result = service.isEnabledNotifications(userId)
+        val result = service.isEnabledNotifications(externalUserId)
 
         assertEquals(true, result)
-        verify(notificationAccessService).isEnabledNotifications(userId)
+        verify(notificationAccessService).isEnabledNotifications(externalUserId)
     }
 
     @Test
     @DisplayName("isEnabledNotifications(): returns false when disabled")
     fun `isEnabledNotifications returns false when disabled`() {
-        `when`(notificationAccessService.isEnabledNotifications(userId)).thenReturn(false)
+        `when`(notificationAccessService.isEnabledNotifications(externalUserId)).thenReturn(false)
 
-        val result = service.isEnabledNotifications(userId)
+        val result = service.isEnabledNotifications(externalUserId)
 
         assertEquals(false, result)
-        verify(notificationAccessService).isEnabledNotifications(userId)
+        verify(notificationAccessService).isEnabledNotifications(externalUserId)
     }
 
     @Test
     @DisplayName("changeInterval(): delegates to access service and returns DTO")
     fun `changeInterval delegates to access service`() {
         val interval = IntervalNotificationType.TWO_HOURS
-        val expected = DtoGenerator.generateNotificationDto(externalUserId = userId)
-        `when`(notificationAccessService.updateNotificationSettings(userId, interval)).thenReturn(expected)
+        val expected = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        `when`(notificationAccessService.updateNotificationSettings(externalUserId, interval)).thenReturn(expected)
 
-        val result = service.changeInterval(userId, interval)
+        val result = service.changeInterval(externalUserId, interval)
 
         assertEquals(expected, result)
-        verify(notificationAccessService).updateNotificationSettings(userId, interval)
+        verify(notificationAccessService).updateNotificationSettings(externalUserId, interval)
     }
 
     @Test
@@ -141,13 +141,13 @@ class NotificationSettingsServiceTest {
         val expectedStart = LocalTime.of(23, 0)
         val expectedEnd = LocalTime.of(8, 0)
         val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
+            externalUserId = externalUserId,
             quietModeStart = expectedStart,
             quietModeEnd = expectedEnd
         )
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
-        val result = service.getQuietMode(userId)
+        val result = service.getQuietMode(externalUserId)
 
         assertEquals(expectedStart, result.first)
         assertEquals(expectedEnd, result.second)
@@ -157,14 +157,14 @@ class NotificationSettingsServiceTest {
     @DisplayName("getQuietMode(): throws IllegalStateException when start is null")
     fun `getQuietMode throws when start is null`() {
         val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
+            externalUserId = externalUserId,
             quietModeStart = null,
             quietModeEnd = LocalTime.of(8, 0)
         )
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         assertThrows(IllegalStateException::class.java) {
-            service.getQuietMode(userId)
+            service.getQuietMode(externalUserId)
         }
     }
 
@@ -172,32 +172,32 @@ class NotificationSettingsServiceTest {
     @DisplayName("getQuietMode(): throws IllegalStateException when end is null")
     fun `getQuietMode throws when end is null`() {
         val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
+            externalUserId = externalUserId,
             quietModeStart = LocalTime.of(23, 0),
             quietModeEnd = null
         )
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         assertThrows(IllegalStateException::class.java) {
-            service.getQuietMode(userId)
+            service.getQuietMode(externalUserId)
         }
     }
 
     @Test
     @DisplayName("changeNotificationStatus(): enables notifications when active is true")
     fun `changeNotificationStatus enables when active true`() {
-        service.changeNotificationStatus(userId, true)
+        service.changeNotificationStatus(externalUserId, true)
 
-        verify(notificationAccessService).enableNotifications(userId)
+        verify(notificationAccessService).enableNotifications(externalUserId)
         verify(notificationAccessService, never()).disableNotifications(anyLong())
     }
 
     @Test
     @DisplayName("changeNotificationStatus(): disables notifications when active is false")
     fun `changeNotificationStatus disables when active false`() {
-        service.changeNotificationStatus(userId, false)
+        service.changeNotificationStatus(externalUserId, false)
 
-        verify(notificationAccessService).disableNotifications(userId)
+        verify(notificationAccessService).disableNotifications(externalUserId)
         verify(notificationAccessService, never()).enableNotifications(anyLong())
     }
 
@@ -206,9 +206,9 @@ class NotificationSettingsServiceTest {
     fun `changeTimezone updates timezone`() {
         val timezone = "America/New_York"
 
-        service.changeTimezone(userId, timezone)
+        service.changeTimezone(externalUserId, timezone)
 
-        verify(notificationAccessService).changeTimezone(userId, timezone)
+        verify(notificationAccessService).changeTimezone(externalUserId, timezone)
     }
 
     @ParameterizedTest
@@ -216,7 +216,7 @@ class NotificationSettingsServiceTest {
     @DisplayName("changeTimezone(): throws IllegalArgumentException for invalid timezone")
     fun `changeTimezone throws when invalid timezone`(timezone: String) {
         assertThrows(IllegalArgumentException::class.java) {
-            service.changeTimezone(userId, timezone)
+            service.changeTimezone(externalUserId, timezone)
         }
 
         verify(notificationAccessService, never()).changeTimezone(anyLong(), anyString())
@@ -225,32 +225,32 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("getNextNotificationAt(): delegates to time service and returns instant")
     fun `getNextNotificationAt delegates to time service`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
         val expectedInstant = Instant.parse("2025-01-01T11:00:00Z")
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
         `when`(notificationTimeService.calculateNextNotificationAt(dto)).thenReturn(expectedInstant)
 
-        val result = service.getNextNotificationAt(userId)
+        val result = service.getNextNotificationAt(externalUserId)
 
         assertEquals(expectedInstant, result)
-        verify(notificationAccessService).findNotificationSettingByTelegramUserId(userId)
+        verify(notificationAccessService).findNotificationSettingByExternalUserId(externalUserId)
         verify(notificationTimeService).calculateNextNotificationAt(dto)
     }
 
     @Test
     @DisplayName("getAllSettings(): returns SettingDto with all fields when notifications are enabled")
     fun `getAllSettings returns full dto when enabled`() {
-        `when`(notificationAccessService.isEnabledNotifications(userId)).thenReturn(true)
+        `when`(notificationAccessService.isEnabledNotifications(externalUserId)).thenReturn(true)
         val notificationDto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
+            externalUserId = externalUserId,
             notificationInterval = IntervalNotificationType.HOUR,
             userTimeZone = "Europe/Moscow",
             quietModeStart = LocalTime.of(23, 0),
             quietModeEnd = LocalTime.of(8, 0),
         )
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(notificationDto)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(notificationDto)
 
-        val result = service.getAllSettings(userId)
+        val result = service.getAllSettings(externalUserId)
 
         assertEquals(true, result.notificationActive)
         assertEquals(IntervalNotificationType.HOUR.name, result.interval)
@@ -260,16 +260,16 @@ class NotificationSettingsServiceTest {
         assertEquals("08:00", result.quietModeEnd)
         assertEquals("Europe/Moscow", result.timezone)
         assertEquals(2000, result.dailyGoalMl)
-        verify(notificationAccessService).isEnabledNotifications(userId)
-        verify(notificationAccessService).findNotificationSettingByTelegramUserId(userId)
+        verify(notificationAccessService).isEnabledNotifications(externalUserId)
+        verify(notificationAccessService).findNotificationSettingByExternalUserId(externalUserId)
     }
 
     @Test
     @DisplayName("getAllSettings(): returns SettingDto with only notificationActive=false when notifications are disabled")
     fun `getAllSettings returns minimal dto when disabled`() {
-        `when`(notificationAccessService.isEnabledNotifications(userId)).thenReturn(false)
+        `when`(notificationAccessService.isEnabledNotifications(externalUserId)).thenReturn(false)
 
-        val result = service.getAllSettings(userId)
+        val result = service.getAllSettings(externalUserId)
 
         assertEquals(false, result.notificationActive)
         assertEquals(null, result.interval)
@@ -279,8 +279,8 @@ class NotificationSettingsServiceTest {
         assertEquals(null, result.quietModeEnd)
         assertEquals(null, result.timezone)
         assertEquals(null, result.dailyGoalMl)
-        verify(notificationAccessService).isEnabledNotifications(userId)
-        verify(notificationAccessService, never()).findNotificationSettingByTelegramUserId(anyLong())
+        verify(notificationAccessService).isEnabledNotifications(externalUserId)
+        verify(notificationAccessService, never()).findNotificationSettingByExternalUserId(anyLong())
     }
 
     @Test
@@ -289,9 +289,9 @@ class NotificationSettingsServiceTest {
         val minutes = 240L
         val expectedPauseUntil = LocalDateTime.of(2025, 1, 1, 16, 0)
 
-        service.pauseNotifications(userId, minutes)
+        service.pauseNotifications(externalUserId, minutes)
 
-        verify(notificationAccessService).setPause(userId, expectedPauseUntil)
+        verify(notificationAccessService).setPause(externalUserId, expectedPauseUntil)
     }
 
     @ParameterizedTest
@@ -299,7 +299,7 @@ class NotificationSettingsServiceTest {
     @DisplayName("pauseNotifications(): throws IllegalArgumentException when minutes is not positive")
     fun `pauseNotifications throws when minutes not positive`(minutes: Long) {
         assertThrows(IllegalArgumentException::class.java) {
-            service.pauseNotifications(userId, minutes)
+            service.pauseNotifications(externalUserId, minutes)
         }
 
         verify(notificationAccessService, never()).setPause(anyLong(), any())
@@ -308,19 +308,19 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("cancelPause(): delegates to access service with null pauseUntil")
     fun `cancelPause delegates with null`() {
-        service.cancelPause(userId)
+        service.cancelPause(externalUserId)
 
-        verify(notificationAccessService).setPause(userId, null)
+        verify(notificationAccessService).setPause(externalUserId, null)
     }
 
     @Test
     @DisplayName("getPauseState(): returns paused=true and ISO UTC pauseUntil when pause is active")
     fun `getPauseState returns paused true when active`() {
         val pauseUntil = LocalDateTime.of(2025, 1, 1, 13, 0)
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, pauseUntil = pauseUntil)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, pauseUntil = pauseUntil)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
-        val result = service.getPauseState(userId)
+        val result = service.getPauseState(externalUserId)
 
         assertEquals(true, result.paused)
         assertEquals(Instant.parse("2025-01-01T13:00:00Z"), result.pauseUntil)
@@ -330,10 +330,10 @@ class NotificationSettingsServiceTest {
     @DisplayName("getPauseState(): returns paused=false and null pauseUntil when pauseUntil is in the past")
     fun `getPauseState returns paused false when pauseUntil expired`() {
         val pauseUntil = LocalDateTime.of(2025, 1, 1, 11, 0)
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, pauseUntil = pauseUntil)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, pauseUntil = pauseUntil)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
-        val result = service.getPauseState(userId)
+        val result = service.getPauseState(externalUserId)
 
         assertEquals(false, result.paused)
         assertEquals(null, result.pauseUntil)
@@ -342,10 +342,10 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("getPauseState(): returns paused=false and null pauseUntil when pauseUntil is null")
     fun `getPauseState returns paused false when pauseUntil null`() {
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, pauseUntil = null)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, pauseUntil = null)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
-        val result = service.getPauseState(userId)
+        val result = service.getPauseState(externalUserId)
 
         assertEquals(false, result.paused)
         assertEquals(null, result.pauseUntil)
@@ -355,10 +355,10 @@ class NotificationSettingsServiceTest {
     @DisplayName("getPauseState(): returns paused=false when pauseUntil equals now")
     fun `getPauseState returns paused false when pauseUntil equals now`() {
         val pauseUntil = LocalDateTime.of(2025, 1, 1, 12, 0)
-        val dto = DtoGenerator.generateNotificationDto(externalUserId = userId, pauseUntil = pauseUntil)
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, pauseUntil = pauseUntil)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
-        val result = service.getPauseState(userId)
+        val result = service.getPauseState(externalUserId)
 
         assertEquals(false, result.paused)
         assertEquals(null, result.pauseUntil)
@@ -372,28 +372,28 @@ class NotificationSettingsServiceTest {
         val firstExpected = LocalDateTime.of(2025, 1, 1, 13, 0)
         val secondExpected = LocalDateTime.of(2025, 1, 1, 16, 0)
 
-        service.pauseNotifications(userId, firstMinutes)
-        service.pauseNotifications(userId, secondMinutes)
+        service.pauseNotifications(externalUserId, firstMinutes)
+        service.pauseNotifications(externalUserId, secondMinutes)
 
-        verify(notificationAccessService).setPause(userId, firstExpected)
-        verify(notificationAccessService).setPause(userId, secondExpected)
+        verify(notificationAccessService).setPause(externalUserId, firstExpected)
+        verify(notificationAccessService).setPause(externalUserId, secondExpected)
     }
 
     @Test
     @DisplayName("pauseNotifications(): does not call cancelPause path")
     fun `pauseNotifications does not cancel`() {
-        service.pauseNotifications(userId, 30L)
+        service.pauseNotifications(externalUserId, 30L)
 
-        verify(notificationAccessService, never()).setPause(userId, null)
+        verify(notificationAccessService, never()).setPause(externalUserId, null)
     }
 
     @ParameterizedTest
     @ValueSource(ints = [2000, 2250, 2500, 2750, 3000])
     @DisplayName("changeDailyGoal(): delegates to access service for any allowed value (incl. 2000 and 3000 boundaries)")
     fun `changeDailyGoal delegates for allowed value`(goalMl: Int) {
-        service.changeDailyGoal(userId, goalMl)
+        service.changeDailyGoal(externalUserId, goalMl)
 
-        verify(notificationAccessService).updateDailyGoal(userId, goalMl)
+        verify(notificationAccessService).updateDailyGoal(externalUserId, goalMl)
     }
 
     @ParameterizedTest
@@ -401,7 +401,7 @@ class NotificationSettingsServiceTest {
     @DisplayName("changeDailyGoal(): throws IllegalArgumentException for value outside ALLOWED_VALUES_ML")
     fun `changeDailyGoal throws when value not allowed`(goalMl: Int) {
         assertThrows(IllegalArgumentException::class.java) {
-            service.changeDailyGoal(userId, goalMl)
+            service.changeDailyGoal(externalUserId, goalMl)
         }
 
         verify(notificationAccessService, never()).updateDailyGoal(anyLong(), anyInt())
@@ -412,13 +412,13 @@ class NotificationSettingsServiceTest {
     fun `getPauseState returns paused true regardless of notificationAttempts`() {
         val pauseUntil = LocalDateTime.of(2025, 1, 1, 13, 0)
         val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = userId,
+            externalUserId = externalUserId,
             pauseUntil = pauseUntil,
             notificationAttempts = 3
         )
-        `when`(notificationAccessService.findNotificationSettingByTelegramUserId(userId)).thenReturn(dto)
+        `when`(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
-        val result = service.getPauseState(userId)
+        val result = service.getPauseState(externalUserId)
 
         assertEquals(true, result.paused)
         assertEquals(Instant.parse("2025-01-01T13:00:00Z"), result.pauseUntil)

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsServiceTest.kt
@@ -18,12 +18,15 @@ import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.service.notification.impl.NotificationSettingsServiceImpl
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
-import java.time.*
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneOffset
 
 @UnitTest
 @DisplayName("NotificationSettingsService Unit Test")
 class NotificationSettingsServiceTest {
-
     private val externalUserId = 1L
 
     private lateinit var notificationAccessService: NotificationAccessService
@@ -145,11 +148,12 @@ class NotificationSettingsServiceTest {
     fun `getQuietMode returns start and end`() {
         val expectedStart = LocalTime.of(23, 0)
         val expectedEnd = LocalTime.of(8, 0)
-        val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = externalUserId,
-            quietModeStart = expectedStart,
-            quietModeEnd = expectedEnd
-        )
+        val dto =
+            DtoGenerator.generateNotificationDto(
+                externalUserId = externalUserId,
+                quietModeStart = expectedStart,
+                quietModeEnd = expectedEnd,
+            )
         whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         val result = service.getQuietMode(externalUserId)
@@ -161,11 +165,12 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("getQuietMode(): throws IllegalStateException when start is null")
     fun `getQuietMode throws when start is null`() {
-        val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = externalUserId,
-            quietModeStart = null,
-            quietModeEnd = LocalTime.of(8, 0)
-        )
+        val dto =
+            DtoGenerator.generateNotificationDto(
+                externalUserId = externalUserId,
+                quietModeStart = null,
+                quietModeEnd = LocalTime.of(8, 0),
+            )
         whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         assertThrows(IllegalStateException::class.java) {
@@ -176,11 +181,12 @@ class NotificationSettingsServiceTest {
     @Test
     @DisplayName("getQuietMode(): throws IllegalStateException when end is null")
     fun `getQuietMode throws when end is null`() {
-        val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = externalUserId,
-            quietModeStart = LocalTime.of(23, 0),
-            quietModeEnd = null
-        )
+        val dto =
+            DtoGenerator.generateNotificationDto(
+                externalUserId = externalUserId,
+                quietModeStart = LocalTime.of(23, 0),
+                quietModeEnd = null,
+            )
         whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         assertThrows(IllegalStateException::class.java) {
@@ -246,14 +252,17 @@ class NotificationSettingsServiceTest {
     @DisplayName("getAllSettings(): returns SettingDto with all fields when notifications are enabled")
     fun `getAllSettings returns full dto when enabled`() {
         whenever(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(true)
-        val notificationDto = DtoGenerator.generateNotificationDto(
-            externalUserId = externalUserId,
-            notificationInterval = IntervalNotificationType.HOUR,
-            userTimeZone = "Europe/Moscow",
-            quietModeStart = LocalTime.of(23, 0),
-            quietModeEnd = LocalTime.of(8, 0),
-        )
-        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(notificationDto)
+        val notificationDto =
+            DtoGenerator.generateNotificationDto(
+                externalUserId = externalUserId,
+                notificationInterval = IntervalNotificationType.HOUR,
+                userTimeZone = "Europe/Moscow",
+                quietModeStart = LocalTime.of(23, 0),
+                quietModeEnd = LocalTime.of(8, 0),
+            )
+        whenever(
+            notificationAccessService.findNotificationSettingByExternalUserId(externalUserId),
+        ).thenReturn(notificationDto)
 
         val result = service.getAllSettings(externalUserId)
 
@@ -270,7 +279,9 @@ class NotificationSettingsServiceTest {
     }
 
     @Test
-    @DisplayName("getAllSettings(): returns SettingDto with only notificationActive=false when notifications are disabled")
+    @DisplayName(
+        "getAllSettings(): returns SettingDto with only notificationActive=false when notifications are disabled",
+    )
     fun `getAllSettings returns minimal dto when disabled`() {
         whenever(notificationAccessService.findIsEnabledNotificationsByExternalUserId(externalUserId)).thenReturn(false)
 
@@ -394,7 +405,9 @@ class NotificationSettingsServiceTest {
 
     @ParameterizedTest
     @ValueSource(ints = [2000, 2250, 2500, 2750, 3000])
-    @DisplayName("changeDailyGoal(): delegates to access service for any allowed value (incl. 2000 and 3000 boundaries)")
+    @DisplayName(
+        "changeDailyGoal(): delegates to access service for any allowed value (incl. 2000 and 3000 boundaries)",
+    )
     fun `changeDailyGoal delegates for allowed value`(goalMl: Int) {
         service.changeDailyGoal(externalUserId, goalMl)
 
@@ -416,11 +429,12 @@ class NotificationSettingsServiceTest {
     @DisplayName("getPauseState(): returns paused=true even when notificationAttempts > 0 (state independent)")
     fun `getPauseState returns paused true regardless of notificationAttempts`() {
         val pauseUntil = LocalDateTime.of(2025, 1, 1, 13, 0)
-        val dto = DtoGenerator.generateNotificationDto(
-            externalUserId = externalUserId,
-            pauseUntil = pauseUntil,
-            notificationAttempts = 3
-        )
+        val dto =
+            DtoGenerator.generateNotificationDto(
+                externalUserId = externalUserId,
+                pauseUntil = pauseUntil,
+                notificationAttempts = 3,
+            )
         whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
 
         val result = service.getPauseState(externalUserId)

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationTimeServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationTimeServiceTest.kt
@@ -19,358 +19,483 @@ import java.util.stream.Stream
 
 @SpringIntegrationTest
 @DisplayName("NotificationTimeService Spring Integration Test")
-class NotificationTimeServiceTest @Autowired constructor(
-    private val notificationTimeService: NotificationTimeService,
-    private val clock: Clock
-) {
-
-    private fun getMutableClock() = clock as ClockHelperTest.MutableClock
-
-    @BeforeEach
-    fun resetClock() {
-        getMutableClock().setTime(ClockHelperTest.DEFAULT_TIME)
-    }
-
-    @ParameterizedTest(name = "{index}: {5}")
-    @MethodSource("quietTimeScenarios")
-    fun `isOutsideQuietTime table test`(
-        currentTimeIso: String,
-        userZone: String,
-        quietStartIso: String?,
-        quietEndIso: String?,
-        expected: Boolean,
-        description: String
+class NotificationTimeServiceTest
+    @Autowired
+    constructor(
+        private val notificationTimeService: NotificationTimeService,
+        private val clock: Clock,
     ) {
-        getMutableClock().setTime(currentTimeIso)
+        private fun getMutableClock() = clock as ClockHelperTest.MutableClock
 
-        val start = quietStartIso?.let { LocalTime.parse(it) }
-        val end = quietEndIso?.let { LocalTime.parse(it) }
-
-        val dto = DtoGenerator.generateNotificationDto(
-            userTimeZone = userZone,
-            quietModeStart = start,
-            quietModeEnd = end
-        )
-
-        val actual = notificationTimeService.isOutsideQuietTime(dto)
-        Assertions.assertEquals(expected, actual, description)
-    }
-
-    @ParameterizedTest(name = "{index}: {4}")
-    @MethodSource("notificationDueScenarios")
-    fun `isNotificationDue table test`(
-        currentTimeIso: String,
-        lastNotificationTimeIso: String,
-        delay: IntervalNotificationType,
-        expected: Boolean,
-        description: String
-    ) {
-        getMutableClock().setTime(currentTimeIso)
-
-        val lastNotification = ZonedDateTime.parse(lastNotificationTimeIso).toLocalDateTime()
-
-        val dto = DtoGenerator.generateNotificationDto(
-            timeOfLastNotification = lastNotification,
-            notificationInterval = delay
-        )
-
-        val actual = notificationTimeService.isNotificationDue(dto)
-        Assertions.assertEquals(expected, actual, description)
-    }
-
-    @ParameterizedTest(name = "{index}: {6}")
-    @MethodSource("nextNotificationAtScenarios")
-    fun `calculateNextNotificationAt table test`(
-        lastNotificationTimeIso: String,
-        interval: IntervalNotificationType,
-        userZone: String,
-        quietStartIso: String?,
-        quietEndIso: String?,
-        expectedIso: String,
-        description: String
-    ) {
-        val lastNotification = ZonedDateTime.parse(lastNotificationTimeIso).toLocalDateTime()
-        val start = quietStartIso?.let { LocalTime.parse(it) }
-        val end = quietEndIso?.let { LocalTime.parse(it) }
-
-        val dto = DtoGenerator.generateNotificationDto(
-            timeOfLastNotification = lastNotification,
-            notificationInterval = interval,
-            userTimeZone = userZone,
-            quietModeStart = start,
-            quietModeEnd = end
-        )
-
-        val actual = notificationTimeService.calculateNextNotificationAt(dto)
-        Assertions.assertEquals(Instant.parse(expectedIso), actual, description)
-    }
-
-    companion object {
-
-        @JvmStatic
-        fun quietTimeScenarios(): Stream<Arguments> {
-            return Stream.of(
-                // FORMAT: CurrentTime | Zone | Start | End | Expected | Description
-
-                Arguments.of(
-                    "2025-01-01T12:00:00Z", "UTC", null, null, true,
-                    "No quiet mode set -> Always allow"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T15:00:00Z", "UTC", "14:00", "16:00", false,
-                    "Day interval: 15:00 is inside 14-16 -> Block"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T13:00:00Z", "UTC", "14:00", "16:00", true,
-                    "Day interval: 13:00 is before 14-16 -> Allow"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T17:00:00Z", "UTC", "14:00", "16:00", true,
-                    "Day interval: 17:00 is after 14-16 -> Allow"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T15:00:00Z", "UTC", "22:00", "08:00", true,
-                    "Night interval: 15:00 is outside 22-08 -> Allow"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T12:00:00Z", "Asia/Tokyo", "20:00", "08:00", false,
-                    "Tokyo (UTC+9): 12:00Z is 21:00 local. Inside 20-08 -> Block"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T14:00:00Z", "UTC", "14:00", "16:00", false,
-                    "Exact start time -> Block (Inclusive)"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T16:00:00Z", "UTC", "14:00", "16:00", false,
-                    "Exact end time -> Block (Inclusive)"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T23:00:00Z", "UTC", "22:00", "08:00", false,
-                    "Night interval: 23:00 (Pre-midnight) inside 22-08 -> Block"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T02:00:00Z", "UTC", "22:00", "08:00", false,
-                    "Night interval: 02:00 (Post-midnight) inside 22-08 -> Block"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T16:00:01Z", "UTC", "14:00", "16:00", true,
-                    "1 second after quiet time ends -> Allow"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T12:00:00Z", "Invalid/Zone", "14:00", "16:00", true,
-                    "Invalid timezone -> Fallback to UTC -> Allow"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T15:00:00Z", "UTC", "14:00", "14:00", true,
-                    "Start == End -> Incorrect start/end  ->  Allow"
-                ),
-
-                Arguments.of(
-                    "2025-01-02T00:00:00Z", "UTC", "22:00", "08:00", false,
-                    "Midnight exactly (00:00) inside night interval (22-08) -> Block"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T21:00:00Z", "Asia/Dubai", "23:00", "07:00", false,
-                    "Day change: UTC 21:00 is Local 01:00 (next day). Inside 23-07 -> Block"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T12:00:00Z", "UTC", "14:00", null, true,
-                    "Partial null: Start set, End null -> Allow"
-                ),
-                Arguments.of(
-                    "2025-01-01T12:00:00Z", "UTC", null, "16:00", true,
-                    "Partial null: Start null, End set -> Allow"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T22:00:00Z", "UTC", "22:00", "08:00", false,
-                    "Night interval start boundary: 22:00 exactly -> Block"
-                ),
-
-                Arguments.of(
-                    "2025-01-02T08:00:00Z", "UTC", "22:00", "08:00", false,
-                    "Night interval end boundary: 08:00 exactly -> Block"
-                ),
-
-                Arguments.of(
-                    "2025-01-02T08:00:00.000000001Z", "UTC", "22:00", "08:00", true,
-                    "1 nanosecond after night interval ends -> Allow"
-                )
-            )
+        @BeforeEach
+        fun resetClock() {
+            getMutableClock().setTime(ClockHelperTest.DEFAULT_TIME)
         }
 
-        @JvmStatic
-        fun nextNotificationAtScenarios(): Stream<Arguments> {
-            return Stream.of(
-                // FORMAT: LastNotificationTime | Interval | Zone | QuietStart | QuietEnd | Expected | Description
+        @ParameterizedTest(name = "{index}: {5}")
+        @MethodSource("quietTimeScenarios")
+        fun `isOutsideQuietTime table test`(
+            currentTimeIso: String,
+            userZone: String,
+            quietStartIso: String?,
+            quietEndIso: String?,
+            expected: Boolean,
+            description: String,
+        ) {
+            getMutableClock().setTime(currentTimeIso)
 
-                Arguments.of(
-                    "2025-01-01T10:00:00Z", IntervalNotificationType.HOUR, "UTC", null, null,
-                    "2025-01-01T11:00:00Z",
-                    "No quiet mode -> rawNext = lastNotification + interval"
-                ),
+            val start = quietStartIso?.let { LocalTime.parse(it) }
+            val end = quietEndIso?.let { LocalTime.parse(it) }
 
-                Arguments.of(
-                    "2025-01-01T14:00:00Z", IntervalNotificationType.HOUR, "UTC", "14:00", "16:00",
-                    "2025-01-01T16:00:00Z",
-                    "Day quiet mode: rawNext 15:00 inside 14-16 -> Shift to quietModeEnd"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T22:00:00Z", IntervalNotificationType.HOUR, "UTC", "22:00", "08:00",
-                    "2025-01-02T08:00:00Z",
-                    "Night quiet mode: rawNext 23:00 inside 22-08 -> Shift to 08:00 next day"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T10:00:00Z", IntervalNotificationType.HOUR, "UTC", "14:00", "14:00",
-                    "2025-01-01T11:00:00Z",
-                    "Quiet mode start == end -> Effectively disabled, return rawNext"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T12:30:00Z", IntervalNotificationType.HOUR, "Asia/Tokyo", "22:00", "08:00",
-                    "2025-01-01T23:00:00Z",
-                    "Tokyo (UTC+9): rawNext 13:30Z = 22:30 local, inside 22-08 -> Shift to 08:00 local next day = 23:00Z"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T10:00:00Z", IntervalNotificationType.HOUR, "UTC", "23:00", "08:00",
-                    "2025-01-01T11:00:00Z",
-                    "rawNext 11:00 outside night quiet 23-08 -> Return rawNext"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T10:00:00Z", IntervalNotificationType.HOUR, "Invalid/Zone", "14:00", "16:00",
-                    "2025-01-01T11:00:00Z",
-                    "Invalid timezone -> Fallback to UTC, rawNext 11:00 outside 14-16 -> Return rawNext"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T13:00:00Z", IntervalNotificationType.HOUR, "UTC", "14:00", "16:00",
-                    "2025-01-01T16:00:00Z",
-                    "Exact quiet start boundary (inclusive): rawNext 14:00 == start -> In quiet, shift to quietModeEnd"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T14:30:00Z", IntervalNotificationType.HOUR_AND_HALF, "UTC", "14:00", "17:00",
-                    "2025-01-01T17:00:00Z",
-                    "Inside quiet near end: rawNext 16:00 inside 14-17 -> Shift to quietModeEnd 17:00"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T10:00:00Z", IntervalNotificationType.TWO_HOURS, "UTC", null, null,
-                    "2025-01-01T12:00:00Z",
-                    "TWO_HOURS interval without quiet mode -> rawNext = lastNotification + 120m"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T06:30:00Z", IntervalNotificationType.HOUR, "UTC", "02:00", "08:00",
-                    "2025-01-01T08:00:00Z",
-                    "rawNext 07:30 inside day quiet 02-08 -> Shift to 08:00 same day"
-                ),
-
-                // Pause + quiet mode interaction:
-                // simulates pauseUntil=23:30 (timeOfLastNotification = 23:30 - 60m = 22:30)
-                // pauseUntil falls inside quiet zone 23:00-08:00, so /next is shifted to 08:00.
-                // This documents UX nuance: getPauseState returns 23:30, but actual notification at 08:00.
-                Arguments.of(
-                    "2025-01-01T22:30:00Z", IntervalNotificationType.HOUR, "UTC", "23:00", "08:00",
-                    "2025-01-02T08:00:00Z",
-                    "Pause ending in quiet mode: rawNext 23:30 inside 23-08 -> Shift to 08:00 next day"
-                ),
-
-                // Covers (quietEnd == null) branch on line 69 of calculateNextNotificationAt.
-                Arguments.of(
-                    "2025-01-01T10:00:00Z", IntervalNotificationType.HOUR, "UTC", "14:00", null,
-                    "2025-01-01T11:00:00Z",
-                    "Partial null: Start set, End null -> Treat as no quiet mode, return rawNext"
-                ),
-
-                // Covers (quietStart == null) branch on line 69 of calculateNextNotificationAt.
-                Arguments.of(
-                    "2025-01-01T10:00:00Z", IntervalNotificationType.HOUR, "UTC", null, "16:00",
-                    "2025-01-01T11:00:00Z",
-                    "Partial null: Start null, End set -> Treat as no quiet mode, return rawNext"
-                ),
-
-                // Covers (isAtOrAfterStart=true && isAtOrBeforeEnd=false) on the day branch (line 82).
-                // rawNext 17:00 is after end 16:00 -> NOT in quiet mode, return rawNext.
-                Arguments.of(
-                    "2025-01-01T16:00:00Z", IntervalNotificationType.HOUR, "UTC", "14:00", "16:00",
-                    "2025-01-01T17:00:00Z",
-                    "Day quiet mode: rawNext 17:00 after end 16:00 -> Return rawNext"
-                ),
-
-                // Covers (isAtOrAfterStart=false || isAtOrBeforeEnd=true) on the night branch (line 84).
-                // rawNext 07:00 is before start 23:00 but at-or-before end 08:00 -> in quiet mode -> shift.
-                Arguments.of(
-                    "2025-01-01T06:00:00Z", IntervalNotificationType.HOUR, "UTC", "23:00", "08:00",
-                    "2025-01-01T08:00:00Z",
-                    "Night quiet mode: rawNext 07:00 in early-morning quiet 23-08 -> Shift to 08:00 same day"
+            val dto =
+                DtoGenerator.generateNotificationDto(
+                    userTimeZone = userZone,
+                    quietModeStart = start,
+                    quietModeEnd = end,
                 )
-            )
+
+            val actual = notificationTimeService.isOutsideQuietTime(dto)
+            Assertions.assertEquals(expected, actual, description)
         }
 
-        @JvmStatic
-        fun notificationDueScenarios(): Stream<Arguments> {
-            return Stream.of(
-                // FORMAT: CurrentTime | LastNotificationTime | Delay | Expected | Description
+        @ParameterizedTest(name = "{index}: {4}")
+        @MethodSource("notificationDueScenarios")
+        fun `isNotificationDue table test`(
+            currentTimeIso: String,
+            lastNotificationTimeIso: String,
+            delay: IntervalNotificationType,
+            expected: Boolean,
+            description: String,
+        ) {
+            getMutableClock().setTime(currentTimeIso)
 
-                Arguments.of(
-                    "2025-01-01T12:00:00Z", "2025-01-01T10:00:00Z", IntervalNotificationType.TWO_HOURS, true,
-                    "Exact boundary: 10:00 + 120m == 12:00, boundary is inclusive [<=] -> Due"
-                ),
+            val lastNotification = ZonedDateTime.parse(lastNotificationTimeIso).toLocalDateTime()
 
-                Arguments.of(
-                    "2025-01-01T13:00:00Z", "2025-01-01T10:00:00Z", IntervalNotificationType.HOUR, true,
-                    "Exact boundary: 12:00 + 60m == 13:00, boundary is inclusive [<=]  -> Due"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T12:00:01Z", "2025-01-01T10:00:00Z", IntervalNotificationType.TWO_HOURS, true,
-                    "1 second after due time -> Due"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T11:59:59Z", "2025-01-01T10:00:00Z", IntervalNotificationType.TWO_HOURS, false,
-                    "1 second before due time -> Not Due"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T15:00:00Z", "2025-01-01T10:00:00Z", IntervalNotificationType.HOUR, true,
-                    "Long overdue: 10:00 + 60m < 15:00 -> Due"
-                ),
-
-                Arguments.of(
-                    "2025-01-02T01:00:00Z", "2025-01-01T23:00:00Z", IntervalNotificationType.HOUR, true,
-                    "Day rollover: 23:00 + 60m = 00:00 (next day) < 01:00 -> Due"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T12:00:00Z", "2025-01-01T11:50:00Z", IntervalNotificationType.HALF_HOUR, false,
-                    "Short delay not reached: 11:50 + 30m = 12:20 > 12:00 -> Not Due"
-                ),
-
-                Arguments.of(
-                    "2025-01-01T10:00:00Z", "2025-01-01T12:00:00Z", IntervalNotificationType.HOUR, false,
-                    "Last notification is in future -> Not Due"
+            val dto =
+                DtoGenerator.generateNotificationDto(
+                    timeOfLastNotification = lastNotification,
+                    notificationInterval = delay,
                 )
-            )
+
+            val actual = notificationTimeService.isNotificationDue(dto)
+            Assertions.assertEquals(expected, actual, description)
+        }
+
+        @ParameterizedTest(name = "{index}: {6}")
+        @MethodSource("nextNotificationAtScenarios")
+        fun `calculateNextNotificationAt table test`(
+            lastNotificationTimeIso: String,
+            interval: IntervalNotificationType,
+            userZone: String,
+            quietStartIso: String?,
+            quietEndIso: String?,
+            expectedIso: String,
+            description: String,
+        ) {
+            val lastNotification = ZonedDateTime.parse(lastNotificationTimeIso).toLocalDateTime()
+            val start = quietStartIso?.let { LocalTime.parse(it) }
+            val end = quietEndIso?.let { LocalTime.parse(it) }
+
+            val dto =
+                DtoGenerator.generateNotificationDto(
+                    timeOfLastNotification = lastNotification,
+                    notificationInterval = interval,
+                    userTimeZone = userZone,
+                    quietModeStart = start,
+                    quietModeEnd = end,
+                )
+
+            val actual = notificationTimeService.calculateNextNotificationAt(dto)
+            Assertions.assertEquals(Instant.parse(expectedIso), actual, description)
+        }
+
+        companion object {
+            @JvmStatic
+            fun quietTimeScenarios(): Stream<Arguments> =
+                Stream.of(
+                    // FORMAT: CurrentTime | Zone | Start | End | Expected | Description
+                    Arguments.of(
+                        "2025-01-01T12:00:00Z",
+                        "UTC",
+                        null,
+                        null,
+                        true,
+                        "No quiet mode set -> Always allow",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T15:00:00Z",
+                        "UTC",
+                        "14:00",
+                        "16:00",
+                        false,
+                        "Day interval: 15:00 is inside 14-16 -> Block",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T13:00:00Z",
+                        "UTC",
+                        "14:00",
+                        "16:00",
+                        true,
+                        "Day interval: 13:00 is before 14-16 -> Allow",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T17:00:00Z",
+                        "UTC",
+                        "14:00",
+                        "16:00",
+                        true,
+                        "Day interval: 17:00 is after 14-16 -> Allow",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T15:00:00Z",
+                        "UTC",
+                        "22:00",
+                        "08:00",
+                        true,
+                        "Night interval: 15:00 is outside 22-08 -> Allow",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T12:00:00Z",
+                        "Asia/Tokyo",
+                        "20:00",
+                        "08:00",
+                        false,
+                        "Tokyo (UTC+9): 12:00Z is 21:00 local. Inside 20-08 -> Block",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T14:00:00Z",
+                        "UTC",
+                        "14:00",
+                        "16:00",
+                        false,
+                        "Exact start time -> Block (Inclusive)",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T16:00:00Z",
+                        "UTC",
+                        "14:00",
+                        "16:00",
+                        false,
+                        "Exact end time -> Block (Inclusive)",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T23:00:00Z",
+                        "UTC",
+                        "22:00",
+                        "08:00",
+                        false,
+                        "Night interval: 23:00 (Pre-midnight) inside 22-08 -> Block",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T02:00:00Z",
+                        "UTC",
+                        "22:00",
+                        "08:00",
+                        false,
+                        "Night interval: 02:00 (Post-midnight) inside 22-08 -> Block",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T16:00:01Z",
+                        "UTC",
+                        "14:00",
+                        "16:00",
+                        true,
+                        "1 second after quiet time ends -> Allow",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T12:00:00Z",
+                        "Invalid/Zone",
+                        "14:00",
+                        "16:00",
+                        true,
+                        "Invalid timezone -> Fallback to UTC -> Allow",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T15:00:00Z",
+                        "UTC",
+                        "14:00",
+                        "14:00",
+                        true,
+                        "Start == End -> Incorrect start/end  ->  Allow",
+                    ),
+                    Arguments.of(
+                        "2025-01-02T00:00:00Z",
+                        "UTC",
+                        "22:00",
+                        "08:00",
+                        false,
+                        "Midnight exactly (00:00) inside night interval (22-08) -> Block",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T21:00:00Z",
+                        "Asia/Dubai",
+                        "23:00",
+                        "07:00",
+                        false,
+                        "Day change: UTC 21:00 is Local 01:00 (next day). Inside 23-07 -> Block",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T12:00:00Z",
+                        "UTC",
+                        "14:00",
+                        null,
+                        true,
+                        "Partial null: Start set, End null -> Allow",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T12:00:00Z",
+                        "UTC",
+                        null,
+                        "16:00",
+                        true,
+                        "Partial null: Start null, End set -> Allow",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T22:00:00Z",
+                        "UTC",
+                        "22:00",
+                        "08:00",
+                        false,
+                        "Night interval start boundary: 22:00 exactly -> Block",
+                    ),
+                    Arguments.of(
+                        "2025-01-02T08:00:00Z",
+                        "UTC",
+                        "22:00",
+                        "08:00",
+                        false,
+                        "Night interval end boundary: 08:00 exactly -> Block",
+                    ),
+                    Arguments.of(
+                        "2025-01-02T08:00:00.000000001Z",
+                        "UTC",
+                        "22:00",
+                        "08:00",
+                        true,
+                        "1 nanosecond after night interval ends -> Allow",
+                    ),
+                )
+
+            @JvmStatic
+            fun nextNotificationAtScenarios(): Stream<Arguments> =
+                Stream.of(
+                    // FORMAT: LastNotificationTime | Interval | Zone | QuietStart | QuietEnd | Expected | Description
+                    Arguments.of(
+                        "2025-01-01T10:00:00Z",
+                        IntervalNotificationType.HOUR,
+                        "UTC",
+                        null,
+                        null,
+                        "2025-01-01T11:00:00Z",
+                        "No quiet mode -> rawNext = lastNotification + interval",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T14:00:00Z",
+                        IntervalNotificationType.HOUR,
+                        "UTC",
+                        "14:00",
+                        "16:00",
+                        "2025-01-01T16:00:00Z",
+                        "Day quiet mode: rawNext 15:00 inside 14-16 -> Shift to quietModeEnd",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T22:00:00Z",
+                        IntervalNotificationType.HOUR,
+                        "UTC",
+                        "22:00",
+                        "08:00",
+                        "2025-01-02T08:00:00Z",
+                        "Night quiet mode: rawNext 23:00 inside 22-08 -> Shift to 08:00 next day",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T10:00:00Z",
+                        IntervalNotificationType.HOUR,
+                        "UTC",
+                        "14:00",
+                        "14:00",
+                        "2025-01-01T11:00:00Z",
+                        "Quiet mode start == end -> Effectively disabled, return rawNext",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T12:30:00Z",
+                        IntervalNotificationType.HOUR,
+                        "Asia/Tokyo",
+                        "22:00",
+                        "08:00",
+                        "2025-01-01T23:00:00Z",
+                        "Tokyo (UTC+9): rawNext 13:30Z = 22:30 local, inside 22-08 -> Shift to 08:00 local next day = 23:00Z",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T10:00:00Z",
+                        IntervalNotificationType.HOUR,
+                        "UTC",
+                        "23:00",
+                        "08:00",
+                        "2025-01-01T11:00:00Z",
+                        "rawNext 11:00 outside night quiet 23-08 -> Return rawNext",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T10:00:00Z",
+                        IntervalNotificationType.HOUR,
+                        "Invalid/Zone",
+                        "14:00",
+                        "16:00",
+                        "2025-01-01T11:00:00Z",
+                        "Invalid timezone -> Fallback to UTC, rawNext 11:00 outside 14-16 -> Return rawNext",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T13:00:00Z",
+                        IntervalNotificationType.HOUR,
+                        "UTC",
+                        "14:00",
+                        "16:00",
+                        "2025-01-01T16:00:00Z",
+                        "Exact quiet start boundary (inclusive): rawNext 14:00 == start -> In quiet, shift to quietModeEnd",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T14:30:00Z",
+                        IntervalNotificationType.HOUR_AND_HALF,
+                        "UTC",
+                        "14:00",
+                        "17:00",
+                        "2025-01-01T17:00:00Z",
+                        "Inside quiet near end: rawNext 16:00 inside 14-17 -> Shift to quietModeEnd 17:00",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T10:00:00Z",
+                        IntervalNotificationType.TWO_HOURS,
+                        "UTC",
+                        null,
+                        null,
+                        "2025-01-01T12:00:00Z",
+                        "TWO_HOURS interval without quiet mode -> rawNext = lastNotification + 120m",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T06:30:00Z",
+                        IntervalNotificationType.HOUR,
+                        "UTC",
+                        "02:00",
+                        "08:00",
+                        "2025-01-01T08:00:00Z",
+                        "rawNext 07:30 inside day quiet 02-08 -> Shift to 08:00 same day",
+                    ),
+                    // Pause + quiet mode interaction:
+                    // simulates pauseUntil=23:30 (timeOfLastNotification = 23:30 - 60m = 22:30)
+                    // pauseUntil falls inside quiet zone 23:00-08:00, so /next is shifted to 08:00.
+                    // This documents UX nuance: getPauseState returns 23:30, but actual notification at 08:00.
+                    Arguments.of(
+                        "2025-01-01T22:30:00Z",
+                        IntervalNotificationType.HOUR,
+                        "UTC",
+                        "23:00",
+                        "08:00",
+                        "2025-01-02T08:00:00Z",
+                        "Pause ending in quiet mode: rawNext 23:30 inside 23-08 -> Shift to 08:00 next day",
+                    ),
+                    // Covers (quietEnd == null) branch on line 69 of calculateNextNotificationAt.
+                    Arguments.of(
+                        "2025-01-01T10:00:00Z",
+                        IntervalNotificationType.HOUR,
+                        "UTC",
+                        "14:00",
+                        null,
+                        "2025-01-01T11:00:00Z",
+                        "Partial null: Start set, End null -> Treat as no quiet mode, return rawNext",
+                    ),
+                    // Covers (quietStart == null) branch on line 69 of calculateNextNotificationAt.
+                    Arguments.of(
+                        "2025-01-01T10:00:00Z",
+                        IntervalNotificationType.HOUR,
+                        "UTC",
+                        null,
+                        "16:00",
+                        "2025-01-01T11:00:00Z",
+                        "Partial null: Start null, End set -> Treat as no quiet mode, return rawNext",
+                    ),
+                    // Covers (isAtOrAfterStart=true && isAtOrBeforeEnd=false) on the day branch (line 82).
+                    // rawNext 17:00 is after end 16:00 -> NOT in quiet mode, return rawNext.
+                    Arguments.of(
+                        "2025-01-01T16:00:00Z",
+                        IntervalNotificationType.HOUR,
+                        "UTC",
+                        "14:00",
+                        "16:00",
+                        "2025-01-01T17:00:00Z",
+                        "Day quiet mode: rawNext 17:00 after end 16:00 -> Return rawNext",
+                    ),
+                    // Covers (isAtOrAfterStart=false || isAtOrBeforeEnd=true) on the night branch (line 84).
+                    // rawNext 07:00 is before start 23:00 but at-or-before end 08:00 -> in quiet mode -> shift.
+                    Arguments.of(
+                        "2025-01-01T06:00:00Z",
+                        IntervalNotificationType.HOUR,
+                        "UTC",
+                        "23:00",
+                        "08:00",
+                        "2025-01-01T08:00:00Z",
+                        "Night quiet mode: rawNext 07:00 in early-morning quiet 23-08 -> Shift to 08:00 same day",
+                    ),
+                )
+
+            @JvmStatic
+            fun notificationDueScenarios(): Stream<Arguments> =
+                Stream.of(
+                    // FORMAT: CurrentTime | LastNotificationTime | Delay | Expected | Description
+                    Arguments.of(
+                        "2025-01-01T12:00:00Z",
+                        "2025-01-01T10:00:00Z",
+                        IntervalNotificationType.TWO_HOURS,
+                        true,
+                        "Exact boundary: 10:00 + 120m == 12:00, boundary is inclusive [<=] -> Due",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T13:00:00Z",
+                        "2025-01-01T10:00:00Z",
+                        IntervalNotificationType.HOUR,
+                        true,
+                        "Exact boundary: 12:00 + 60m == 13:00, boundary is inclusive [<=]  -> Due",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T12:00:01Z",
+                        "2025-01-01T10:00:00Z",
+                        IntervalNotificationType.TWO_HOURS,
+                        true,
+                        "1 second after due time -> Due",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T11:59:59Z",
+                        "2025-01-01T10:00:00Z",
+                        IntervalNotificationType.TWO_HOURS,
+                        false,
+                        "1 second before due time -> Not Due",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T15:00:00Z",
+                        "2025-01-01T10:00:00Z",
+                        IntervalNotificationType.HOUR,
+                        true,
+                        "Long overdue: 10:00 + 60m < 15:00 -> Due",
+                    ),
+                    Arguments.of(
+                        "2025-01-02T01:00:00Z",
+                        "2025-01-01T23:00:00Z",
+                        IntervalNotificationType.HOUR,
+                        true,
+                        "Day rollover: 23:00 + 60m = 00:00 (next day) < 01:00 -> Due",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T12:00:00Z",
+                        "2025-01-01T11:50:00Z",
+                        IntervalNotificationType.HALF_HOUR,
+                        false,
+                        "Short delay not reached: 11:50 + 30m = 12:20 > 12:00 -> Not Due",
+                    ),
+                    Arguments.of(
+                        "2025-01-01T10:00:00Z",
+                        "2025-01-01T12:00:00Z",
+                        IntervalNotificationType.HOUR,
+                        false,
+                        "Last notification is in future -> Not Due",
+                    ),
+                )
         }
     }
-}

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsServiceTest.kt
@@ -31,7 +31,7 @@ import java.util.stream.Stream
 @DisplayName("StatisticsService Unit Test")
 class StatisticsServiceTest {
 
-    private val userId = 1L
+    private val externalUserId = 1L
 
     private lateinit var notificationAccessService: NotificationAccessService
     private lateinit var waterStatisticAccessService: WaterStatisticAccessService
@@ -51,9 +51,9 @@ class StatisticsServiceTest {
     }
 
     private fun stubSettings(zone: String = "UTC", dailyGoalMl: Int = 2000) {
-        whenever(notificationAccessService.findNotificationSettingByTelegramUserId(userId))
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId))
             .thenReturn(DtoGenerator.generateNotificationDto(
-                externalUserId = userId, userTimeZone = zone, dailyGoalMl = dailyGoalMl
+                externalUserId = externalUserId, userTimeZone = zone, dailyGoalMl = dailyGoalMl
             ))
     }
 
@@ -89,17 +89,17 @@ class StatisticsServiceTest {
         val expectedFromService = emptyList<WaterStatisticDto>()
         stubEvents(expectedFromService)
 
-        val result = service.getToday(userId)
+        val result = service.getToday(externalUserId)
 
         val startCaptor = argumentCaptor<LocalDateTime>()
         val endCaptor = argumentCaptor<LocalDateTime>()
         verify(waterStatisticAccessService).findByUserAndEventTimeBetween(
-            eq(userId), startCaptor.capture(), endCaptor.capture()
+            eq(externalUserId), startCaptor.capture(), endCaptor.capture()
         )
         assertEquals(expectedStart, startCaptor.firstValue)
         assertEquals(expectedEnd, endCaptor.firstValue)
         assertSame(expectedFromService, result)
-        verify(notificationAccessService).findNotificationSettingByTelegramUserId(userId)
+        verify(notificationAccessService).findNotificationSettingByExternalUserId(externalUserId)
     }
 
     @Test
@@ -109,14 +109,14 @@ class StatisticsServiceTest {
         stubSettings(zone = "Europe/Moscow")
         val expected = listOf(
             DtoGenerator.generateWaterStatisticDto(
-                externalUserId = userId,
+                externalUserId = externalUserId,
                 eventTime = LocalDateTime.of(2026, 5, 8, 8, 15),
                 waterAmountMl = 250,
             ),
         )
         stubEvents(expected)
 
-        val result = service.getToday(userId)
+        val result = service.getToday(externalUserId)
 
         assertEquals(expected, result)
     }
@@ -130,7 +130,7 @@ class StatisticsServiceTest {
         stubEvents(
             listOf(
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 12, 8, 15),
                     waterAmountMl = 250,
                 )
@@ -139,7 +139,7 @@ class StatisticsServiceTest {
         stubFirstEntry(LocalDateTime.of(2026, 5, 1, 9, 0))
         stubInsight("insight day")
 
-        val result = service.getStatistics(userId, today, today)
+        val result = service.getStatistics(externalUserId, today, today)
 
         assertEquals(24, result.points.size)
         assertEquals("08:00", result.points[8].label)
@@ -160,12 +160,12 @@ class StatisticsServiceTest {
         stubEvents(
             listOf(
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 4, 10, 0),
                     waterAmountMl = 2100,
                 ),
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 6, 10, 0),
                     waterAmountMl = 2400,
                 ),
@@ -174,7 +174,7 @@ class StatisticsServiceTest {
         stubFirstEntry(null)
         stubInsight("insight week")
 
-        val result = service.getStatistics(userId, LocalDate.of(2026, 5, 4), LocalDate.of(2026, 5, 10))
+        val result = service.getStatistics(externalUserId, LocalDate.of(2026, 5, 4), LocalDate.of(2026, 5, 10))
 
         assertEquals(7, result.points.size)
         assertEquals("2026-05-04", result.points[0].label)
@@ -199,7 +199,7 @@ class StatisticsServiceTest {
         stubEvents(
             listOf(
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 1, 9, 30),
                     waterAmountMl = 400,
                 )
@@ -208,7 +208,7 @@ class StatisticsServiceTest {
         stubFirstEntry(null)
         stubInsight()
 
-        val result = service.getStatistics(userId, past, past)
+        val result = service.getStatistics(externalUserId, past, past)
 
         assertEquals(24, result.points.size)
         assertEquals(400, result.points[9].valueMl)
@@ -226,19 +226,19 @@ class StatisticsServiceTest {
         stubEvents(
             listOf(
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 12, 8, 0),
                     eventType = AnswerNotificationType.YES,
                     waterAmountMl = 500,
                 ),
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 12, 10, 0),
                     eventType = AnswerNotificationType.SNOOZE,
                     waterAmountMl = 100,
                 ),
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 12, 14, 0),
                     eventType = AnswerNotificationType.CANCEL,
                     waterAmountMl = 200,
@@ -248,7 +248,7 @@ class StatisticsServiceTest {
         stubFirstEntry(null)
         stubInsight()
 
-        val result = service.getStatistics(userId, today, today)
+        val result = service.getStatistics(externalUserId, today, today)
 
         assertEquals(500, result.averageMlPerDay)
         assertEquals(500, result.points[8].valueMl)
@@ -267,7 +267,7 @@ class StatisticsServiceTest {
         stubSettings()
         val recentMet = (0L..6L).map { offset ->
             DtoGenerator.generateWaterStatisticDto(
-                externalUserId = userId,
+                externalUserId = externalUserId,
                 eventTime = today.minusDays(offset).atTime(10, 0),
                 waterAmountMl = 2200,
             )
@@ -276,7 +276,7 @@ class StatisticsServiceTest {
         stubFirstEntry(null)
         stubInsight()
 
-        val result = service.getStatistics(userId, LocalDate.of(2026, 4, 1), LocalDate.of(2026, 4, 30))
+        val result = service.getStatistics(externalUserId, LocalDate.of(2026, 4, 1), LocalDate.of(2026, 4, 30))
 
         assertEquals(7, result.currentStreakDays)
     }
@@ -291,7 +291,7 @@ class StatisticsServiceTest {
         stubSettings()
         val events = (0L..500L).map { offset ->
             DtoGenerator.generateWaterStatisticDto(
-                externalUserId = userId,
+                externalUserId = externalUserId,
                 eventTime = today.minusDays(offset).atTime(10, 0),
                 waterAmountMl = 2200,
             )
@@ -301,7 +301,7 @@ class StatisticsServiceTest {
         stubInsight()
 
         val result = service.getStatistics(
-            userId, today.minusDays(500), today
+            externalUserId, today.minusDays(500), today
         )
 
         assertEquals(367, result.currentStreakDays)
@@ -319,13 +319,13 @@ class StatisticsServiceTest {
             listOf(
                 // outside range, fetched only for streak
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 1, 10, 0),
                     waterAmountMl = 9999,
                 ),
                 // inside range
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 17, 10, 0),
                     waterAmountMl = 2500,
                 ),
@@ -335,7 +335,7 @@ class StatisticsServiceTest {
         stubInsight()
 
         val result = service.getStatistics(
-            userId, LocalDate.of(2026, 5, 15), today
+            externalUserId, LocalDate.of(2026, 5, 15), today
         )
 
         assertNotNull(result.bestDay)
@@ -351,7 +351,7 @@ class StatisticsServiceTest {
         stubSettings()
 
         val ex = assertThrows(IllegalArgumentException::class.java) {
-            service.getStatistics(userId, LocalDate.of(2026, 5, 10), LocalDate.of(2026, 5, 9))
+            service.getStatistics(externalUserId, LocalDate.of(2026, 5, 10), LocalDate.of(2026, 5, 9))
         }
         assertTrue(ex.message!!.contains("'from' must be before or equal to 'to'"))
     }
@@ -364,7 +364,7 @@ class StatisticsServiceTest {
         stubSettings()
 
         val ex = assertThrows(IllegalArgumentException::class.java) {
-            service.getStatistics(userId, today.plusDays(1), today.plusDays(2))
+            service.getStatistics(externalUserId, today.plusDays(1), today.plusDays(2))
         }
         assertTrue(ex.message!!.contains("'from' must not be in the future"))
     }
@@ -379,10 +379,10 @@ class StatisticsServiceTest {
         stubFirstEntry(null)
         stubInsight()
 
-        val result = service.getStatistics(userId, today, today)
+        val result = service.getStatistics(externalUserId, today, today)
 
         assertNull(result.firstEntryAt)
-        verify(waterStatisticAccessService).findEarliestEventTimeByUser(userId)
+        verify(waterStatisticAccessService).findEarliestEventTimeByUser(externalUserId)
     }
 
     @Test
@@ -395,7 +395,7 @@ class StatisticsServiceTest {
         stubFirstEntry(LocalDateTime.of(2026, 1, 15, 7, 45))
         stubInsight()
 
-        val result = service.getStatistics(userId, today, today)
+        val result = service.getStatistics(externalUserId, today, today)
 
         assertEquals(Instant.parse("2026-01-15T07:45:00Z"), result.firstEntryAt)
     }
@@ -409,7 +409,7 @@ class StatisticsServiceTest {
         stubEvents(
             listOf(
                 DtoGenerator.generateWaterStatisticDto(
-                    externalUserId = userId,
+                    externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 12, 10, 0),
                     waterAmountMl = 2200,
                 )
@@ -418,7 +418,7 @@ class StatisticsServiceTest {
         stubFirstEntry(null)
         stubInsight("text")
 
-        val result = service.getStatistics(userId, today, today)
+        val result = service.getStatistics(externalUserId, today, today)
 
         val ctxCaptor = argumentCaptor<InsightStatsContext>()
         verify(messageProvider).getMessage(eq(MessageSpec.InsightStats), ctxCaptor.capture())

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsServiceTest.kt
@@ -1,6 +1,11 @@
 package ru.illine.drinking.ponies.service.statistic
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -24,13 +29,17 @@ import ru.illine.drinking.ponies.service.statistic.impl.StatisticsServiceImpl
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import ru.illine.drinking.ponies.util.message.MessageSpec
-import java.time.*
+import java.time.Clock
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.stream.Stream
 
 @UnitTest
 @DisplayName("StatisticsService Unit Test")
 class StatisticsServiceTest {
-
     private val externalUserId = 1L
 
     private lateinit var notificationAccessService: NotificationAccessService
@@ -50,11 +59,18 @@ class StatisticsServiceTest {
             .thenReturn(MessageDto(text))
     }
 
-    private fun stubSettings(zone: String = "UTC", dailyGoalMl: Int = 2000) {
+    private fun stubSettings(
+        zone: String = "UTC",
+        dailyGoalMl: Int = 2000,
+    ) {
         whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId))
-            .thenReturn(DtoGenerator.generateNotificationDto(
-                externalUserId = externalUserId, userTimeZone = zone, dailyGoalMl = dailyGoalMl
-            ))
+            .thenReturn(
+                DtoGenerator.generateNotificationDto(
+                    externalUserId = externalUserId,
+                    userTimeZone = zone,
+                    dailyGoalMl = dailyGoalMl,
+                ),
+            )
     }
 
     private fun stubEvents(events: List<WaterStatisticDto>) {
@@ -67,9 +83,13 @@ class StatisticsServiceTest {
     }
 
     private fun buildService(clock: Clock) {
-        service = StatisticsServiceImpl(
-            notificationAccessService, waterStatisticAccessService, messageProvider, clock
-        )
+        service =
+            StatisticsServiceImpl(
+                notificationAccessService,
+                waterStatisticAccessService,
+                messageProvider,
+                clock,
+            )
     }
 
     private fun clockAt(iso: String): Clock = Clock.fixed(Instant.parse(iso), ZoneOffset.UTC)
@@ -94,7 +114,9 @@ class StatisticsServiceTest {
         val startCaptor = argumentCaptor<LocalDateTime>()
         val endCaptor = argumentCaptor<LocalDateTime>()
         verify(waterStatisticAccessService).findByUserAndEventTimeBetween(
-            eq(externalUserId), startCaptor.capture(), endCaptor.capture()
+            eq(externalUserId),
+            startCaptor.capture(),
+            endCaptor.capture(),
         )
         assertEquals(expectedStart, startCaptor.firstValue)
         assertEquals(expectedEnd, endCaptor.firstValue)
@@ -107,13 +129,14 @@ class StatisticsServiceTest {
     fun `getToday returns list as-is`() {
         buildService(clockAt("2026-05-07T22:30:00Z"))
         stubSettings(zone = "Europe/Moscow")
-        val expected = listOf(
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = externalUserId,
-                eventTime = LocalDateTime.of(2026, 5, 8, 8, 15),
-                waterAmountMl = 250,
-            ),
-        )
+        val expected =
+            listOf(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = externalUserId,
+                    eventTime = LocalDateTime.of(2026, 5, 8, 8, 15),
+                    waterAmountMl = 250,
+                ),
+            )
         stubEvents(expected)
 
         val result = service.getToday(externalUserId)
@@ -133,8 +156,8 @@ class StatisticsServiceTest {
                     externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 12, 8, 15),
                     waterAmountMl = 250,
-                )
-            )
+                ),
+            ),
         )
         stubFirstEntry(LocalDateTime.of(2026, 5, 1, 9, 0))
         stubInsight("insight day")
@@ -146,7 +169,7 @@ class StatisticsServiceTest {
         assertEquals(250, result.points[8].valueMl)
         assertEquals(2000, result.dailyGoalMl)
         assertEquals(250, result.averageMlPerDay) // days=1 -> total
-        assertNull(result.bestDay)                 // days=1 -> null
+        assertNull(result.bestDay) // days=1 -> null
         assertEquals("insight day", result.insightText)
         assertEquals(Instant.parse("2026-05-01T09:00:00Z"), result.firstEntryAt)
     }
@@ -169,7 +192,7 @@ class StatisticsServiceTest {
                     eventTime = LocalDateTime.of(2026, 5, 6, 10, 0),
                     waterAmountMl = 2400,
                 ),
-            )
+            ),
         )
         stubFirstEntry(null)
         stubInsight("insight week")
@@ -203,8 +226,8 @@ class StatisticsServiceTest {
                     externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 1, 9, 30),
                     waterAmountMl = 400,
-                )
-            )
+                ),
+            ),
         )
         stubFirstEntry(null)
         stubInsight()
@@ -244,7 +267,7 @@ class StatisticsServiceTest {
                     eventType = AnswerNotificationType.CANCEL,
                     waterAmountMl = 200,
                 ),
-            )
+            ),
         )
         stubFirstEntry(null)
         stubInsight()
@@ -266,13 +289,14 @@ class StatisticsServiceTest {
         val today = LocalDate.of(2026, 5, 20)
         buildService(clockAt("2026-05-20T12:00:00Z"))
         stubSettings()
-        val recentMet = (0L..6L).map { offset ->
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = externalUserId,
-                eventTime = today.minusDays(offset).atTime(10, 0),
-                waterAmountMl = 2200,
-            )
-        }
+        val recentMet =
+            (0L..6L).map { offset ->
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = externalUserId,
+                    eventTime = today.minusDays(offset).atTime(10, 0),
+                    waterAmountMl = 2200,
+                )
+            }
         stubEvents(recentMet)
         stubFirstEntry(null)
         stubInsight()
@@ -290,20 +314,24 @@ class StatisticsServiceTest {
         val today = LocalDate.of(2026, 5, 20)
         buildService(clockAt("2026-05-20T12:00:00Z"))
         stubSettings()
-        val events = (0L..500L).map { offset ->
-            DtoGenerator.generateWaterStatisticDto(
-                externalUserId = externalUserId,
-                eventTime = today.minusDays(offset).atTime(10, 0),
-                waterAmountMl = 2200,
-            )
-        }
+        val events =
+            (0L..500L).map { offset ->
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = externalUserId,
+                    eventTime = today.minusDays(offset).atTime(10, 0),
+                    waterAmountMl = 2200,
+                )
+            }
         stubEvents(events)
         stubFirstEntry(null)
         stubInsight()
 
-        val result = service.getStatistics(
-            externalUserId, today.minusDays(500), today
-        )
+        val result =
+            service.getStatistics(
+                externalUserId,
+                today.minusDays(500),
+                today,
+            )
 
         assertEquals(367, result.currentStreakDays)
     }
@@ -330,14 +358,17 @@ class StatisticsServiceTest {
                     eventTime = LocalDateTime.of(2026, 5, 17, 10, 0),
                     waterAmountMl = 2500,
                 ),
-            )
+            ),
         )
         stubFirstEntry(null)
         stubInsight()
 
-        val result = service.getStatistics(
-            externalUserId, LocalDate.of(2026, 5, 15), today
-        )
+        val result =
+            service.getStatistics(
+                externalUserId,
+                LocalDate.of(2026, 5, 15),
+                today,
+            )
 
         assertNotNull(result.bestDay)
         val bestDay = result.bestDay!!
@@ -352,9 +383,10 @@ class StatisticsServiceTest {
         // settings stub not needed: validation runs before user context fetch
         stubSettings()
 
-        val ex = assertThrows(IllegalArgumentException::class.java) {
-            service.getStatistics(externalUserId, LocalDate.of(2026, 5, 10), LocalDate.of(2026, 5, 9))
-        }
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                service.getStatistics(externalUserId, LocalDate.of(2026, 5, 10), LocalDate.of(2026, 5, 9))
+            }
         assertTrue(ex.message!!.contains("'from' must be before or equal to 'to'"))
     }
 
@@ -365,9 +397,10 @@ class StatisticsServiceTest {
         buildService(clockAt("2026-05-20T12:00:00Z"))
         stubSettings()
 
-        val ex = assertThrows(IllegalArgumentException::class.java) {
-            service.getStatistics(externalUserId, today.plusDays(1), today.plusDays(2))
-        }
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                service.getStatistics(externalUserId, today.plusDays(1), today.plusDays(2))
+            }
         assertTrue(ex.message!!.contains("'from' must not be in the future"))
     }
 
@@ -414,8 +447,8 @@ class StatisticsServiceTest {
                     externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 12, 10, 0),
                     waterAmountMl = 2200,
-                )
-            )
+                ),
+            ),
         )
         stubFirstEntry(null)
         stubInsight("text")
@@ -433,52 +466,52 @@ class StatisticsServiceTest {
     }
 
     companion object {
-
         @JvmStatic
-        fun provideZoneCases(): Stream<Arguments> = Stream.of(
-            Arguments.of(
-                "Europe/Moscow",
-                "2026-05-07T22:30:00Z",
-                LocalDateTime.of(2026, 5, 7, 21, 0),
-                LocalDateTime.of(2026, 5, 8, 21, 0),
-                "UTC+3, no DST",
-            ),
-            Arguments.of(
-                "UTC",
-                "2026-05-07T22:30:00Z",
-                LocalDateTime.of(2026, 5, 7, 0, 0),
-                LocalDateTime.of(2026, 5, 8, 0, 0),
-                "UTC, no offset",
-            ),
-            Arguments.of(
-                "America/Los_Angeles",
-                "2026-05-07T22:30:00Z",
-                LocalDateTime.of(2026, 5, 7, 7, 0),
-                LocalDateTime.of(2026, 5, 8, 7, 0),
-                "UTC-7, DST in May",
-            ),
-            Arguments.of(
-                "Pacific/Kiritimati",
-                "2026-05-07T22:30:00Z",
-                LocalDateTime.of(2026, 5, 7, 10, 0),
-                LocalDateTime.of(2026, 5, 8, 10, 0),
-                "UTC+14, extreme east",
-            ),
-            Arguments.of(
-                "Asia/Kolkata",
-                "2026-05-07T22:30:00Z",
-                LocalDateTime.of(2026, 5, 7, 18, 30),
-                LocalDateTime.of(2026, 5, 8, 18, 30),
-                "UTC+5:30, fractional offset",
-            ),
-            // DST spring-forward (23h day)
-            Arguments.of(
-                "America/New_York",
-                "2026-03-08T07:30:00Z",
-                LocalDateTime.of(2026, 3, 8, 5, 0),
-                LocalDateTime.of(2026, 3, 9, 4, 0),
-                "DST spring-forward (23-hour day)",
-            ),
-        )
+        fun provideZoneCases(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of(
+                    "Europe/Moscow",
+                    "2026-05-07T22:30:00Z",
+                    LocalDateTime.of(2026, 5, 7, 21, 0),
+                    LocalDateTime.of(2026, 5, 8, 21, 0),
+                    "UTC+3, no DST",
+                ),
+                Arguments.of(
+                    "UTC",
+                    "2026-05-07T22:30:00Z",
+                    LocalDateTime.of(2026, 5, 7, 0, 0),
+                    LocalDateTime.of(2026, 5, 8, 0, 0),
+                    "UTC, no offset",
+                ),
+                Arguments.of(
+                    "America/Los_Angeles",
+                    "2026-05-07T22:30:00Z",
+                    LocalDateTime.of(2026, 5, 7, 7, 0),
+                    LocalDateTime.of(2026, 5, 8, 7, 0),
+                    "UTC-7, DST in May",
+                ),
+                Arguments.of(
+                    "Pacific/Kiritimati",
+                    "2026-05-07T22:30:00Z",
+                    LocalDateTime.of(2026, 5, 7, 10, 0),
+                    LocalDateTime.of(2026, 5, 8, 10, 0),
+                    "UTC+14, extreme east",
+                ),
+                Arguments.of(
+                    "Asia/Kolkata",
+                    "2026-05-07T22:30:00Z",
+                    LocalDateTime.of(2026, 5, 7, 18, 30),
+                    LocalDateTime.of(2026, 5, 8, 18, 30),
+                    "UTC+5:30, fractional offset",
+                ),
+                // DST spring-forward (23h day)
+                Arguments.of(
+                    "America/New_York",
+                    "2026-03-08T07:30:00Z",
+                    LocalDateTime.of(2026, 3, 8, 5, 0),
+                    LocalDateTime.of(2026, 3, 9, 4, 0),
+                    "DST spring-forward (23-hour day)",
+                ),
+            )
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsServiceTest.kt
@@ -182,9 +182,10 @@ class StatisticsServiceTest {
         assertEquals("2026-05-06", result.points[2].label)
         assertEquals(2400, result.points[2].valueMl)
         assertNotNull(result.bestDay)
-        assertEquals(LocalDate.of(2026, 5, 6), result.bestDay!!.date)
-        assertEquals(2400, result.bestDay!!.valueMl)
-        assertEquals(DayOfWeek.WEDNESDAY, result.bestDay!!.weekday)
+        val bestDay = result.bestDay!!
+        assertEquals(LocalDate.of(2026, 5, 6), bestDay.date)
+        assertEquals(2400, bestDay.valueMl)
+        assertEquals(DayOfWeek.WEDNESDAY, bestDay.weekday)
         assertEquals((2100 + 2400) / 7, result.averageMlPerDay)
         assertNull(result.firstEntryAt)
     }
@@ -339,8 +340,9 @@ class StatisticsServiceTest {
         )
 
         assertNotNull(result.bestDay)
-        assertEquals(LocalDate.of(2026, 5, 17), result.bestDay!!.date)
-        assertEquals(2500, result.bestDay!!.valueMl)
+        val bestDay = result.bestDay!!
+        assertEquals(LocalDate.of(2026, 5, 17), bestDay.date)
+        assertEquals(2500, bestDay.valueMl)
     }
 
     @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsServiceTest.kt
@@ -7,11 +7,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
@@ -40,9 +40,9 @@ class StatisticsServiceTest {
 
     @BeforeEach
     fun setUp() {
-        notificationAccessService = mock(NotificationAccessService::class.java)
-        waterStatisticAccessService = mock(WaterStatisticAccessService::class.java)
-        messageProvider = mock(MessageProvider::class.java)
+        notificationAccessService = mock<NotificationAccessService>()
+        waterStatisticAccessService = mock<WaterStatisticAccessService>()
+        messageProvider = mock<MessageProvider>()
     }
 
     private fun stubInsight(text: String = "insight") {

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
@@ -28,7 +28,6 @@ import java.time.temporal.ChronoUnit
 @UnitTest
 @DisplayName("WaterStatisticService Unit Test")
 class WaterStatisticServiceTest {
-
     private val fixedNow = LocalDateTime.of(2025, 1, 1, 14, 0, 0)
     private val fixedClock = Clock.fixed(fixedNow.toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
 
@@ -75,10 +74,11 @@ class WaterStatisticServiceTest {
     @Test
     @DisplayName("recordEvents(): saves all statistics with correct eventType and source=NOTIFICATION")
     fun `recordEvents saves all statistics`() {
-        val users = listOf(
-            DtoGenerator.generateNotificationDto(externalUserId = 1L).telegramUser,
-            DtoGenerator.generateNotificationDto(externalUserId = 2L).telegramUser
-        )
+        val users =
+            listOf(
+                DtoGenerator.generateNotificationDto(externalUserId = 1L).telegramUser,
+                DtoGenerator.generateNotificationDto(externalUserId = 2L).telegramUser,
+            )
         val captor = argumentCaptor<Collection<WaterStatisticDto>>()
 
         service.recordEvents(users, AnswerNotificationType.CANCEL)
@@ -97,7 +97,9 @@ class WaterStatisticServiceTest {
     }
 
     @Test
-    @DisplayName("manualRecordEvent(): saves statistic with source=MANUAL, eventType=YES and converts consumedAt to UTC LocalDateTime")
+    @DisplayName(
+        "manualRecordEvent(): saves statistic with source=MANUAL, eventType=YES and converts consumedAt to UTC LocalDateTime",
+    )
     fun `manualRecordEvent saves statistic with manual source`() {
         val externalUserId = 1L
         val consumedAt = fixedClock.instant().minus(2, ChronoUnit.HOURS)
@@ -189,13 +191,14 @@ class WaterStatisticServiceTest {
     @Test
     @DisplayName("manualRecordEvent(): rejects consumedAt older than MAX_DAYS_AGO")
     fun `manualRecordEvent rejects consumedAt older than max days`() {
-        val tooOld = fixedClock.instant()
-            .minus(WaterEntryConstants.MAX_DAYS_AGO, ChronoUnit.DAYS)
-            .minus(1, ChronoUnit.SECONDS)
+        val tooOld =
+            fixedClock
+                .instant()
+                .minus(WaterEntryConstants.MAX_DAYS_AGO, ChronoUnit.DAYS)
+                .minus(1, ChronoUnit.SECONDS)
         assertThrows(IllegalArgumentException::class.java) {
             service.manualRecordEvent(1L, tooOld, 250)
         }
         verify(waterStatisticAccessService, never()).save(any())
     }
-
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/WaterStatisticServiceTest.kt
@@ -7,11 +7,11 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.never
-import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
@@ -37,7 +37,7 @@ class WaterStatisticServiceTest {
 
     @BeforeEach
     fun setUp() {
-        waterStatisticAccessService = mock(WaterStatisticAccessService::class.java)
+        waterStatisticAccessService = mock<WaterStatisticAccessService>()
         service = WaterStatisticServiceImpl(waterStatisticAccessService, fixedClock)
     }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/telegram/MessageEditorServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/telegram/MessageEditorServiceTest.kt
@@ -21,7 +21,6 @@ import ru.illine.drinking.ponies.test.tag.UnitTest
 @UnitTest
 @DisplayName("MessageEditorService Unit Test")
 class MessageEditorServiceTest {
-
     private val chatId = 1L
     private val messageId = 2
 
@@ -81,10 +80,11 @@ class MessageEditorServiceTest {
     @Test
     @DisplayName("deleteMessages(): executes DeleteMessage for each element")
     fun `deleteMessages with elements`() {
-        val messages = listOf(
-            Pair(chatId, 1),
-            Pair(chatId, 2)
-        )
+        val messages =
+            listOf(
+                Pair(chatId, 1),
+                Pair(chatId, 2),
+            )
 
         service.deleteMessages(messages)
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/telegram/MessageEditorServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/telegram/MessageEditorServiceTest.kt
@@ -3,8 +3,13 @@ package ru.illine.drinking.ponies.service.telegram
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.DeleteMessage
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageReplyMarkup
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText
@@ -25,7 +30,7 @@ class MessageEditorServiceTest {
 
     @BeforeEach
     fun setUp() {
-        sender = mock(TelegramClient::class.java)
+        sender = mock<TelegramClient>()
         service = MessageEditorServiceImpl(sender)
     }
 
@@ -49,7 +54,7 @@ class MessageEditorServiceTest {
     @Test
     @DisplayName("editReplyMarkup(): deletes old markup and sends new text with keyboard")
     fun `editReplyMarkup with keyboard`() {
-        val keyboard = mock(InlineKeyboardMarkup::class.java)
+        val keyboard = mock<InlineKeyboardMarkup>()
 
         service.editReplyMarkup("new text", chatId, messageId, replyKeyboard = keyboard)
 
@@ -97,7 +102,7 @@ class MessageEditorServiceTest {
     @Test
     @DisplayName("deleteMessage(): catches exception and does not rethrow")
     fun `deleteMessage catches exception`() {
-        doThrow(RuntimeException("Telegram error")).`when`(sender).execute(any<DeleteMessage>())
+        doThrow(RuntimeException("Telegram error")).whenever(sender).execute(any<DeleteMessage>())
 
         service.deleteMessage(chatId, messageId)
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/telegram/TelegramValidatorServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/telegram/TelegramValidatorServiceTest.kt
@@ -1,7 +1,10 @@
 package ru.illine.drinking.ponies.service.telegram
 
 import org.apache.commons.codec.digest.HmacUtils
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -18,7 +21,6 @@ import java.time.Instant
 @UnitTest
 @DisplayName("TelegramValidatorService Unit Test")
 class TelegramValidatorServiceTest {
-
     private val token = "token"
     private val userJson = """{"id":1,"first_name":"First Name"}"""
     private val queryId = "query"
@@ -27,14 +29,15 @@ class TelegramValidatorServiceTest {
 
     @BeforeEach
     fun setUp() {
-        val properties = TelegramBotProperties(
-            token = token,
-            username = "username",
-            miniAppUrl = "https://t.me/Test/app",
-            autoUpdateTelegramConfig = false,
-            authDateExpirationSeconds = 3600,
-            http = TelegramBotProperties.Http(connectionTimeToLiveInSec = 30, maxConnectionTotal = 10)
-        )
+        val properties =
+            TelegramBotProperties(
+                token = token,
+                username = "username",
+                miniAppUrl = "https://t.me/Test/app",
+                autoUpdateTelegramConfig = false,
+                authDateExpirationSeconds = 3600,
+                http = TelegramBotProperties.Http(connectionTimeToLiveInSec = 30, maxConnectionTotal = 10),
+            )
         service = TelegramValidatorServiceImpl(properties)
     }
 
@@ -97,11 +100,12 @@ class TelegramValidatorServiceTest {
     }
 
     private fun buildInitData(authDate: Long): String {
-        val fields = sortedMapOf(
-            "auth_date" to authDate.toString(),
-            "query_id" to queryId,
-            "user" to userJson
-        )
+        val fields =
+            sortedMapOf(
+                "auth_date" to authDate.toString(),
+                "query_id" to queryId,
+                "user" to userJson,
+            )
         val dataCheckString = fields.entries.joinToString("\n") { "${it.key}=${it.value}" }
         val secretKey = HmacUtils("HmacSHA256", "WebAppData").hmac(token)
         val hash = HmacUtils("HmacSHA256", secretKey).hmacHex(dataCheckString)

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/telegram/TelegramValidatorServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/telegram/TelegramValidatorServiceTest.kt
@@ -82,7 +82,7 @@ class TelegramValidatorServiceTest {
 
         val result = service.map(initData)
 
-        assertEquals(1L, result.telegramId)
+        assertEquals(1L, result.externalUserId)
         assertEquals("First Name", result.firstName)
     }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/test/config/TestDatabaseConfig.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/test/config/TestDatabaseConfig.kt
@@ -11,24 +11,18 @@ import javax.sql.DataSource
 
 @TestConfiguration
 class TestDatabaseConfig {
-
-    private val POSTGRES_IMAGE = "postgres:14-alpine"
-    private val INIT_DATABASE_FILE_PATH = "sql/init.sql"
-    private val COMPATIBLE_POSTGRES = "postgres"
-
     @Bean(initMethod = "start", destroyMethod = "stop")
-    fun postgresContainer(dockerPostgres: DockerImageName): PostgreSQLContainer<*> {
-        return PostgreSQLContainer(dockerPostgres)
-            .withReuse(true )
+    fun postgresContainer(dockerPostgres: DockerImageName): PostgreSQLContainer<*> =
+        PostgreSQLContainer(dockerPostgres)
+            .withReuse(true)
             .withInitScript(INIT_DATABASE_FILE_PATH)
             .waitingFor(Wait.forListeningPort())
-    }
 
     @Bean
-    fun dockerPostgres(): DockerImageName {
-        return DockerImageName.parse(POSTGRES_IMAGE)
+    fun dockerPostgres(): DockerImageName =
+        DockerImageName
+            .parse(POSTGRES_IMAGE)
             .asCompatibleSubstituteFor(COMPATIBLE_POSTGRES)
-    }
 
     @Bean
     fun dataSource(postgresContainer: PostgreSQLContainer<*>): DataSource {
@@ -37,5 +31,11 @@ class TestDatabaseConfig {
         hikariConfig.username = postgresContainer.username
         hikariConfig.password = postgresContainer.password
         return HikariDataSource(hikariConfig)
+    }
+
+    companion object {
+        private const val POSTGRES_IMAGE = "postgres:14-alpine"
+        private const val INIT_DATABASE_FILE_PATH = "sql/init.sql"
+        private const val COMPATIBLE_POSTGRES = "postgres"
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/test/config/TestTimeConfig.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/test/config/TestTimeConfig.kt
@@ -9,15 +9,13 @@ import kotlin.random.Random
 
 @TestConfiguration
 class TestTimeConfig {
-
     @Bean
-    fun clock(): Clock {
-        return ClockHelperTest.MutableClock(
-            Instant.parse(ClockHelperTest.DEFAULT_TIME), ClockHelperTest.DEFAULT_ZONE
+    fun clock(): Clock =
+        ClockHelperTest.MutableClock(
+            Instant.parse(ClockHelperTest.DEFAULT_TIME),
+            ClockHelperTest.DEFAULT_ZONE,
         )
-    }
 
     @Bean
     fun random(): Random = Random(42)
-
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
@@ -3,21 +3,27 @@ package ru.illine.drinking.ponies.test.generator
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
-import ru.illine.drinking.ponies.model.dto.*
+import ru.illine.drinking.ponies.model.dto.BestDayDto
+import ru.illine.drinking.ponies.model.dto.SettingDto
+import ru.illine.drinking.ponies.model.dto.StatisticsDto
+import ru.illine.drinking.ponies.model.dto.StatisticsPointDto
+import ru.illine.drinking.ponies.model.dto.TelegramUserDto
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.model.dto.message.InsightStatsContext
 import ru.illine.drinking.ponies.model.dto.request.WaterEntryRequest
 import ru.illine.drinking.ponies.model.dto.response.PauseStateResponse
-import java.time.*
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
 import kotlin.random.Random
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto as InternalTelegramUserDto
 
 class DtoGenerator {
-
     companion object {
-
         fun generateNotificationDto(
             externalUserId: Long = Random.nextLong(),
             externalChatId: Long = Random.nextLong(),
@@ -31,15 +37,17 @@ class DtoGenerator {
             pauseUntil: LocalDateTime? = null,
             dailyGoalMl: Int = 2000,
         ): NotificationSettingDto {
-            val user = InternalTelegramUserDto(
-                externalUserId = externalUserId,
-                userTimeZone = userTimeZone,
-            )
-            val chat = TelegramChatDto(
-                telegramUser = user,
-                externalChatId = externalChatId,
-                previousNotificationMessageId = previousNotificationMessageId,
-            )
+            val user =
+                InternalTelegramUserDto(
+                    externalUserId = externalUserId,
+                    userTimeZone = userTimeZone,
+                )
+            val chat =
+                TelegramChatDto(
+                    telegramUser = user,
+                    externalChatId = externalChatId,
+                    previousNotificationMessageId = previousNotificationMessageId,
+                )
             return NotificationSettingDto(
                 telegramUser = user,
                 telegramChat = chat,
@@ -61,10 +69,11 @@ class DtoGenerator {
             userTimeZone: String = "Europe/Moscow",
             source: WaterEntrySourceType = WaterEntrySourceType.NOTIFICATION,
         ): WaterStatisticDto {
-            val user = InternalTelegramUserDto(
-                externalUserId = externalUserId,
-                userTimeZone = userTimeZone,
-            )
+            val user =
+                InternalTelegramUserDto(
+                    externalUserId = externalUserId,
+                    userTimeZone = userTimeZone,
+                )
             return WaterStatisticDto(
                 telegramUser = user,
                 eventTime = eventTime,
@@ -77,52 +86,57 @@ class DtoGenerator {
         fun generateWaterEvent(
             eventTime: LocalDateTime = LocalDateTime.now(),
             waterAmountMl: Int = 250,
-        ): WaterStatisticDto = generateWaterStatisticDto(
-            eventTime = eventTime,
-            waterAmountMl = waterAmountMl,
-        )
+        ): WaterStatisticDto =
+            generateWaterStatisticDto(
+                eventTime = eventTime,
+                waterAmountMl = waterAmountMl,
+            )
 
         fun generateInsightStatsContext(
             currentStreakDays: Int = 0,
             avgMlPerDay: Int = 0,
             dailyGoalMl: Int = 2000,
             bestDay: BestDayDto? = null,
-        ): InsightStatsContext = InsightStatsContext(
-            avgMlPerDay = avgMlPerDay,
-            bestDay = bestDay,
-            currentStreakDays = currentStreakDays,
-            dailyGoalMl = dailyGoalMl,
-        )
+        ): InsightStatsContext =
+            InsightStatsContext(
+                avgMlPerDay = avgMlPerDay,
+                bestDay = bestDay,
+                currentStreakDays = currentStreakDays,
+                dailyGoalMl = dailyGoalMl,
+            )
 
         fun generateBestDayDto(
             date: LocalDate = LocalDate.of(2026, 5, 6),
             valueMl: Int = 2400,
             weekday: DayOfWeek = DayOfWeek.WEDNESDAY,
-        ): BestDayDto = BestDayDto(
-            date = date,
-            valueMl = valueMl,
-            weekday = weekday,
-        )
+        ): BestDayDto =
+            BestDayDto(
+                date = date,
+                valueMl = valueMl,
+                weekday = weekday,
+            )
 
         fun generateWaterEntryRequest(
             consumedAt: Instant? = Instant.now().minusSeconds(300),
             amountMl: Int = 250,
-        ): WaterEntryRequest = WaterEntryRequest(
-            consumedAt = consumedAt,
-            amountMl = amountMl,
-        )
+        ): WaterEntryRequest =
+            WaterEntryRequest(
+                consumedAt = consumedAt,
+                amountMl = amountMl,
+            )
 
         fun generateTelegramUserDto(
             externalUserId: Long = 1L,
             firstName: String? = "First Name",
             lastName: String? = null,
             username: String? = "username",
-        ): TelegramUserDto = TelegramUserDto(
-            externalUserId = externalUserId,
-            firstName = firstName,
-            lastName = lastName,
-            username = username,
-        )
+        ): TelegramUserDto =
+            TelegramUserDto(
+                externalUserId = externalUserId,
+                firstName = firstName,
+                lastName = lastName,
+                username = username,
+            )
 
         fun generateSettingDto(
             interval: String? = IntervalNotificationType.HOUR_AND_HALF.name,
@@ -133,49 +147,53 @@ class DtoGenerator {
             timezone: String? = "America/New_York",
             dailyGoalMl: Int? = 2500,
             notificationActive: Boolean = true,
-        ): SettingDto = SettingDto(
-            interval = interval,
-            intervalDisplayName = intervalDisplayName,
-            intervalMinutes = intervalMinutes,
-            quietModeStart = quietModeStart,
-            quietModeEnd = quietModeEnd,
-            timezone = timezone,
-            dailyGoalMl = dailyGoalMl,
-            notificationActive = notificationActive,
-        )
+        ): SettingDto =
+            SettingDto(
+                interval = interval,
+                intervalDisplayName = intervalDisplayName,
+                intervalMinutes = intervalMinutes,
+                quietModeStart = quietModeStart,
+                quietModeEnd = quietModeEnd,
+                timezone = timezone,
+                dailyGoalMl = dailyGoalMl,
+                notificationActive = notificationActive,
+            )
 
         fun generateStatisticsDto(
-            points: List<StatisticsPointDto> = listOf(
-                StatisticsPointDto("2026-05-04", 1800),
-                StatisticsPointDto("2026-05-05", 2100),
-                StatisticsPointDto("2026-05-06", 2400),
-                StatisticsPointDto("2026-05-07", 1500),
-                StatisticsPointDto("2026-05-08", 0),
-                StatisticsPointDto("2026-05-09", 0),
-                StatisticsPointDto("2026-05-10", 0),
-            ),
+            points: List<StatisticsPointDto> =
+                listOf(
+                    StatisticsPointDto("2026-05-04", 1800),
+                    StatisticsPointDto("2026-05-05", 2100),
+                    StatisticsPointDto("2026-05-06", 2400),
+                    StatisticsPointDto("2026-05-07", 1500),
+                    StatisticsPointDto("2026-05-08", 0),
+                    StatisticsPointDto("2026-05-09", 0),
+                    StatisticsPointDto("2026-05-10", 0),
+                ),
             dailyGoalMl: Int = 2000,
             averageMlPerDay: Int = 1114,
             bestDay: BestDayDto? = generateBestDayDto(),
             currentStreakDays: Int = 3,
             insightText: String = "insight",
             firstEntryAt: Instant? = Instant.parse("2026-04-15T10:30:00Z"),
-        ): StatisticsDto = StatisticsDto(
-            points = points,
-            dailyGoalMl = dailyGoalMl,
-            averageMlPerDay = averageMlPerDay,
-            bestDay = bestDay,
-            currentStreakDays = currentStreakDays,
-            insightText = insightText,
-            firstEntryAt = firstEntryAt,
-        )
+        ): StatisticsDto =
+            StatisticsDto(
+                points = points,
+                dailyGoalMl = dailyGoalMl,
+                averageMlPerDay = averageMlPerDay,
+                bestDay = bestDay,
+                currentStreakDays = currentStreakDays,
+                insightText = insightText,
+                firstEntryAt = firstEntryAt,
+            )
 
         fun generatePauseStateResponse(
             paused: Boolean = true,
             pauseUntil: Instant? = Instant.parse("2025-01-01T18:00:00Z"),
-        ): PauseStateResponse = PauseStateResponse(
-            paused = paused,
-            pauseUntil = pauseUntil,
-        )
+        ): PauseStateResponse =
+            PauseStateResponse(
+                paused = paused,
+                pauseUntil = pauseUntil,
+            )
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
@@ -113,12 +113,12 @@ class DtoGenerator {
         )
 
         fun generateTelegramUserDto(
-            telegramId: Long = 1L,
+            externalUserId: Long = 1L,
             firstName: String? = "First Name",
             lastName: String? = null,
             username: String? = "username",
         ): TelegramUserDto = TelegramUserDto(
-            telegramId = telegramId,
+            externalUserId = externalUserId,
             firstName = firstName,
             lastName = lastName,
             username = username,

--- a/src/test/kotlin/ru/illine/drinking/ponies/test/tag/SpringIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/test/tag/SpringIntegrationTest.kt
@@ -19,9 +19,9 @@ import ru.illine.drinking.ponies.test.config.TestTimeConfig
         DrinkingPoniesApplication::class,
         TestDatabaseConfig::class,
         TestTimeConfig::class,
-    ]
+    ],
 )
-// These library beans must be mocked via @MockitoBean (not @Bean @Primary) 
+// These library beans must be mocked via @MockitoBean (not @Bean @Primary)
 // to prevent real instantiation and network connections
 @MockitoBean(types = [TelegramBotsLongPollingApplication::class, BaseAbilityBot::class])
 @ActiveProfiles("integration-test")

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/ClockHelperTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/ClockHelperTest.kt
@@ -6,13 +6,12 @@ import java.time.ZoneId
 import java.time.ZoneOffset
 
 object ClockHelperTest {
-
     val DEFAULT_TIME = "2025-01-01T12:00:00Z"
     val DEFAULT_ZONE = ZoneOffset.UTC
 
     class MutableClock(
         private var instant: Instant,
-        private val zone: ZoneId
+        private val zone: ZoneId,
     ) : Clock() {
         fun setTime(newInstant: Instant) {
             this.instant = newInstant

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/FunctionHelperTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/FunctionHelperTest.kt
@@ -1,6 +1,9 @@
 package ru.illine.drinking.ponies.util
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import ru.illine.drinking.ponies.test.tag.UnitTest
@@ -11,15 +14,15 @@ import ru.illine.drinking.ponies.util.FunctionHelper.check
 @UnitTest
 @DisplayName("FunctionHelper Unit Test")
 class FunctionHelperTest {
-
     @Test
     @DisplayName("check(): returns necessary value when true")
     fun `successful check true`() {
         val expected = "true"
-        val actual = true.check(
-            ifTrue = { "true" },
-            ifFalse = { "false" }
-        )
+        val actual =
+            true.check(
+                ifTrue = { "true" },
+                ifFalse = { "false" },
+            )
 
         assertEquals(expected, actual)
     }
@@ -28,10 +31,11 @@ class FunctionHelperTest {
     @DisplayName("check(): returns necessary value when false")
     fun `successful check false`() {
         val expected = "false"
-        val actual = false.check(
-            ifTrue = { "true" },
-            ifFalse = { "false" }
-        )
+        val actual =
+            false.check(
+                ifTrue = { "true" },
+                ifFalse = { "false" },
+            )
 
         assertEquals(expected, actual)
     }
@@ -42,9 +46,9 @@ class FunctionHelperTest {
         var expected = false
 
         catchAny(
-            action = {  },
+            action = { },
             ifException = { expected = true },
-            errorLogging = { /* No-op for test */ }
+            errorLogging = { /* No-op for test */ },
         )
 
         assertFalse(expected)
@@ -58,7 +62,7 @@ class FunctionHelperTest {
         catchAny(
             action = { throw RuntimeException() },
             ifException = { expected = true },
-            errorLogging = { /* No-op for test */ }
+            errorLogging = { /* No-op for test */ },
         )
 
         assertTrue(expected)
@@ -72,7 +76,7 @@ class FunctionHelperTest {
         catchAny(
             action = { throw RuntimeException() },
             ifException = { /* No-op for test */ },
-            errorLogging = { expected = true }
+            errorLogging = { expected = true },
         )
 
         assertTrue(expected)
@@ -81,14 +85,14 @@ class FunctionHelperTest {
     @Test
     @DisplayName("catchAnyWithReturn(): doesn't executes ifException when there isn't any exception")
     fun `successful catchAnyWithReturn action`() {
-
         val expected = true
 
-        val actual: Boolean? = catchAnyWithReturn(
-            action = { true },
-            ifException = { false },
-            errorLogging = { /* No-op for test */ }
-        )
+        val actual: Boolean? =
+            catchAnyWithReturn(
+                action = { true },
+                ifException = { false },
+                errorLogging = { /* No-op for test */ },
+            )
 
         assertEquals(expected, actual)
     }
@@ -96,14 +100,14 @@ class FunctionHelperTest {
     @Test
     @DisplayName("catchAnyWithReturn(): executes ifException when any exception")
     fun `successful catchAnyWithReturn ifException`() {
-
         val expected = false
 
-        val actual: Boolean? = catchAnyWithReturn(
-            action = { throw RuntimeException() },
-            ifException = { false },
-            errorLogging = { /* No-op for test */ }
-        )
+        val actual: Boolean? =
+            catchAnyWithReturn(
+                action = { throw RuntimeException() },
+                ifException = { false },
+                errorLogging = { /* No-op for test */ },
+            )
 
         assertEquals(expected, actual)
     }
@@ -116,7 +120,7 @@ class FunctionHelperTest {
         catchAnyWithReturn(
             action = { throw RuntimeException() },
             ifException = { true },
-            errorLogging = { expected = true }
+            errorLogging = { expected = true },
         )
 
         assertTrue(expected)

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/PluralizationHelperTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/PluralizationHelperTest.kt
@@ -9,7 +9,6 @@ import ru.illine.drinking.ponies.test.tag.UnitTest
 @UnitTest
 @DisplayName("PluralizationHelper Unit Test")
 class PluralizationHelperTest {
-
     @ParameterizedTest(name = "[{index}] n={0} -> {1}")
     @CsvSource(
         // singular form (1, 21, 31, 101, ..., excluding 11)
@@ -50,7 +49,10 @@ class PluralizationHelperTest {
         "-11,       дней",
         "-21,       день",
     )
-    fun `pluralizeDays returns russian form by mod100 and mod10 rules`(n: Int, expected: String) {
+    fun `pluralizeDays returns russian form by mod100 and mod10 rules`(
+        n: Int,
+        expected: String,
+    ) {
         val result = PluralizationHelper.pluralizeDays(n)
 
         assertEquals(expected, result)

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/TelegramBotKeyboardHelperTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/TelegramBotKeyboardHelperTest.kt
@@ -1,6 +1,8 @@
 package ru.illine.drinking.ponies.util
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup
@@ -13,7 +15,6 @@ import ru.illine.drinking.ponies.util.telegram.TelegramBotKeyboardHelper
 @UnitTest
 @DisplayName("TelegramBotKeyboardHelper Unit Test")
 class TelegramBotKeyboardHelperTest {
-
     @Test
     @DisplayName("snoozeTimeButtons(): returns valid keyboard")
     fun `successful snoozeTimeButtons`() {

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/TimeHelperTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/TimeHelperTest.kt
@@ -7,12 +7,15 @@ import ru.illine.drinking.ponies.test.tag.UnitTest
 import ru.illine.drinking.ponies.util.TimeHelper.DEFAULT_TIME_FORMATTER
 import ru.illine.drinking.ponies.util.TimeHelper.nextNotificationTimeByNow
 import ru.illine.drinking.ponies.util.TimeHelper.timeToString
-import java.time.*
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneOffset
 
 @UnitTest
 @DisplayName("TimeHelper Unit Test")
 class TimeHelperTest {
-
     private val clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)
     private val now = LocalDateTime.now(clock)
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/message/TemplateRuleTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/message/TemplateRuleTest.kt
@@ -1,0 +1,39 @@
+package ru.illine.drinking.ponies.util.message
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import ru.illine.drinking.ponies.model.dto.message.InsightStatsContext
+import ru.illine.drinking.ponies.test.tag.UnitTest
+
+@UnitTest
+@DisplayName("TemplateRule Unit Test")
+class TemplateRuleTest {
+
+    @Test
+    @DisplayName("init: empty templates list is rejected (rule must carry at least one template)")
+    fun `empty templates rejected`() {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            TemplateRule<InsightStatsContext>(
+                predicate = { true },
+                templates = emptyList()
+            )
+        }
+
+        assertEquals("TemplateRule must have at least one template", exception.message)
+    }
+
+    @Test
+    @DisplayName("init: non-empty templates list is accepted")
+    fun `non-empty templates accepted`() {
+        val rule = TemplateRule<InsightStatsContext>(
+            predicate = { true },
+            templates = listOf({ "phrase" })
+        )
+
+        assertTrue(rule.predicate(InsightStatsContext(avgMlPerDay = 0, bestDay = null, currentStreakDays = 0, dailyGoalMl = 0)))
+        assertEquals(1, rule.templates.size)
+    }
+}

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/message/TemplateRuleTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/message/TemplateRuleTest.kt
@@ -11,16 +11,16 @@ import ru.illine.drinking.ponies.test.tag.UnitTest
 @UnitTest
 @DisplayName("TemplateRule Unit Test")
 class TemplateRuleTest {
-
     @Test
     @DisplayName("init: empty templates list is rejected (rule must carry at least one template)")
     fun `empty templates rejected`() {
-        val exception = assertThrows(IllegalArgumentException::class.java) {
-            TemplateRule<InsightStatsContext>(
-                predicate = { true },
-                templates = emptyList()
-            )
-        }
+        val exception =
+            assertThrows(IllegalArgumentException::class.java) {
+                TemplateRule<InsightStatsContext>(
+                    predicate = { true },
+                    templates = emptyList(),
+                )
+            }
 
         assertEquals("TemplateRule must have at least one template", exception.message)
     }
@@ -28,12 +28,17 @@ class TemplateRuleTest {
     @Test
     @DisplayName("init: non-empty templates list is accepted")
     fun `non-empty templates accepted`() {
-        val rule = TemplateRule<InsightStatsContext>(
-            predicate = { true },
-            templates = listOf({ "phrase" })
-        )
+        val rule =
+            TemplateRule<InsightStatsContext>(
+                predicate = { true },
+                templates = listOf({ "phrase" }),
+            )
 
-        assertTrue(rule.predicate(InsightStatsContext(avgMlPerDay = 0, bestDay = null, currentStreakDays = 0, dailyGoalMl = 0)))
+        assertTrue(
+            rule.predicate(
+                InsightStatsContext(avgMlPerDay = 0, bestDay = null, currentStreakDays = 0, dailyGoalMl = 0),
+            ),
+        )
         assertEquals(1, rule.templates.size)
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/sql/CustomP6SpyLoggerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/sql/CustomP6SpyLoggerTest.kt
@@ -12,7 +12,6 @@ import ru.illine.drinking.ponies.test.tag.UnitTest
 @UnitTest
 @DisplayName("CustomP6SpyLogger Unit Test")
 class CustomP6SpyLoggerTest {
-
     @Test
     @DisplayName("init(): initializes without exception when field is found")
     fun `init succeeds when field found`() {

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/sql/CustomP6SpyLoggerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/sql/CustomP6SpyLoggerTest.kt
@@ -22,6 +22,8 @@ class CustomP6SpyLoggerTest {
     @Test
     @DisplayName("init(): does nothing when field is not found")
     fun `init skips when field not found`() {
+        // Exception to the mockito-kotlin style: mockito-kotlin 5.2.1 has no mockStatic wrapper,
+        // so static mocking uses the raw Mockito API (mockStatic + MockedStatic.`when`).
         mockStatic(ReflectionUtils::class.java).use { mocked: MockedStatic<ReflectionUtils> ->
             mocked.`when`<Any?> { ReflectionUtils.findField(any(), anyString()) }.thenReturn(null)
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsAggregatorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsAggregatorTest.kt
@@ -1,6 +1,9 @@
 package ru.illine.drinking.ponies.util.statistics
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -18,18 +21,18 @@ import java.util.stream.Stream
 @UnitTest
 @DisplayName("StatisticsAggregator Unit Test")
 class StatisticsAggregatorTest {
-
     private val utcZone = ZoneId.of("UTC")
     private val yekZone = ZoneId.of("Asia/Yekaterinburg")
 
     @Test
     @DisplayName("sumByLocalDate(): groups events by local date and sums waterAmountMl")
     fun `sumByLocalDate groups by local date`() {
-        val events = listOf(
-            DtoGenerator.generateWaterEvent(LocalDateTime.of(2026, 5, 12, 8, 0), 250),
-            DtoGenerator.generateWaterEvent(LocalDateTime.of(2026, 5, 12, 18, 0), 500),
-            DtoGenerator.generateWaterEvent(LocalDateTime.of(2026, 5, 13, 9, 0), 300),
-        )
+        val events =
+            listOf(
+                DtoGenerator.generateWaterEvent(LocalDateTime.of(2026, 5, 12, 8, 0), 250),
+                DtoGenerator.generateWaterEvent(LocalDateTime.of(2026, 5, 12, 18, 0), 500),
+                DtoGenerator.generateWaterEvent(LocalDateTime.of(2026, 5, 13, 9, 0), 300),
+            )
 
         val result = StatisticsAggregator.sumByLocalDate(events, utcZone)
 
@@ -59,7 +62,6 @@ class StatisticsAggregatorTest {
         assertTrue(result.isEmpty())
     }
 
-
     @Test
     @DisplayName("aggregateByHour(): always returns 24 points with HH:00 labels")
     fun `aggregateByHour returns 24 points`() {
@@ -84,11 +86,12 @@ class StatisticsAggregatorTest {
     @Test
     @DisplayName("aggregateByHour(): event at 08:15 local -> bucket 08:00 (sum across same hour)")
     fun `aggregateByHour buckets by local hour`() {
-        val events = listOf(
-            DtoGenerator.generateWaterEvent(LocalDateTime.of(2026, 5, 12, 8, 15), 250),
-            DtoGenerator.generateWaterEvent(LocalDateTime.of(2026, 5, 12, 8, 45), 300),
-            DtoGenerator.generateWaterEvent(LocalDateTime.of(2026, 5, 12, 13, 0), 500),
-        )
+        val events =
+            listOf(
+                DtoGenerator.generateWaterEvent(LocalDateTime.of(2026, 5, 12, 8, 15), 250),
+                DtoGenerator.generateWaterEvent(LocalDateTime.of(2026, 5, 12, 8, 45), 300),
+                DtoGenerator.generateWaterEvent(LocalDateTime.of(2026, 5, 12, 13, 0), 500),
+            )
 
         val result = StatisticsAggregator.aggregateByHour(events, utcZone)
 
@@ -114,10 +117,11 @@ class StatisticsAggregatorTest {
     @Test
     @DisplayName("aggregateByDay(): builds dense series with zero filling")
     fun `aggregateByDay fills zeros for missing days`() {
-        val byDate = mapOf(
-            LocalDate.of(2026, 5, 4) to 1800,
-            LocalDate.of(2026, 5, 6) to 2400,
-        )
+        val byDate =
+            mapOf(
+                LocalDate.of(2026, 5, 4) to 1800,
+                LocalDate.of(2026, 5, 6) to 2400,
+            )
 
         val result = StatisticsAggregator.aggregateByDay(byDate, LocalDate.of(2026, 5, 4), 7)
 
@@ -143,7 +147,9 @@ class StatisticsAggregatorTest {
     @MethodSource("provideAverageCases")
     @DisplayName("averageMlPerDay(): returns floor(total / days)")
     fun `averageMlPerDay table`(
-        days: Int, points: List<StatisticsPointDto>, expected: Int,
+        days: Int,
+        points: List<StatisticsPointDto>,
+        expected: Int,
         @Suppress("UNUSED_PARAMETER") description: String,
     ) {
         val result = StatisticsAggregator.averageMlPerDay(days, points)
@@ -182,10 +188,11 @@ class StatisticsAggregatorTest {
     @Test
     @DisplayName("bestDay(): all-zero values -> null")
     fun `bestDay all zeros returns null`() {
-        val byDate = mapOf(
-            LocalDate.of(2026, 5, 4) to 0,
-            LocalDate.of(2026, 5, 5) to 0,
-        )
+        val byDate =
+            mapOf(
+                LocalDate.of(2026, 5, 4) to 0,
+                LocalDate.of(2026, 5, 5) to 0,
+            )
 
         val result = StatisticsAggregator.bestDay(7, byDate)
 
@@ -196,12 +203,13 @@ class StatisticsAggregatorTest {
     @DisplayName("bestDay(): picks max value with weekday")
     fun `bestDay picks max with weekday`() {
         // 2026-05-06 is Wednesday
-        val byDate = mapOf(
-            LocalDate.of(2026, 5, 4) to 1800,
-            LocalDate.of(2026, 5, 5) to 2100,
-            LocalDate.of(2026, 5, 6) to 2400,
-            LocalDate.of(2026, 5, 7) to 1500,
-        )
+        val byDate =
+            mapOf(
+                LocalDate.of(2026, 5, 4) to 1800,
+                LocalDate.of(2026, 5, 5) to 2100,
+                LocalDate.of(2026, 5, 6) to 2400,
+                LocalDate.of(2026, 5, 7) to 1500,
+            )
 
         val result = StatisticsAggregator.bestDay(7, byDate)
 
@@ -214,11 +222,12 @@ class StatisticsAggregatorTest {
     @Test
     @DisplayName("bestDay(): tie returns chronologically first maximum")
     fun `bestDay tie returns earliest`() {
-        val byDate = mapOf(
-            LocalDate.of(2026, 5, 6) to 2400,
-            LocalDate.of(2026, 5, 4) to 2400,
-            LocalDate.of(2026, 5, 7) to 1800,
-        )
+        val byDate =
+            mapOf(
+                LocalDate.of(2026, 5, 6) to 2400,
+                LocalDate.of(2026, 5, 4) to 2400,
+                LocalDate.of(2026, 5, 7) to 1800,
+            )
 
         val result = StatisticsAggregator.bestDay(7, byDate)
 
@@ -243,49 +252,49 @@ class StatisticsAggregatorTest {
     }
 
     companion object {
-
         @JvmStatic
-        fun provideAverageCases(): Stream<Arguments> = Stream.of(
-            // days=1, total=750
-            Arguments.of(
-                1,
-                listOf(StatisticsPointDto("08:00", 250), StatisticsPointDto("13:00", 500)),
-                750,
-                "days=1 returns total",
-            ),
-            // days=7, floor division
-            Arguments.of(
-                7,
-                listOf(
-                    StatisticsPointDto("2026-05-04", 1800),
-                    StatisticsPointDto("2026-05-05", 2100),
-                    StatisticsPointDto("2026-05-06", 2400),
-                    StatisticsPointDto("2026-05-07", 1500),
-                    StatisticsPointDto("2026-05-08", 0),
-                    StatisticsPointDto("2026-05-09", 0),
-                    StatisticsPointDto("2026-05-10", 0),
+        fun provideAverageCases(): Stream<Arguments> =
+            Stream.of(
+                // days=1, total=750
+                Arguments.of(
+                    1,
+                    listOf(StatisticsPointDto("08:00", 250), StatisticsPointDto("13:00", 500)),
+                    750,
+                    "days=1 returns total",
                 ),
-                (1800 + 2100 + 2400 + 1500) / 7,
-                "days=7 with partial fill (floor division)",
-            ),
-            // days=28, all zeros
-            Arguments.of(
-                28,
-                (1..28).map { StatisticsPointDto("2025-02-%02d".format(it), 0) },
-                0,
-                "all zeros",
-            ),
-            // days=2, total=999 -> 999/2 = 499 (floor)
-            Arguments.of(
-                2,
-                listOf(
-                    StatisticsPointDto("2026-05-04", 500),
-                    StatisticsPointDto("2026-05-05", 499),
+                // days=7, floor division
+                Arguments.of(
+                    7,
+                    listOf(
+                        StatisticsPointDto("2026-05-04", 1800),
+                        StatisticsPointDto("2026-05-05", 2100),
+                        StatisticsPointDto("2026-05-06", 2400),
+                        StatisticsPointDto("2026-05-07", 1500),
+                        StatisticsPointDto("2026-05-08", 0),
+                        StatisticsPointDto("2026-05-09", 0),
+                        StatisticsPointDto("2026-05-10", 0),
+                    ),
+                    (1800 + 2100 + 2400 + 1500) / 7,
+                    "days=7 with partial fill (floor division)",
                 ),
-                499,
-                "floor division non-zero",
-            ),
-        )
+                // days=28, all zeros
+                Arguments.of(
+                    28,
+                    (1..28).map { StatisticsPointDto("2025-02-%02d".format(it), 0) },
+                    0,
+                    "all zeros",
+                ),
+                // days=2, total=999 -> 999/2 = 499 (floor)
+                Arguments.of(
+                    2,
+                    listOf(
+                        StatisticsPointDto("2026-05-04", 500),
+                        StatisticsPointDto("2026-05-05", 499),
+                    ),
+                    499,
+                    "floor division non-zero",
+                ),
+            )
 
         @JvmStatic
         fun provideCalculateStreakCases(): Stream<Arguments> {

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsAggregatorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsAggregatorTest.kt
@@ -342,14 +342,25 @@ class StatisticsAggregatorTest {
                     ),
                     today,
                     2000,
-                    "today below goal -> streak=0 (chain broken now, prior days ignored)",
-                    0,
+                    "today below goal but yesterday met -> hanging streak ignores unfinished today -> 2",
+                    2,
                 ),
                 Arguments.of(
                     mapOf(today.minusDays(1) to 2000),
                     today,
                     2000,
-                    "today missing entirely -> streak=0",
+                    "today missing but yesterday met -> hanging streak -> 1",
+                    1,
+                ),
+                Arguments.of(
+                    mapOf(
+                        today to 500,
+                        today.minusDays(1) to 500,
+                        today.minusDays(2) to 2000,
+                    ),
+                    today,
+                    2000,
+                    "today below goal and yesterday below goal -> real gap -> 0",
                     0,
                 ),
                 Arguments.of(

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsPeriodHelperTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsPeriodHelperTest.kt
@@ -16,7 +16,6 @@ import java.util.stream.Stream
 @UnitTest
 @DisplayName("StatisticsPeriodHelper Unit Test")
 class StatisticsPeriodHelperTest {
-
     @Test
     @DisplayName("toLocal(): converts UTC LocalDateTime to user zone LocalDateTime")
     fun `toLocal converts utc to user zone`() {
@@ -55,13 +54,18 @@ class StatisticsPeriodHelperTest {
     @MethodSource("provideLocalDayBoundsCases")
     @DisplayName("localDayBoundsToUtc(): zone-aware UTC bounds for local day")
     fun `localDayBoundsToUtc returns zone aware utc bounds`(
-        zone: String, localDay: LocalDate,
-        expectedStartUtc: LocalDateTime, expectedEndUtc: LocalDateTime,
+        zone: String,
+        localDay: LocalDate,
+        expectedStartUtc: LocalDateTime,
+        expectedEndUtc: LocalDateTime,
         @Suppress("UNUSED_PARAMETER") description: String,
     ) {
-        val (startUtc, endUtc) = StatisticsPeriodHelper.localDayBoundsToUtc(
-            localDay, localDay.plusDays(1), ZoneId.of(zone)
-        )
+        val (startUtc, endUtc) =
+            StatisticsPeriodHelper.localDayBoundsToUtc(
+                localDay,
+                localDay.plusDays(1),
+                ZoneId.of(zone),
+            )
 
         assertEquals(expectedStartUtc, startUtc)
         assertEquals(expectedEndUtc, endUtc)
@@ -88,65 +92,65 @@ class StatisticsPeriodHelperTest {
     }
 
     companion object {
-
         @JvmStatic
-        fun provideLocalDayBoundsCases(): Stream<Arguments> = Stream.of(
-            // UTC
-            Arguments.of(
-                "UTC",
-                LocalDate.of(2026, 5, 12),
-                LocalDateTime.of(2026, 5, 12, 0, 0),
-                LocalDateTime.of(2026, 5, 13, 0, 0),
-                "UTC",
-            ),
-            // Asia/Yekaterinburg (+5)
-            Arguments.of(
-                "Asia/Yekaterinburg",
-                LocalDate.of(2026, 5, 12),
-                LocalDateTime.of(2026, 5, 11, 19, 0),
-                LocalDateTime.of(2026, 5, 12, 19, 0),
-                "UTC+5",
-            ),
-            // Pacific/Kiritimati (+14)
-            Arguments.of(
-                "Pacific/Kiritimati",
-                LocalDate.of(2026, 5, 12),
-                LocalDateTime.of(2026, 5, 11, 10, 0),
-                LocalDateTime.of(2026, 5, 12, 10, 0),
-                "UTC+14 extreme",
-            ),
-            // Etc/GMT+12 is UTC-12 (POSIX sign-flip).
-            Arguments.of(
-                "Etc/GMT+12",
-                LocalDate.of(2026, 5, 12),
-                LocalDateTime.of(2026, 5, 12, 12, 0),
-                LocalDateTime.of(2026, 5, 13, 12, 0),
-                "UTC-12 extreme",
-            ),
-            // Asia/Kolkata (+5:30) fractional
-            Arguments.of(
-                "Asia/Kolkata",
-                LocalDate.of(2026, 5, 12),
-                LocalDateTime.of(2026, 5, 11, 18, 30),
-                LocalDateTime.of(2026, 5, 12, 18, 30),
-                "UTC+5:30 fractional",
-            ),
-            // DST spring-forward NY: 2026-03-08 is a 23-hour day in NY.
-            Arguments.of(
-                "America/New_York",
-                LocalDate.of(2026, 3, 8),
-                LocalDateTime.of(2026, 3, 8, 5, 0),
-                LocalDateTime.of(2026, 3, 9, 4, 0),
-                "DST spring-forward (23-hour day)",
-            ),
-            // DST fall-back NY: 2026-11-01 is a 25-hour day in NY.
-            Arguments.of(
-                "America/New_York",
-                LocalDate.of(2026, 11, 1),
-                LocalDateTime.of(2026, 11, 1, 4, 0),
-                LocalDateTime.of(2026, 11, 2, 5, 0),
-                "DST fall-back (25-hour day)",
-            ),
-        )
+        fun provideLocalDayBoundsCases(): Stream<Arguments> =
+            Stream.of(
+                // UTC
+                Arguments.of(
+                    "UTC",
+                    LocalDate.of(2026, 5, 12),
+                    LocalDateTime.of(2026, 5, 12, 0, 0),
+                    LocalDateTime.of(2026, 5, 13, 0, 0),
+                    "UTC",
+                ),
+                // Asia/Yekaterinburg (+5)
+                Arguments.of(
+                    "Asia/Yekaterinburg",
+                    LocalDate.of(2026, 5, 12),
+                    LocalDateTime.of(2026, 5, 11, 19, 0),
+                    LocalDateTime.of(2026, 5, 12, 19, 0),
+                    "UTC+5",
+                ),
+                // Pacific/Kiritimati (+14)
+                Arguments.of(
+                    "Pacific/Kiritimati",
+                    LocalDate.of(2026, 5, 12),
+                    LocalDateTime.of(2026, 5, 11, 10, 0),
+                    LocalDateTime.of(2026, 5, 12, 10, 0),
+                    "UTC+14 extreme",
+                ),
+                // Etc/GMT+12 is UTC-12 (POSIX sign-flip).
+                Arguments.of(
+                    "Etc/GMT+12",
+                    LocalDate.of(2026, 5, 12),
+                    LocalDateTime.of(2026, 5, 12, 12, 0),
+                    LocalDateTime.of(2026, 5, 13, 12, 0),
+                    "UTC-12 extreme",
+                ),
+                // Asia/Kolkata (+5:30) fractional
+                Arguments.of(
+                    "Asia/Kolkata",
+                    LocalDate.of(2026, 5, 12),
+                    LocalDateTime.of(2026, 5, 11, 18, 30),
+                    LocalDateTime.of(2026, 5, 12, 18, 30),
+                    "UTC+5:30 fractional",
+                ),
+                // DST spring-forward NY: 2026-03-08 is a 23-hour day in NY.
+                Arguments.of(
+                    "America/New_York",
+                    LocalDate.of(2026, 3, 8),
+                    LocalDateTime.of(2026, 3, 8, 5, 0),
+                    LocalDateTime.of(2026, 3, 9, 4, 0),
+                    "DST spring-forward (23-hour day)",
+                ),
+                // DST fall-back NY: 2026-11-01 is a 25-hour day in NY.
+                Arguments.of(
+                    "America/New_York",
+                    LocalDate.of(2026, 11, 1),
+                    LocalDateTime.of(2026, 11, 1, 4, 0),
+                    LocalDateTime.of(2026, 11, 2, 5, 0),
+                    "DST fall-back (25-hour day)",
+                ),
+            )
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramWebAppDataHelperTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramWebAppDataHelperTest.kt
@@ -1,7 +1,9 @@
 package ru.illine.drinking.ponies.util.telegram
 
 import org.apache.commons.codec.digest.HmacUtils
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import ru.illine.drinking.ponies.test.tag.UnitTest
@@ -11,7 +13,6 @@ import java.time.Instant
 @UnitTest
 @DisplayName("TelegramWebAppDataHelper Unit Test")
 class TelegramWebAppDataHelperTest {
-
     @Test
     @DisplayName("validateAuthDate(): returns true when auth_date is present and not expired")
     fun `validateAuthDate valid`() {
@@ -43,18 +44,20 @@ class TelegramWebAppDataHelperTest {
     @DisplayName("validateHash(): returns true when hash is valid")
     fun `validateHash valid`() {
         val token = "test-bot-token"
-        val dataFields = sortedMapOf(
-            TelegramWebAppDataHelper.AUTH_DATE_FIELD_NAME to "1234567890",
-            TelegramWebAppDataHelper.QUERY_ID_FIELD_NAME to "test-query-id",
-            TelegramWebAppDataHelper.USER_FIELD_NAME to "{\"id\":1}"
-        )
+        val dataFields =
+            sortedMapOf(
+                TelegramWebAppDataHelper.AUTH_DATE_FIELD_NAME to "1234567890",
+                TelegramWebAppDataHelper.QUERY_ID_FIELD_NAME to "test-query-id",
+                TelegramWebAppDataHelper.USER_FIELD_NAME to "{\"id\":1}",
+            )
         val dataCheckString = dataFields.map { "${it.key}=${it.value}" }.joinToString("\n")
         val secretKey = HmacUtils("HmacSHA256", "WebAppData").hmac(token)
         val expectedHash = HmacUtils("HmacSHA256", secretKey).hmacHex(dataCheckString)
 
-        val dataWithHash = dataFields.toMutableMap().apply {
-            put(TelegramWebAppDataHelper.HASH_FIELD_NAME, expectedHash)
-        }
+        val dataWithHash =
+            dataFields.toMutableMap().apply {
+                put(TelegramWebAppDataHelper.HASH_FIELD_NAME, expectedHash)
+            }
 
         assertTrue(TelegramWebAppDataHelper.validateHash(dataWithHash, token))
     }
@@ -62,10 +65,11 @@ class TelegramWebAppDataHelperTest {
     @Test
     @DisplayName("validateHash(): returns false when hash is invalid")
     fun `validateHash invalid`() {
-        val data = mapOf(
-            TelegramWebAppDataHelper.AUTH_DATE_FIELD_NAME to "1234567890",
-            TelegramWebAppDataHelper.HASH_FIELD_NAME to "wrong-hash"
-        )
+        val data =
+            mapOf(
+                TelegramWebAppDataHelper.AUTH_DATE_FIELD_NAME to "1234567890",
+                TelegramWebAppDataHelper.HASH_FIELD_NAME to "wrong-hash",
+            )
 
         assertFalse(TelegramWebAppDataHelper.validateHash(data, "test-bot-token"))
     }

--- a/src/test/resources/application-integration-test.yaml
+++ b/src/test/resources/application-integration-test.yaml
@@ -49,6 +49,12 @@ telegram-bot:
     notification:
       cron: "*/15 * * * * *"
 
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+
 logbook:
   strategy: body-only-if-status-at-least
   minimum-status: 200


### PR DESCRIPTION
## Summary

**Features**
- DPTB-181: keep the streak alive when today's goal is not yet met (hanging streak)

**Security & config**
- DPTB-109: switch WebConfig to default-secure auth mapping

**Build & CI**
- DPTB-180: slim down the fat jar and Docker image
- DPTB-179: speed up bot CI with Gradle build cache and cache policy tuning
- DPTB-44: linter and static analysis for the Kotlin backend (ktlint + detekt)
- DPTB-158: pin ci-templates include ref to v1.0.0

**Refactoring**
- DPTB-136: migrate builders to Konvert compile-time mappers
- DPTB-165: replace builder facades with mapper companion delegates
- DPTB-170: make tests idiomatic mockito-kotlin (remove Java-style Mockito)
- DPTB-164: opt in to Kotlin param-property annotation default target (KT-73255)
- DPTB-110: unify access-service method naming by layer convention
- DPTB-140: unify Telegram user id naming to externalUserId

## Test plan
- [x] CI green on develop
- [x] Unit and integration tests pass
