### PR TITLE
DPTB-193: expose X-Auth-Error-Code via CORS Access-Control-Expose-Headers

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/WebConfig.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/WebConfig.kt
@@ -11,6 +11,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import ru.illine.drinking.ponies.config.property.CorsProperties
 import ru.illine.drinking.ponies.config.web.interceptor.AdminAuthInterceptor
 import ru.illine.drinking.ponies.config.web.interceptor.TelegramAuthInterceptor
+import ru.illine.drinking.ponies.config.web.security.AuthErrorType
 
 @Configuration
 class WebConfig(
@@ -49,6 +50,7 @@ class WebConfig(
                         HttpMethod.DELETE.name(),
                     )
                 allowedHeaders = listOf("*")
+                exposedHeaders = listOf(AuthErrorType.HEADER_NAME)
                 allowCredentials = true
             }
         val source = UrlBasedCorsConfigurationSource()

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigTest.kt
@@ -12,6 +12,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.RequestEntity
+import ru.illine.drinking.ponies.config.web.security.AuthErrorType
 import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
 import java.net.URI
 
@@ -40,6 +41,25 @@ class WebConfigTest
             assertEquals(HttpStatus.OK, response.statusCode)
             assertEquals(allowedOrigin, response.headers["Access-Control-Allow-Origin"]?.first())
             assertTrue(response.headers["Access-Control-Allow-Methods"]?.first()?.contains("PUT") == true)
+        }
+
+        @Test
+        @DisplayName("actual request from allowed origin - exposes X-Auth-Error-Code to the browser")
+        fun `cors actual request exposes auth error code header`() {
+            val headers =
+                HttpHeaders().apply {
+                    set("Origin", "http://localhost:3000")
+                }
+            val request = RequestEntity<Void>(headers, HttpMethod.GET, URI(url))
+
+            val response = restTemplate.exchange(request, Void::class.java)
+
+            assertEquals("http://localhost:3000", response.headers["Access-Control-Allow-Origin"]?.first())
+            assertTrue(
+                response.headers[HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS]
+                    ?.first()
+                    ?.contains(AuthErrorType.HEADER_NAME) == true,
+            )
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Add `Access-Control-Expose-Headers: X-Auth-Error-Code` to the CORS filter so the cross-origin MiniApp can read the auth-error code header via `response.headers.get(...)`.
- Without it the browser hides the custom header on cross-origin responses, so `_client.ts` sees `code = null` and treats every 403 (including `forbidden_admin`) as `session`, showing the blocking StatusScreen instead of degrading gracefully.
- Reuse the existing `AuthErrorType.HEADER_NAME` constant; use an explicit header name (not `*`, which browsers ignore in expose when credentials are allowed).

## Test plan
- [x] New `WebConfigTest` case asserts the actual cross-origin response exposes `X-Auth-Error-Code`
- [x] `test *WebConfigTest` green (4 tests, 0 failures)
- [x] `formatKotlin` (ktlint) and `detekt` clean
