### PR TITLE
DPTB-223: don't abort notification batch on chat-not-found (400) errors

### DIFF
--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -18,7 +18,6 @@
     <ID>MagicNumber:IntervalNotificationType.kt:IntervalNotificationType.THREE_HOURS$180</ID>
     <ID>MagicNumber:IntervalNotificationType.kt:IntervalNotificationType.TWO_HOURS$120</ID>
     <ID>MagicNumber:NotificationController.kt:NotificationController$300</ID>
-    <ID>MagicNumber:NotificationSenderServiceImpl.kt:NotificationSenderServiceImpl$403</ID>
     <ID>MagicNumber:NotificationSettingDto.kt:NotificationSettingDto.Companion$11</ID>
     <ID>MagicNumber:NotificationSettingDto.kt:NotificationSettingDto.Companion$23</ID>
     <ID>MagicNumber:PluralizationHelper.kt:PluralizationHelper$10</ID>

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSenderServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSenderServiceImpl.kt
@@ -58,7 +58,8 @@ class NotificationSenderServiceImpl(
                             messageProvider.getMessage(MessageSpec.NotificationQuestion, NoContext).text,
                         ).apply {
                             replyMarkup = TelegramBotKeyboardHelper.notifyButtons()
-                        }.let { sender.execute(it) }.messageId
+                        }.let { sender.execute(it) }
+                            .messageId
                 }
             }
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSenderServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSenderServiceImpl.kt
@@ -1,6 +1,7 @@
 package ru.illine.drinking.ponies.service.notification.impl
 
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException
@@ -43,7 +44,7 @@ class NotificationSenderServiceImpl(
 
         val sent =
             notifications.filter {
-                sendOrDisableOnBlock(it) {
+                trySend(it) {
                     ++it.notificationAttempts
                     it.timeOfLastNotification =
                         TimeHelper.nextNotificationTimeByNow(
@@ -57,8 +58,7 @@ class NotificationSenderServiceImpl(
                             messageProvider.getMessage(MessageSpec.NotificationQuestion, NoContext).text,
                         ).apply {
                             replyMarkup = TelegramBotKeyboardHelper.notifyButtons()
-                        }.let { sender.execute(it) }
-                            .messageId
+                        }.let { sender.execute(it) }.messageId
                 }
             }
 
@@ -75,7 +75,7 @@ class NotificationSenderServiceImpl(
 
         val sent =
             notifications.filter {
-                sendOrDisableOnBlock(it) {
+                trySend(it) {
                     SendMessage(
                         it.telegramChat.externalChatId.toString(),
                         messageProvider
@@ -100,7 +100,7 @@ class NotificationSenderServiceImpl(
         )
     }
 
-    private fun sendOrDisableOnBlock(
+    private fun trySend(
         notification: NotificationSettingDto,
         send: () -> Unit,
     ): Boolean =
@@ -108,12 +108,15 @@ class NotificationSenderServiceImpl(
             send()
             true
         } catch (e: TelegramApiRequestException) {
-            if (e.errorCode == 403) {
-                logger.warn(
+            if (e.errorCode == HttpStatus.FORBIDDEN.value()) {
+                logger.info(
                     "User (externalUserId: [{}]) blocked the bot, disabling notifications",
                     notification.telegramUser.externalUserId,
                 )
                 notificationAccessService.updateNotificationsDisabled(notification.telegramUser.externalUserId)
+                false
+            } else if (e.errorCode == HttpStatus.BAD_REQUEST.value()) {
+                logger.info("Bad request: [{}]", e.message)
                 false
             } else {
                 throw e

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
@@ -7,10 +7,13 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -22,6 +25,7 @@ import ru.illine.drinking.ponies.config.property.TelegramBotProperties
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
+import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.service.message.impl.LocalMessageProvider
 import ru.illine.drinking.ponies.service.notification.impl.NotificationSenderServiceImpl
 import ru.illine.drinking.ponies.service.statistic.WaterStatisticService
@@ -132,6 +136,57 @@ class NotificationSenderServiceTest {
     }
 
     @Test
+    @DisplayName("sendNotifications(): 400 error - skips user without disabling notifications")
+    fun `sendNotifications on 400 chat not found`() {
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
+        val exception = mock<TelegramApiRequestException>()
+        whenever(exception.errorCode).thenReturn(400)
+        doThrow(exception).whenever(sender).execute(any<SendMessage>())
+
+        service.sendNotifications(listOf(dto))
+
+        val captor = argumentCaptor<Collection<NotificationSettingDto>>()
+        verify(notificationAccessService, never()).updateNotificationsDisabled(any())
+        verify(notificationAccessService).updateNotificationSettings(captor.capture())
+        assertEquals(emptyList<NotificationSettingDto>(), captor.firstValue.toList())
+    }
+
+    @Test
+    @DisplayName("sendNotifications(): 400 error for one notification - the rest of the batch is still sent")
+    fun `sendNotifications on 400 keeps sending the rest of the batch`() {
+        val failingChatId = chatId + 1
+        val first = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
+        val failing =
+            DtoGenerator.generateNotificationDto(
+                externalUserId = externalUserId + 1,
+                externalChatId = failingChatId,
+            )
+        val last =
+            DtoGenerator.generateNotificationDto(
+                externalUserId = externalUserId + 2,
+                externalChatId = chatId + 2,
+            )
+        val exception = mock<TelegramApiRequestException>()
+        whenever(exception.errorCode).thenReturn(400)
+        val returnedMessage = mock<Message>()
+        whenever(returnedMessage.messageId).thenReturn(2)
+        doAnswer { invocation ->
+            if (invocation.getArgument<SendMessage>(0).chatId == failingChatId.toString()) {
+                throw exception
+            }
+            returnedMessage
+        }.whenever(sender).execute(any<SendMessage>())
+
+        service.sendNotifications(listOf(first, failing, last))
+
+        val captor = argumentCaptor<Collection<NotificationSettingDto>>()
+        verify(sender, times(3)).execute(any<SendMessage>())
+        verify(notificationAccessService, never()).updateNotificationsDisabled(any())
+        verify(notificationAccessService).updateNotificationSettings(captor.capture())
+        assertEquals(listOf(first, last), captor.firstValue.toList())
+    }
+
+    @Test
     @DisplayName("suspendNotifications(): empty collection - no interactions with sender or access service")
     fun `suspendNotifications with empty list does nothing`() {
         service.suspendNotifications(emptyList())
@@ -183,6 +238,22 @@ class NotificationSenderServiceTest {
 
         verify(notificationAccessService).updateNotificationsDisabled(externalUserId)
         verify(notificationAccessService).updateNotificationSettings(any())
+    }
+
+    @Test
+    @DisplayName("suspendNotifications(): 400 error - skips user without disabling notifications")
+    fun `suspendNotifications on 400 chat not found`() {
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId, externalChatId = chatId)
+        val exception = mock<TelegramApiRequestException>()
+        whenever(exception.errorCode).thenReturn(400)
+        doThrow(exception).whenever(sender).execute(any<SendMessage>())
+
+        service.suspendNotifications(listOf(dto))
+
+        val captor = argumentCaptor<Collection<NotificationSettingDto>>()
+        verify(notificationAccessService, never()).updateNotificationsDisabled(any())
+        verify(notificationAccessService).updateNotificationSettings(captor.capture())
+        assertEquals(emptyList<NotificationSettingDto>(), captor.firstValue.toList())
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Handle Telegram `400 Bad Request: chat not found` per-user in `NotificationSenderServiceImpl` (renamed `sendOrDisableOnBlock` -> `trySend`), instead of rethrowing and aborting the whole notification batch
- Log at info level and skip the affected user without disabling their notification settings (unlike the existing 403 "blocked the bot" branch)
- Add a regression test proving a batch with one 400 failure still processes the rest of the users
- Reference `HttpStatus.FORBIDDEN`/`HttpStatus.BAD_REQUEST` instead of magic numbers, drop the now-obsolete detekt baseline entry

## Test plan
- [x] `./gradlew test --tests NotificationSenderServiceTest` - green (13/13)
- [x] `./gradlew test` - full suite green, no regressions
- [x] `./gradlew lintKotlin detekt` - green
