### PR TITLE
DPTB-221: align water amount presets with the mini app

### DIFF
--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -40,6 +40,7 @@
     <ID>MagicNumber:WaterAmountType.kt:WaterAmountType.ML_250$250</ID>
     <ID>MagicNumber:WaterAmountType.kt:WaterAmountType.ML_450$450</ID>
     <ID>MagicNumber:WaterAmountType.kt:WaterAmountType.ML_50$50</ID>
+    <ID>MagicNumber:WaterAmountType.kt:WaterAmountType.ML_750$750</ID>
     <ID>MaxLineLength:MeResponse.kt:MeResponse$// The JSON key is intentionally kept as "telegramUserId" - it is the public /users/me contract consumed by the MiniApp.</ID>
     <ID>MaxLineLength:MessageEditorServiceImpl.kt:MessageEditorServiceImpl$"A previous message can't be deleted! A chatId: [${this.chatId}], messageId: [${this.messageId}]"</ID>
     <ID>MaxLineLength:NotificationAccessServiceTest.kt:NotificationAccessServiceTest$"findNotificationSettingByExternalUserId(): throws NotificationSettingsNotFoundException when record not found by externalUserId"</ID>

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/base/WaterAmountType.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/base/WaterAmountType.kt
@@ -1,21 +1,23 @@
 package ru.illine.drinking.ponies.model.base
 
-import ru.illine.drinking.ponies.util.telegram.TelegramWaterAmountConstants
 import java.util.Objects
 import java.util.UUID
 
 @Suppress("unused")
 enum class WaterAmountType(
-    val displayName: String,
     val amountMl: Int,
     val queryData: UUID,
 ) {
-    ML_50(TelegramWaterAmountConstants.ML_50, 50, UUID.fromString("a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d")),
-    ML_100(TelegramWaterAmountConstants.ML_100, 100, UUID.fromString("b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e")),
-    ML_150(TelegramWaterAmountConstants.ML_150, 150, UUID.fromString("c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f")),
-    ML_250(TelegramWaterAmountConstants.ML_250, 250, UUID.fromString("d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a")),
-    ML_450(TelegramWaterAmountConstants.ML_450, 450, UUID.fromString("e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8a9b")),
+    ML_50(50, UUID.fromString("a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d")),
+    ML_100(100, UUID.fromString("b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e")),
+    ML_150(150, UUID.fromString("c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f")),
+    ML_250(250, UUID.fromString("d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a")),
+    ML_450(450, UUID.fromString("e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8a9b")),
+    ML_750(750, UUID.fromString("f6a7b8c9-d0e1-4f2a-3b4c-5d6e7f8a9b0c")),
     ;
+
+    val displayName: String
+        get() = "$amountMl мл"
 
     companion object {
         fun typeOf(queryData: String): WaterAmountType? =

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramBotKeyboardHelper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramBotKeyboardHelper.kt
@@ -10,6 +10,8 @@ import ru.illine.drinking.ponies.model.base.WaterAmountType
 import java.util.UUID
 
 object TelegramBotKeyboardHelper {
+    private const val WATER_AMOUNT_BUTTONS_PER_ROW = 3
+
     fun snoozeTimeButtons(): ReplyKeyboard =
         buildInlineKeyboard(
             SnoozeNotificationType.entries,
@@ -22,6 +24,7 @@ object TelegramBotKeyboardHelper {
             WaterAmountType.entries,
             WaterAmountType::displayName,
             WaterAmountType::queryData,
+            buttonsPerRow = WATER_AMOUNT_BUTTONS_PER_ROW,
         )
 
     fun notifyButtons(): ReplyKeyboard =
@@ -29,30 +32,25 @@ object TelegramBotKeyboardHelper {
             AnswerNotificationType.entries,
             AnswerNotificationType::displayName,
             AnswerNotificationType::queryData,
-            singleRow = true,
+            buttonsPerRow = AnswerNotificationType.entries.size,
         )
 
     private fun <T> buildInlineKeyboard(
         entries: List<T>,
         displayName: (T) -> String,
         queryData: (T) -> UUID,
-        singleRow: Boolean = false,
+        buttonsPerRow: Int = 1,
     ): ReplyKeyboard {
-        val buttons =
-            entries.map {
-                InlineKeyboardButton
-                    .builder()
-                    .text(displayName(it))
-                    .callbackData(queryData(it).toString())
-                    .build()
-            }
-
         val keyboard =
-            if (singleRow) {
-                listOf(InlineKeyboardRow(buttons))
-            } else {
-                buttons.map { InlineKeyboardRow(it) }
-            }
+            entries
+                .map {
+                    InlineKeyboardButton
+                        .builder()
+                        .text(displayName(it))
+                        .callbackData(queryData(it).toString())
+                        .build()
+                }.chunked(buttonsPerRow)
+                .map { InlineKeyboardRow(it) }
 
         return InlineKeyboardMarkup
             .builder()

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramWaterAmountConstants.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/telegram/TelegramWaterAmountConstants.kt
@@ -1,9 +1,0 @@
-package ru.illine.drinking.ponies.util.telegram
-
-object TelegramWaterAmountConstants {
-    const val ML_50 = "50 мл"
-    const val ML_100 = "100 мл"
-    const val ML_150 = "150 мл"
-    const val ML_250 = "250 мл"
-    const val ML_450 = "450 мл"
-}

--- a/src/test/kotlin/ru/illine/drinking/ponies/model/base/WaterAmountTypeTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/model/base/WaterAmountTypeTest.kt
@@ -1,6 +1,8 @@
 package ru.illine.drinking.ponies.model.base
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
 @DisplayName("WaterAmountType Unit Test")
 class WaterAmountTypeTest :
@@ -8,4 +10,12 @@ class WaterAmountTypeTest :
         WaterAmountType.entries,
         WaterAmountType::typeOf,
         WaterAmountType::queryData,
-    )
+    ) {
+    @Test
+    @DisplayName("entries: amounts are distinct and declared in ascending order")
+    fun `amounts are distinct and ascending`() {
+        val amounts = WaterAmountType.entries.map { it.amountMl }
+
+        assertEquals(amounts.distinct().sorted(), amounts)
+    }
+}

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategyTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategyTest.kt
@@ -18,13 +18,12 @@ import org.mockito.kotlin.whenever
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.api.objects.message.Message
-import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
-import ru.illine.drinking.ponies.model.base.WaterAmountType
 import ru.illine.drinking.ponies.service.message.impl.LocalMessageProvider
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService
 import ru.illine.drinking.ponies.test.tag.UnitTest
+import ru.illine.drinking.ponies.util.telegram.TelegramBotKeyboardHelper
 import kotlin.random.Random
 
 @UnitTest
@@ -65,8 +64,7 @@ class YesAnswerNotificationReplyButtonStrategyTest {
         val sent = captor.firstValue
         assertEquals(chatId.toString(), sent.chatId)
         assertEquals("Сколько водицы выпито?", sent.text)
-        val buttons = (sent.replyMarkup as InlineKeyboardMarkup).keyboard
-        assertEquals(WaterAmountType.entries.size, buttons.size)
+        assertEquals(TelegramBotKeyboardHelper.waterAmountButtons(), sent.replyMarkup)
     }
 
     @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/TelegramBotKeyboardHelperTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/TelegramBotKeyboardHelperTest.kt
@@ -5,12 +5,17 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
 import ru.illine.drinking.ponies.model.base.WaterAmountType
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import ru.illine.drinking.ponies.util.telegram.TelegramBotKeyboardHelper
+import java.util.stream.Stream
 
 @UnitTest
 @DisplayName("TelegramBotKeyboardHelper Unit Test")
@@ -31,10 +36,10 @@ class TelegramBotKeyboardHelperTest {
     }
 
     @Test
-    @DisplayName("waterAmountButtons(): returns valid keyboard")
+    @DisplayName("waterAmountButtons(): returns valid keyboard laid out as two rows of three buttons")
     fun `successful waterAmountButtons`() {
-        val expectedButtonsSize = 1
-        val expectedRowsSize = WaterAmountType.entries.size
+        val expectedRowsSize = 2
+        val expectedButtonsSize = 3
 
         val actual =
             TelegramBotKeyboardHelper.waterAmountButtons() as InlineKeyboardMarkup
@@ -42,7 +47,7 @@ class TelegramBotKeyboardHelperTest {
         assertNotNull(actual)
         assertDoesNotThrow { actual.validate() }
         assertEquals(expectedRowsSize, actual.keyboard.size)
-        assertEquals(expectedButtonsSize, actual.keyboard[0].size)
+        actual.keyboard.forEach { assertEquals(expectedButtonsSize, it.size) }
     }
 
     @Test
@@ -58,5 +63,47 @@ class TelegramBotKeyboardHelperTest {
         assertDoesNotThrow { actual.validate() }
         assertEquals(expectedRowsSize, actual.keyboard.size)
         assertEquals(expectedButtonsSize, actual.keyboard[0].size)
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("provideKeyboardButtonCases")
+    @DisplayName("keyboards: every entry becomes a button carrying its display name and query data")
+    fun `keyboard buttons carry display name and query data of every entry`(
+        @Suppress("UNUSED_PARAMETER") keyboardName: String,
+        keyboardFactory: () -> ReplyKeyboard,
+        expectedTexts: List<String>,
+        expectedCallbackData: List<String>,
+    ) {
+        val actual = keyboardFactory() as InlineKeyboardMarkup
+
+        val buttons = actual.keyboard.flatten()
+
+        assertEquals(expectedTexts, buttons.map { it.text })
+        assertEquals(expectedCallbackData, buttons.map { it.callbackData })
+    }
+
+    companion object {
+        @JvmStatic
+        fun provideKeyboardButtonCases(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of(
+                    "snoozeTimeButtons",
+                    TelegramBotKeyboardHelper::snoozeTimeButtons,
+                    SnoozeNotificationType.entries.map { it.displayName },
+                    SnoozeNotificationType.entries.map { it.queryData.toString() },
+                ),
+                Arguments.of(
+                    "waterAmountButtons",
+                    TelegramBotKeyboardHelper::waterAmountButtons,
+                    WaterAmountType.entries.map { it.displayName },
+                    WaterAmountType.entries.map { it.queryData.toString() },
+                ),
+                Arguments.of(
+                    "notifyButtons",
+                    TelegramBotKeyboardHelper::notifyButtons,
+                    AnswerNotificationType.entries.map { it.displayName },
+                    AnswerNotificationType.entries.map { it.queryData.toString() },
+                ),
+            )
     }
 }


### PR DESCRIPTION
## Summary
- Add a 750 ml preset to `WaterAmountType` so the bot offers the same six amounts as the mini app (50/100/150/250/450/750)
- Lay out the amount buttons three per row (two rows) instead of one vertical column
- Replace the boolean `singleRow` flag in `TelegramBotKeyboardHelper` with `buttonsPerRow`, so every keyboard picks its own row width via `chunked()`
- Derive `WaterAmountType.displayName` from `amountMl` and drop `TelegramWaterAmountConstants`, which only mirrored those numbers

## Test plan
- [x] `./gradlew test` - 598 tests green
- [x] `./gradlew detekt lintKotlinMain lintKotlinTest` - green
- [x] Local bot run: the "Да" reply shows two rows of three buttons, 750 ml included
- [x] Snooze and notify keyboards keep their previous layout
