### PR TITLE
DPTB-123: add notification journal endpoints over water statistics

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/DefaultExceptionHandler.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/DefaultExceptionHandler.kt
@@ -12,7 +12,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.servlet.resource.NoResourceFoundException
-import ru.illine.drinking.ponies.exception.NotificationSettingsNotFoundException
+import ru.illine.drinking.ponies.exception.NotFoundException
+import ru.illine.drinking.ponies.exception.NotificationHistoryEntryNotEditableException
 import ru.illine.drinking.ponies.model.dto.response.ErrorResponse
 
 @RestControllerAdvice
@@ -65,12 +66,24 @@ class DefaultExceptionHandler {
             .body(response)
     }
 
-    @ExceptionHandler(NotificationSettingsNotFoundException::class)
-    fun handleNotificationSettingsNotFound(e: NotificationSettingsNotFoundException): ResponseEntity<ErrorResponse> {
-        logger.warn("Notification settings not found: ${e.message}")
-        val response = ErrorResponse("notification settings not found")
+    @ExceptionHandler(NotFoundException::class)
+    fun handleNotFound(e: NotFoundException): ResponseEntity<ErrorResponse> {
+        logger.warn("${e.clientMessage}: ${e.message}")
+        val response = ErrorResponse(e.clientMessage)
         return ResponseEntity
             .status(HttpStatus.NOT_FOUND)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(response)
+    }
+
+    @ExceptionHandler(NotificationHistoryEntryNotEditableException::class)
+    fun handleNotificationHistoryEntryNotEditable(
+        e: NotificationHistoryEntryNotEditableException,
+    ): ResponseEntity<ErrorResponse> {
+        logger.warn("Notification history entry is not editable: ${e.message}")
+        val response = ErrorResponse("notification history entry is not editable")
+        return ResponseEntity
+            .status(HttpStatus.CONFLICT)
             .contentType(MediaType.APPLICATION_JSON)
             .body(response)
     }

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/NotificationController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/NotificationController.kt
@@ -2,23 +2,34 @@ package ru.illine.drinking.ponies.controller
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestAttribute
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.request.NotificationHistoryEntryRequest
+import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryEvent
+import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryResponse
 import ru.illine.drinking.ponies.model.dto.response.NotificationNextResponse
 import ru.illine.drinking.ponies.model.dto.response.PauseStateResponse
+import ru.illine.drinking.ponies.service.notification.NotificationHistoryService
 import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
+import java.time.LocalDate
 
 @RestController
 @RequestMapping("/notifications")
@@ -26,6 +37,7 @@ import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
 @Validated
 class NotificationController(
     private val notificationSettingsService: NotificationSettingsService,
+    private val notificationHistoryService: NotificationHistoryService,
 ) {
     @GetMapping("/next")
     @Operation(summary = "Get next notification time")
@@ -61,4 +73,41 @@ class NotificationController(
             notificationSettingsService.pauseNotifications(telegramUser.externalUserId, minutes)
         }
     }
+
+    @GetMapping("/history")
+    @Operation(summary = "Get the notification journal for the requested period")
+    fun getHistory(
+        @Parameter(hidden = true)
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @Parameter(
+            description = "Range start (inclusive) in yyyy-MM-dd format, in the user's timezone",
+            example = "2026-05-01",
+            schema = Schema(type = "string", format = "date"),
+        )
+        @RequestParam(name = "from", required = true)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
+        @Parameter(
+            description = "Range end (inclusive) in yyyy-MM-dd format, in the user's timezone",
+            example = "2026-05-31",
+            schema = Schema(type = "string", format = "date"),
+        )
+        @RequestParam(name = "to", required = true)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
+    ): NotificationHistoryResponse = notificationHistoryService.getHistory(telegramUser.externalUserId, from, to)
+
+    @PatchMapping("/history/{id}")
+    @Operation(summary = "Update a notification journal entry")
+    fun updateHistoryEntry(
+        @Parameter(hidden = true)
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @Parameter(description = "Journal entry identifier", example = "1042")
+        @PathVariable(name = "id") id: Long,
+        @Valid @RequestBody request: NotificationHistoryEntryRequest,
+    ): NotificationHistoryEvent =
+        notificationHistoryService.updateEntry(
+            externalUserId = telegramUser.externalUserId,
+            entryId = id,
+            status = request.status,
+            amountMl = request.amountMl,
+        )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/WaterStatisticAccessService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/WaterStatisticAccessService.kt
@@ -1,5 +1,7 @@
 package ru.illine.drinking.ponies.dao.access
 
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import java.time.LocalDateTime
 
@@ -9,6 +11,19 @@ interface WaterStatisticAccessService {
         startInclusive: LocalDateTime,
         endExclusive: LocalDateTime,
     ): List<WaterStatisticDto>
+
+    fun findByUserAndTypesAndEventTimeBetween(
+        externalUserId: Long,
+        sources: Collection<WaterEntrySourceType>,
+        eventTypes: Collection<AnswerNotificationType>,
+        startInclusive: LocalDateTime,
+        endExclusive: LocalDateTime,
+    ): List<WaterStatisticDto>
+
+    fun findByIdAndUser(
+        id: Long,
+        externalUserId: Long,
+    ): WaterStatisticDto?
 
     fun findEarliestEventTimeByUser(externalUserId: Long): LocalDateTime?
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/WaterStatisticAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/WaterStatisticAccessServiceImpl.kt
@@ -11,6 +11,8 @@ import ru.illine.drinking.ponies.dao.repository.TelegramUserRepository
 import ru.illine.drinking.ponies.dao.repository.WaterStatisticRepository
 import ru.illine.drinking.ponies.mapper.TelegramUserMapper
 import ru.illine.drinking.ponies.mapper.WaterStatisticMapper
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import java.time.LocalDateTime
 
@@ -33,6 +35,34 @@ class WaterStatisticAccessServiceImpl(
         return waterStatisticRepository
             .findByUserAndEventTimeBetween(externalUserId, startInclusive, endExclusive)
             .map { WaterStatisticMapper.toDto(it, TelegramUserMapper.toDto(it.telegramUser)) }
+    }
+
+    @Transactional(readOnly = true)
+    override fun findByUserAndTypesAndEventTimeBetween(
+        externalUserId: Long,
+        sources: Collection<WaterEntrySourceType>,
+        eventTypes: Collection<AnswerNotificationType>,
+        startInclusive: LocalDateTime,
+        endExclusive: LocalDateTime,
+    ): List<WaterStatisticDto> {
+        logger.debug(
+            "Finding [$sources] water statistics for externalUserId [$externalUserId] " +
+                "between [$startInclusive] and [$endExclusive]",
+        )
+        return waterStatisticRepository
+            .findByUserAndTypesAndEventTimeBetween(externalUserId, sources, eventTypes, startInclusive, endExclusive)
+            .map { WaterStatisticMapper.toDto(it, TelegramUserMapper.toDto(it.telegramUser)) }
+    }
+
+    @Transactional(readOnly = true)
+    override fun findByIdAndUser(
+        id: Long,
+        externalUserId: Long,
+    ): WaterStatisticDto? {
+        logger.debug("Finding a water statistic [$id] for externalUserId [$externalUserId]")
+        return waterStatisticRepository
+            .findByIdAndUser(id, externalUserId)
+            ?.let { WaterStatisticMapper.toDto(it, TelegramUserMapper.toDto(it.telegramUser)) }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/WaterStatisticRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/WaterStatisticRepository.kt
@@ -3,6 +3,8 @@ package ru.illine.drinking.ponies.dao.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
 import ru.illine.drinking.ponies.model.entity.WaterStatisticEntity
 import java.time.LocalDateTime
 
@@ -22,6 +24,39 @@ interface WaterStatisticRepository : JpaRepository<WaterStatisticEntity, Long> {
         @Param("startInclusive") startInclusive: LocalDateTime,
         @Param("endExclusive") endExclusive: LocalDateTime,
     ): List<WaterStatisticEntity>
+
+    @Query(
+        value = """
+            select ws from WaterStatisticEntity ws
+            join fetch ws.telegramUser u
+            where u.externalUserId = :externalUserId
+              and ws.source in :sources
+              and ws.eventType in :eventTypes
+              and ws.eventTime >= :startInclusive
+              and ws.eventTime < :endExclusive
+            order by ws.eventTime asc
+        """,
+    )
+    fun findByUserAndTypesAndEventTimeBetween(
+        @Param("externalUserId") externalUserId: Long,
+        @Param("sources") sources: Collection<WaterEntrySourceType>,
+        @Param("eventTypes") eventTypes: Collection<AnswerNotificationType>,
+        @Param("startInclusive") startInclusive: LocalDateTime,
+        @Param("endExclusive") endExclusive: LocalDateTime,
+    ): List<WaterStatisticEntity>
+
+    @Query(
+        value = """
+            select ws from WaterStatisticEntity ws
+            join fetch ws.telegramUser u
+            where ws.id = :id
+              and u.externalUserId = :externalUserId
+        """,
+    )
+    fun findByIdAndUser(
+        @Param("id") id: Long,
+        @Param("externalUserId") externalUserId: Long,
+    ): WaterStatisticEntity?
 
     @Query(
         value = """

--- a/src/main/kotlin/ru/illine/drinking/ponies/exception/NotFoundException.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/exception/NotFoundException.kt
@@ -1,0 +1,6 @@
+package ru.illine.drinking.ponies.exception
+
+abstract class NotFoundException(
+    val clientMessage: String,
+    message: String,
+) : RuntimeException(message)

--- a/src/main/kotlin/ru/illine/drinking/ponies/exception/NotificationHistoryEntryNotEditableException.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/exception/NotificationHistoryEntryNotEditableException.kt
@@ -1,0 +1,5 @@
+package ru.illine.drinking.ponies.exception
+
+class NotificationHistoryEntryNotEditableException(
+    message: String,
+) : RuntimeException(message)

--- a/src/main/kotlin/ru/illine/drinking/ponies/exception/NotificationHistoryEntryNotFoundException.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/exception/NotificationHistoryEntryNotFoundException.kt
@@ -1,0 +1,5 @@
+package ru.illine.drinking.ponies.exception
+
+class NotificationHistoryEntryNotFoundException(
+    message: String,
+) : NotFoundException("notification history entry not found", message)

--- a/src/main/kotlin/ru/illine/drinking/ponies/exception/NotificationSettingsNotFoundException.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/exception/NotificationSettingsNotFoundException.kt
@@ -2,4 +2,4 @@ package ru.illine.drinking.ponies.exception
 
 class NotificationSettingsNotFoundException(
     message: String,
-) : RuntimeException(message)
+) : NotFoundException("notification settings not found", message)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/base/NotificationHistoryStatus.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/base/NotificationHistoryStatus.kt
@@ -1,0 +1,15 @@
+package ru.illine.drinking.ponies.model.base
+
+enum class NotificationHistoryStatus(
+    val eventType: AnswerNotificationType,
+) {
+    CONFIRMED(AnswerNotificationType.YES),
+    MISSED(AnswerNotificationType.CANCEL),
+    ;
+
+    companion object {
+        // Event types without a status here are not journal entries at all: SNOOZE is such a case.
+        fun of(eventType: AnswerNotificationType): NotificationHistoryStatus? =
+            entries.find { it.eventType == eventType }
+    }
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/NotificationHistoryEntryRequest.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/NotificationHistoryEntryRequest.kt
@@ -1,0 +1,25 @@
+package ru.illine.drinking.ponies.model.dto.request
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.swagger.v3.oas.annotations.media.Schema
+import ru.illine.drinking.ponies.model.base.NotificationHistoryStatus
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "Notification journal entry update payload")
+data class NotificationHistoryEntryRequest(
+    @Schema(
+        description = "New status of the entry",
+        example = "CONFIRMED",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
+    val status: NotificationHistoryStatus,
+    // The range is checked by the service instead of bean validation: a missed entry ignores the amount,
+    // and clients do send the whole form snapshot, zero included.
+    @Schema(
+        description = "Water amount in milliliters, from 50 to 1000. Required when CONFIRMED, ignored when MISSED.",
+        example = "300",
+        nullable = true,
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val amountMl: Int?,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/NotificationHistoryDay.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/NotificationHistoryDay.kt
@@ -1,0 +1,12 @@
+package ru.illine.drinking.ponies.model.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "Single day of the notification journal")
+data class NotificationHistoryDay(
+    @Schema(description = "Calendar date in the user's timezone", example = "2026-07-25")
+    val date: LocalDate,
+    @Schema(description = "Entries of this day ordered by event time, ascending")
+    val events: List<NotificationHistoryEvent>,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/NotificationHistoryEvent.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/NotificationHistoryEvent.kt
@@ -1,0 +1,25 @@
+package ru.illine.drinking.ponies.model.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import ru.illine.drinking.ponies.model.base.NotificationHistoryStatus
+import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
+import java.time.Instant
+
+@Schema(description = "Single notification journal entry")
+data class NotificationHistoryEvent(
+    @Schema(description = "Entry identifier, used by the edit request", example = "1042")
+    val id: Long,
+    @Schema(description = "Event time in ISO 8601 UTC format", example = "2026-07-25T07:00:00Z")
+    val eventTime: Instant,
+    @Schema(description = "Entry status as shown in the journal", example = "CONFIRMED")
+    val status: NotificationHistoryStatus,
+    @Schema(description = "Water amount in milliliters; 0 means confirmed without an amount", example = "300")
+    val amountMl: Int,
+    @Schema(
+        description = "Entry origin. Only NOTIFICATION entries are returned for now; clients must tolerate new values",
+        example = "NOTIFICATION",
+    )
+    val source: WaterEntrySourceType,
+    @Schema(description = "Whether the entry is still within the edit window", example = "true")
+    val editable: Boolean,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/NotificationHistoryResponse.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/NotificationHistoryResponse.kt
@@ -1,0 +1,9 @@
+package ru.illine.drinking.ponies.model.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Notification journal grouped by day in the user's timezone")
+data class NotificationHistoryResponse(
+    @Schema(description = "Days holding at least one entry, ascending; empty days are omitted")
+    val days: List<NotificationHistoryDay>,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationHistoryService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationHistoryService.kt
@@ -1,0 +1,21 @@
+package ru.illine.drinking.ponies.service.notification
+
+import ru.illine.drinking.ponies.model.base.NotificationHistoryStatus
+import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryEvent
+import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryResponse
+import java.time.LocalDate
+
+interface NotificationHistoryService {
+    fun getHistory(
+        externalUserId: Long,
+        from: LocalDate,
+        to: LocalDate,
+    ): NotificationHistoryResponse
+
+    fun updateEntry(
+        externalUserId: Long,
+        entryId: Long,
+        status: NotificationHistoryStatus,
+        amountMl: Int?,
+    ): NotificationHistoryEvent
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationHistoryServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationHistoryServiceImpl.kt
@@ -1,0 +1,175 @@
+package ru.illine.drinking.ponies.service.notification.impl
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
+import ru.illine.drinking.ponies.exception.NotificationHistoryEntryNotEditableException
+import ru.illine.drinking.ponies.exception.NotificationHistoryEntryNotFoundException
+import ru.illine.drinking.ponies.model.base.NotificationHistoryStatus
+import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
+import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryDay
+import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryEvent
+import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryResponse
+import ru.illine.drinking.ponies.service.notification.NotificationHistoryService
+import ru.illine.drinking.ponies.util.statistics.StatisticsPeriodHelper
+import ru.illine.drinking.ponies.util.statistics.toUtcInstant
+import ru.illine.drinking.ponies.util.water.WaterEntryConstants
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+@Service
+class NotificationHistoryServiceImpl(
+    private val notificationAccessService: NotificationAccessService,
+    private val waterStatisticAccessService: WaterStatisticAccessService,
+    private val clock: Clock,
+) : NotificationHistoryService {
+    private val logger = LoggerFactory.getLogger("SERVICE")
+
+    override fun getHistory(
+        externalUserId: Long,
+        from: LocalDate,
+        to: LocalDate,
+    ): NotificationHistoryResponse {
+        logger.debug("Getting [{} - {}] notification history for telegram user [{}]", from, to, externalUserId)
+
+        require(from <= to) { "Invalid parameter: 'from' must be before or equal to 'to'" }
+        require(ChronoUnit.DAYS.between(from, to) < MAX_RANGE_DAYS) {
+            "Invalid parameter: the range must not exceed $MAX_RANGE_DAYS days"
+        }
+        // Without an upper bound, a date near LocalDate.MAX overflows while shifting the end of the range.
+        require(to.year < LocalDate.MAX.year) {
+            "Invalid parameter: 'to' must not be later than the year ${LocalDate.MAX.year}"
+        }
+        // Symmetrically, a date near LocalDate.MIN underflows while shifting the start of the range into UTC:
+        // that raises a DateTimeException, which is not a rejected request but a server error.
+        require(from.year > LocalDate.MIN.year) {
+            "Invalid parameter: 'from' must not be earlier than the year ${LocalDate.MIN.year}"
+        }
+
+        // A range in the future is legitimate - the client may page the calendar forward, it just gets no days.
+        val zone = userZone(externalUserId)
+        val (startInclusive, endExclusive) =
+            StatisticsPeriodHelper.localDayBoundsToUtc(
+                from,
+                to.plusDays(1),
+                zone,
+            )
+        val isEditable = editWindow(zone)
+
+        val days =
+            waterStatisticAccessService
+                .findByUserAndTypesAndEventTimeBetween(
+                    externalUserId,
+                    JOURNAL_SOURCES,
+                    JOURNAL_EVENT_TYPES,
+                    startInclusive,
+                    endExclusive,
+                ).map { toEvent(it, isEditable) }
+                .groupBy { it.eventTime.atZone(zone).toLocalDate() }
+                .map { (date, events) -> NotificationHistoryDay(date = date, events = events) }
+                // Days come out ordered by event time, except where a DST fall-back crosses local midnight.
+                .sortedBy { it.date }
+
+        return NotificationHistoryResponse(days = days)
+    }
+
+    override fun updateEntry(
+        externalUserId: Long,
+        entryId: Long,
+        status: NotificationHistoryStatus,
+        amountMl: Int?,
+    ): NotificationHistoryEvent {
+        logger.info(
+            "Updating notification history entry [{}] of telegram user [{}] to status [{}]",
+            entryId,
+            externalUserId,
+            status,
+        )
+
+        // A missed entry never holds a volume, so the client's snapshot of the form is ignored for it.
+        val newAmountMl =
+            if (status == NotificationHistoryStatus.CONFIRMED) {
+                val confirmedAmountMl =
+                    requireNotNull(amountMl) { "Invalid parameter: 'amountMl' is required when status is CONFIRMED" }
+                require(confirmedAmountMl in AMOUNT_RANGE) {
+                    "Invalid parameter: 'amountMl' must be within $AMOUNT_RANGE"
+                }
+                confirmedAmountMl
+            } else {
+                0
+            }
+
+        // An entry the journal never shows (foreign, manual or snoozed) is reported as missing:
+        // we do not confirm that it exists.
+        val entry =
+            waterStatisticAccessService
+                .findByIdAndUser(entryId, externalUserId)
+                ?.takeIf { journalStatus(it) != null }
+                ?: throw NotificationHistoryEntryNotFoundException(
+                    "Not found a notification history entry by id [$entryId] of externalUserId [$externalUserId]",
+                )
+
+        // The entry is fetched with its owner, so the timezone comes from it instead of a second lookup.
+        val isEditable = editWindow(ZoneId.of(entry.telegramUser.userTimeZone))
+        if (!isEditable(entry.eventTime.toUtcInstant())) {
+            throw NotificationHistoryEntryNotEditableException(
+                "The notification history entry [$entryId] is older than $EDIT_WINDOW_DAYS calendar days",
+            )
+        }
+
+        val saved =
+            waterStatisticAccessService.save(
+                entry.copy(eventType = status.eventType, waterAmountMl = newAmountMl),
+            )
+        return toEvent(saved, isEditable)
+    }
+
+    private fun userZone(externalUserId: Long): ZoneId {
+        val settings = notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
+        return ZoneId.of(settings.telegramUser.userTimeZone)
+    }
+
+    // Single answer to "is this record a journal entry at all", shared by reading and editing.
+    private fun journalStatus(dto: WaterStatisticDto): NotificationHistoryStatus? =
+        if (dto.source in JOURNAL_SOURCES) NotificationHistoryStatus.of(dto.eventType) else null
+
+    // The single predicate behind both the 'editable' flag of the journal and the refusal to update.
+    // The window spans whole calendar dates of the user's timezone, so all entries of one local day
+    // always share the same flag: the client draws a single lock per day.
+    private fun editWindow(zone: ZoneId): (Instant) -> Boolean {
+        val startDate = LocalDate.now(clock.withZone(zone)).minusDays(EDIT_WINDOW_DAYS)
+        return { eventTime -> !eventTime.atZone(zone).toLocalDate().isBefore(startDate) }
+    }
+
+    private fun toEvent(
+        dto: WaterStatisticDto,
+        isEditable: (Instant) -> Boolean,
+    ): NotificationHistoryEvent {
+        val eventTime = dto.eventTime.toUtcInstant()
+        return NotificationHistoryEvent(
+            id = checkNotNull(dto.id) { "A persisted water statistic record must have an id" },
+            eventTime = eventTime,
+            status = checkNotNull(journalStatus(dto)) { "A journal entry must carry a journal status" },
+            amountMl = dto.waterAmountMl,
+            source = dto.source,
+            editable = isEditable(eventTime),
+        )
+    }
+
+    companion object {
+        // Calendar days of the user's timezone: the current local day and that many days before it stay editable.
+        const val EDIT_WINDOW_DAYS = 7L
+        const val MAX_RANGE_DAYS = 62L
+
+        // Widening the journal to another source is a single addition here: both reading and editing follow it.
+        val JOURNAL_SOURCES = setOf(WaterEntrySourceType.NOTIFICATION)
+        val JOURNAL_EVENT_TYPES = NotificationHistoryStatus.entries.map { it.eventType }
+
+        private val AMOUNT_RANGE = WaterEntryConstants.MIN_ML.toInt()..WaterEntryConstants.MAX_ML.toInt()
+    }
+}

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/NotificationControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/NotificationControllerTest.kt
@@ -1,14 +1,19 @@
 package ru.illine.drinking.ponies.controller
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -20,15 +25,26 @@ import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
+import ru.illine.drinking.ponies.exception.NotificationHistoryEntryNotEditableException
+import ru.illine.drinking.ponies.exception.NotificationHistoryEntryNotFoundException
 import ru.illine.drinking.ponies.exception.NotificationSettingsNotFoundException
+import ru.illine.drinking.ponies.model.base.NotificationHistoryStatus
+import ru.illine.drinking.ponies.model.dto.response.ErrorResponse
+import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryDay
+import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryEvent
+import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryResponse
 import ru.illine.drinking.ponies.model.dto.response.NotificationNextResponse
 import ru.illine.drinking.ponies.model.dto.response.PauseStateResponse
+import ru.illine.drinking.ponies.service.notification.NotificationHistoryService
 import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
 import java.time.Instant
+import java.time.LocalDate
+import java.util.stream.Stream
 
 @SpringIntegrationTest
 @DisplayName("NotificationController Spring Integration Test")
@@ -36,12 +52,16 @@ class NotificationControllerTest
     @Autowired
     constructor(
         private val restTemplate: TestRestTemplate,
+        private val objectMapper: ObjectMapper,
     ) {
         @MockitoBean
         private lateinit var telegramValidatorService: TelegramValidatorService
 
         @MockitoBean
         private lateinit var notificationSettingsService: NotificationSettingsService
+
+        @MockitoBean
+        private lateinit var notificationHistoryService: NotificationHistoryService
 
         private val telegramUser = DtoGenerator.generateTelegramUserDto()
 
@@ -341,5 +361,249 @@ class NotificationControllerTest
 
                 assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
             }
+        }
+
+        @Nested
+        @DisplayName("GET /notifications/history")
+        inner class GetHistory {
+            private val from = LocalDate.of(2026, 5, 4)
+            private val to = LocalDate.of(2026, 5, 10)
+
+            private fun journal() =
+                NotificationHistoryResponse(
+                    days =
+                        listOf(
+                            NotificationHistoryDay(
+                                date = from,
+                                events =
+                                    listOf(
+                                        DtoGenerator.generateNotificationHistoryEvent(
+                                            eventTime = Instant.parse("2026-05-04T09:30:00Z"),
+                                            status = NotificationHistoryStatus.MISSED,
+                                            amountMl = 0,
+                                        ),
+                                    ),
+                            ),
+                        ),
+                )
+
+            private fun get(query: String) =
+                restTemplate.exchange(
+                    "/notifications/history?$query",
+                    HttpMethod.GET,
+                    HttpEntity<Void>(buildHeaders()),
+                    String::class.java,
+                )
+
+            @Test
+            @DisplayName("valid range - returns 200 with the journal and forwards from/to")
+            fun `returns 200 with the journal`() {
+                whenever(notificationHistoryService.getHistory(any(), any(), any())).thenReturn(journal())
+
+                val response = get("from=$from&to=$to")
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertEquals(journal(), objectMapper.readValue(response.body, NotificationHistoryResponse::class.java))
+                // Dates and instants go over the wire as ISO 8601 strings, not as numbers.
+                val day = objectMapper.readTree(response.body).path("days").path(0)
+                val event = day.path("events").path(0)
+                assertEquals("2026-05-04", day.path("date").asText())
+                assertEquals("2026-05-04T09:30:00Z", event.path("eventTime").asText())
+                verify(notificationHistoryService).getHistory(telegramUser.externalUserId, from, to)
+            }
+
+            @Test
+            @DisplayName("no entries in the range - returns 200 with an empty days array")
+            fun `returns 200 with empty days`() {
+                whenever(notificationHistoryService.getHistory(any(), any(), any()))
+                    .thenReturn(NotificationHistoryResponse(days = emptyList()))
+
+                val response = get("from=$from&to=$to")
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertTrue(
+                    objectMapper.readValue(response.body, NotificationHistoryResponse::class.java).days.isEmpty(),
+                )
+            }
+
+            @Test
+            @DisplayName("service rejects the range - returns 400")
+            fun `returns 400 when the service rejects the range`() {
+                doThrow(IllegalArgumentException("Invalid parameter"))
+                    .whenever(notificationHistoryService)
+                    .getHistory(any(), any(), any())
+
+                assertEquals(HttpStatus.BAD_REQUEST, get("from=$from&to=$to").statusCode)
+            }
+
+            @ParameterizedTest(name = "[{index}] query={0} - returns 400")
+            @ValueSource(strings = ["from=foobar&to=2026-05-10", "from=2026-05-04", "to=2026-05-10", "from=&to="])
+            @DisplayName("malformed or missing dates - returns 400")
+            fun `returns 400 on malformed dates`(query: String) {
+                assertEquals(HttpStatus.BAD_REQUEST, get(query).statusCode)
+                verifyNoInteractions(notificationHistoryService)
+            }
+
+            @Test
+            @DisplayName("missing auth header - returns 401")
+            fun `returns 401`() {
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/history?from=$from&to=$to",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(HttpHeaders()),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                verifyNoInteractions(notificationHistoryService)
+            }
+
+            @Test
+            @DisplayName("settings not found (e.g. disabled user) - returns 404")
+            fun `returns 404 when settings not found`() {
+                doThrow(NotificationSettingsNotFoundException("Not found"))
+                    .whenever(notificationHistoryService)
+                    .getHistory(any(), any(), any())
+
+                assertEquals(HttpStatus.NOT_FOUND, get("from=$from&to=$to").statusCode)
+            }
+        }
+
+        @Nested
+        @DisplayName("PATCH /notifications/history/{id}")
+        inner class UpdateHistoryEntry {
+            private fun patch(
+                id: String,
+                body: String,
+            ) = restTemplate.exchange(
+                "/notifications/history/$id",
+                HttpMethod.PATCH,
+                HttpEntity(body, buildHeaders().apply { contentType = MediaType.APPLICATION_JSON }),
+                String::class.java,
+            )
+
+            @ParameterizedTest(name = "[{index}] body={0} - forwards status={1} and amountMl={2}")
+            @MethodSource("ru.illine.drinking.ponies.controller.NotificationControllerTest#updatePayloads")
+            @DisplayName("valid payload - returns 200 with the updated entry and forwards the payload as it came")
+            fun `returns 200 on a valid payload`(
+                body: String,
+                expectedStatus: NotificationHistoryStatus,
+                expectedAmountMl: Int?,
+            ) {
+                val updated =
+                    DtoGenerator.generateNotificationHistoryEvent(
+                        status = expectedStatus,
+                        amountMl = expectedAmountMl ?: 0,
+                    )
+                whenever(notificationHistoryService.updateEntry(any(), any(), any(), anyOrNull())).thenReturn(updated)
+
+                val response = patch("1042", body)
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertEquals(updated, objectMapper.readValue(response.body, NotificationHistoryEvent::class.java))
+                verify(notificationHistoryService)
+                    .updateEntry(telegramUser.externalUserId, 1042L, expectedStatus, expectedAmountMl)
+            }
+
+            @ParameterizedTest(name = "[{index}] body={0} - returns 400")
+            @ValueSource(
+                strings = [
+                    """{"status":"UNKNOWN","amountMl":300}""",
+                    """{"amountMl":300}""",
+                    "{}",
+                ],
+            )
+            @DisplayName("malformed payload - returns 400")
+            fun `returns 400 on malformed payload`(body: String) {
+                assertEquals(HttpStatus.BAD_REQUEST, patch("1042", body).statusCode)
+                verifyNoInteractions(notificationHistoryService)
+            }
+
+            @Test
+            @DisplayName("service rejects the payload (an out-of-range amount, for one) - returns 400")
+            fun `returns 400 when the service rejects the payload`() {
+                doThrow(IllegalArgumentException("Invalid parameter: 'amountMl' must be within 50..1000"))
+                    .whenever(notificationHistoryService)
+                    .updateEntry(any(), any(), any(), anyOrNull())
+
+                val response = patch("1042", """{"status":"CONFIRMED","amountMl":1001}""")
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+            }
+
+            @Test
+            @DisplayName("non-numeric id - returns 400")
+            fun `returns 400 on non-numeric id`() {
+                val response = patch("abc", """{"status":"MISSED"}""")
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                verifyNoInteractions(notificationHistoryService)
+            }
+
+            @Test
+            @DisplayName("unknown, foreign or non-journal entry - returns 404")
+            fun `returns 404 when entry not found`() {
+                doThrow(NotificationHistoryEntryNotFoundException("Not found"))
+                    .whenever(notificationHistoryService)
+                    .updateEntry(any(), any(), any(), anyOrNull())
+
+                val response = patch("1042", """{"status":"MISSED"}""")
+
+                assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+                assertEquals(
+                    ErrorResponse("notification history entry not found"),
+                    objectMapper.readValue(response.body, ErrorResponse::class.java),
+                )
+            }
+
+            @Test
+            @DisplayName("entry outside the edit window - returns 409")
+            fun `returns 409 when entry is not editable`() {
+                doThrow(NotificationHistoryEntryNotEditableException("Too old"))
+                    .whenever(notificationHistoryService)
+                    .updateEntry(any(), any(), any(), anyOrNull())
+
+                val response = patch("1042", """{"status":"MISSED"}""")
+
+                assertEquals(HttpStatus.CONFLICT, response.statusCode)
+                assertEquals(
+                    ErrorResponse("notification history entry is not editable"),
+                    objectMapper.readValue(response.body, ErrorResponse::class.java),
+                )
+            }
+
+            @Test
+            @DisplayName("missing auth header - returns 401")
+            fun `returns 401`() {
+                val response =
+                    restTemplate.exchange(
+                        "/notifications/history/1042",
+                        HttpMethod.PATCH,
+                        HttpEntity(
+                            """{"status":"MISSED"}""",
+                            HttpHeaders().apply { contentType = MediaType.APPLICATION_JSON },
+                        ),
+                        Void::class.java,
+                    )
+
+                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+                verifyNoInteractions(notificationHistoryService)
+            }
+        }
+
+        companion object {
+            @JvmStatic
+            fun updatePayloads(): Stream<Arguments> =
+                Stream.of(
+                    Arguments.of(
+                        """{"status":"CONFIRMED","amountMl":300}""",
+                        NotificationHistoryStatus.CONFIRMED,
+                        300,
+                    ),
+                    // A missed entry ignores the amount, but whatever the form sent still reaches the service.
+                    Arguments.of("""{"status":"MISSED"}""", NotificationHistoryStatus.MISSED, null),
+                    Arguments.of("""{"status":"MISSED","amountMl":0}""", NotificationHistoryStatus.MISSED, 0),
+                )
         }
     }

--- a/src/test/kotlin/ru/illine/drinking/ponies/dao/access/WaterStatisticAccessServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/dao/access/WaterStatisticAccessServiceTest.kt
@@ -10,10 +10,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.function.ThrowingSupplier
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlConfig
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.WaterAmountType
+import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
 import java.time.LocalDateTime
@@ -34,6 +36,7 @@ class WaterStatisticAccessServiceTest
     @Autowired
     constructor(
         private val accessService: WaterStatisticAccessService,
+        private val jdbcTemplate: JdbcTemplate,
     ) {
         @Test
         @DisplayName("save(): returns a saved record with id")
@@ -52,6 +55,44 @@ class WaterStatisticAccessServiceTest
             assertEquals(DEFAULT_EXTERNAL_USER_ID, actual.telegramUser.externalUserId)
             assertEquals(AnswerNotificationType.YES, actual.eventType)
             assertEquals(expectedWaterAmount, actual.waterAmountMl)
+        }
+
+        @Test
+        @DisplayName("save(): updates the stored row in place when the record already has an id")
+        fun `successful save updates an existing record`() {
+            val stored =
+                accessService.save(
+                    DtoGenerator.generateWaterStatisticDto(
+                        externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                        eventType = AnswerNotificationType.YES,
+                        waterAmountMl = WaterAmountType.ML_250.amountMl,
+                    ),
+                )
+
+            val actual =
+                assertDoesNotThrow(
+                    ThrowingSupplier {
+                        accessService.save(stored.copy(eventType = AnswerNotificationType.CANCEL, waterAmountMl = 0))
+                    },
+                )
+
+            // The returned DTO alone cannot tell an update from an insert - a second row would silently double
+            // the drunk volume on every edit of the journal - so the table itself is read back.
+            val rows =
+                jdbcTemplate.queryForList(
+                    """
+                    select ws.id, ws.event_type, ws.water_amount_ml
+                    from water_statistics ws
+                    join telegram_users u on u.id = ws.user_id
+                    where u.external_user_id = ?
+                    """.trimIndent(),
+                    DEFAULT_EXTERNAL_USER_ID,
+                )
+            assertEquals(1, rows.size)
+            assertEquals(stored.id, (rows.single()["id"] as Number).toLong())
+            assertEquals(AnswerNotificationType.CANCEL.name, rows.single()["event_type"])
+            assertEquals(0, rows.single()["water_amount_ml"])
+            assertEquals(stored.id, actual.id)
         }
 
         @Test
@@ -306,6 +347,154 @@ class WaterStatisticAccessServiceTest
         }
 
         @Test
+        @DisplayName("findByUserAndTypesAndEventTimeBetween(): keeps only the requested sources and event types")
+        fun `successful findByUserAndTypesAndEventTimeBetween filters by source and event type`() {
+            val baseTime = LocalDateTime.of(2025, 6, 15, 10, 0)
+            val matching =
+                accessService.save(
+                    DtoGenerator.generateWaterStatisticDto(
+                        externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                        eventTime = baseTime,
+                        eventType = AnswerNotificationType.YES,
+                        source = WaterEntrySourceType.NOTIFICATION,
+                    ),
+                )
+            // Right source, wrong event type.
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    eventTime = baseTime.plusMinutes(1),
+                    eventType = AnswerNotificationType.SNOOZE,
+                    source = WaterEntrySourceType.NOTIFICATION,
+                ),
+            )
+            // Right event type, wrong source.
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                    eventTime = baseTime.plusMinutes(2),
+                    eventType = AnswerNotificationType.YES,
+                    source = WaterEntrySourceType.MANUAL,
+                ),
+            )
+
+            val actual =
+                accessService.findByUserAndTypesAndEventTimeBetween(
+                    DEFAULT_EXTERNAL_USER_ID,
+                    setOf(WaterEntrySourceType.NOTIFICATION),
+                    setOf(AnswerNotificationType.YES, AnswerNotificationType.CANCEL),
+                    baseTime,
+                    baseTime.plusHours(1),
+                )
+
+            assertEquals(1, actual.size)
+            assertEquals(matching.id, actual[0].id)
+            assertEquals(AnswerNotificationType.YES, actual[0].eventType)
+            assertEquals(WaterEntrySourceType.NOTIFICATION, actual[0].source)
+        }
+
+        @Test
+        @DisplayName("findByUserAndTypesAndEventTimeBetween(): returns only records of the requested user")
+        fun `successful findByUserAndTypesAndEventTimeBetween filters by user`() {
+            val time = LocalDateTime.of(2025, 6, 15, 10, 0)
+            val mine =
+                accessService.save(
+                    DtoGenerator.generateWaterStatisticDto(
+                        externalUserId = DEFAULT_EXTERNAL_USER_ID,
+                        eventTime = time,
+                        eventType = AnswerNotificationType.YES,
+                        source = WaterEntrySourceType.NOTIFICATION,
+                    ),
+                )
+            // Same window, same source and event type, another owner: the journal must never show it.
+            accessService.save(
+                DtoGenerator.generateWaterStatisticDto(
+                    externalUserId = SECOND_EXTERNAL_USER_ID,
+                    eventTime = time,
+                    eventType = AnswerNotificationType.YES,
+                    source = WaterEntrySourceType.NOTIFICATION,
+                ),
+            )
+
+            val actual =
+                accessService.findByUserAndTypesAndEventTimeBetween(
+                    DEFAULT_EXTERNAL_USER_ID,
+                    setOf(WaterEntrySourceType.NOTIFICATION),
+                    setOf(AnswerNotificationType.YES, AnswerNotificationType.CANCEL),
+                    time.minusMinutes(1),
+                    time.plusMinutes(1),
+                )
+
+            assertEquals(1, actual.size)
+            assertEquals(mine.id, actual[0].id)
+            assertEquals(DEFAULT_EXTERNAL_USER_ID, actual[0].telegramUser.externalUserId)
+        }
+
+        @Test
+        @DisplayName("findByIdAndUser(): returns the record of the requesting user, together with its owner")
+        fun `findByIdAndUser returns own record`() {
+            val eventTime = LocalDateTime.of(2025, 6, 15, 10, 0)
+            // The saved DTO deliberately carries another timezone: the owner of the record comes from the
+            // database, and the notification journal measures its edit window by exactly that value.
+            val saved =
+                accessService.save(
+                    DtoGenerator.generateWaterStatisticDto(
+                        externalUserId = THIRD_EXTERNAL_USER_ID,
+                        eventTime = eventTime,
+                        waterAmountMl = WaterAmountType.ML_150.amountMl,
+                        userTimeZone = "UTC",
+                    ),
+                )
+
+            val actual = accessService.findByIdAndUser(saved.id!!, THIRD_EXTERNAL_USER_ID)
+
+            assertNotNull(actual)
+            assertEquals(saved.id, actual!!.id)
+            assertEquals(eventTime, actual.eventTime)
+            assertEquals(WaterAmountType.ML_150.amountMl, actual.waterAmountMl)
+            assertEquals(THIRD_EXTERNAL_USER_ID, actual.telegramUser.externalUserId)
+            assertEquals(THIRD_USER_TIME_ZONE, actual.telegramUser.userTimeZone)
+        }
+
+        @Test
+        @DisplayName("findByIdAndUser(): returns null for a record of another user")
+        fun `findByIdAndUser hides a foreign record`() {
+            val saved =
+                accessService.save(
+                    DtoGenerator.generateWaterStatisticDto(externalUserId = DEFAULT_EXTERNAL_USER_ID),
+                )
+
+            val actual = accessService.findByIdAndUser(saved.id!!, SECOND_EXTERNAL_USER_ID)
+
+            assertNull(actual)
+        }
+
+        @Test
+        @DisplayName("findByIdAndUser(): returns null for an unknown id")
+        fun `findByIdAndUser unknown id`() {
+            val actual = accessService.findByIdAndUser(NOT_EXISTED_ENTRY_ID, DEFAULT_EXTERNAL_USER_ID)
+
+            assertNull(actual)
+        }
+
+        @Test
+        @DisplayName("findByIdAndUser(): returns null once the owner is deleted")
+        fun `findByIdAndUser hides a record of a deleted user`() {
+            val saved =
+                accessService.save(
+                    DtoGenerator.generateWaterStatisticDto(externalUserId = SECOND_EXTERNAL_USER_ID),
+                )
+            assertNotNull(accessService.findByIdAndUser(saved.id!!, SECOND_EXTERNAL_USER_ID))
+
+            jdbcTemplate.update(
+                "update telegram_users set deleted = true where external_user_id = ?",
+                SECOND_EXTERNAL_USER_ID,
+            )
+
+            assertNull(accessService.findByIdAndUser(saved.id!!, SECOND_EXTERNAL_USER_ID))
+        }
+
+        @Test
         @DisplayName("findEarliestEventTimeByUser(): returns the minimum eventTime for the user")
         fun `findEarliestEventTimeByUser returns min`() {
             val earliest = LocalDateTime.of(2025, 1, 5, 9, 30)
@@ -375,6 +564,11 @@ class WaterStatisticAccessServiceTest
         companion object {
             private const val DEFAULT_EXTERNAL_USER_ID = 1L
             private const val SECOND_EXTERNAL_USER_ID = 2L
+            private const val THIRD_EXTERNAL_USER_ID = 3L
+
+            // The timezone the seed script stores for the third user.
+            private const val THIRD_USER_TIME_ZONE = "Asia/Kolkata"
             private const val NOT_EXISTED_USER_ID = 0L
+            private const val NOT_EXISTED_ENTRY_ID = 0L
         }
     }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationHistoryServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationHistoryServiceTest.kt
@@ -1,0 +1,609 @@
+package ru.illine.drinking.ponies.service.notification
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
+import ru.illine.drinking.ponies.exception.NotificationHistoryEntryNotEditableException
+import ru.illine.drinking.ponies.exception.NotificationHistoryEntryNotFoundException
+import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.base.NotificationHistoryStatus
+import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
+import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
+import ru.illine.drinking.ponies.service.notification.impl.NotificationHistoryServiceImpl
+import ru.illine.drinking.ponies.test.generator.DtoGenerator
+import ru.illine.drinking.ponies.test.tag.UnitTest
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.stream.Stream
+
+@UnitTest
+@DisplayName("NotificationHistoryService Unit Test")
+class NotificationHistoryServiceTest {
+    private lateinit var notificationAccessService: NotificationAccessService
+    private lateinit var waterStatisticAccessService: WaterStatisticAccessService
+    private lateinit var service: NotificationHistoryService
+
+    @BeforeEach
+    fun setUp() {
+        notificationAccessService = mock<NotificationAccessService>()
+        waterStatisticAccessService = mock<WaterStatisticAccessService>()
+        service =
+            NotificationHistoryServiceImpl(
+                notificationAccessService,
+                waterStatisticAccessService,
+                Clock.fixed(NOW, ZoneOffset.UTC),
+            )
+    }
+
+    private fun stubZone(zone: String = "UTC") {
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(EXTERNAL_USER_ID))
+            .thenReturn(
+                DtoGenerator.generateNotificationDto(externalUserId = EXTERNAL_USER_ID, userTimeZone = zone),
+            )
+    }
+
+    private fun stubEvents(vararg events: WaterStatisticDto) {
+        whenever(
+            waterStatisticAccessService.findByUserAndTypesAndEventTimeBetween(any(), any(), any(), any(), any()),
+        ).thenReturn(events.toList())
+    }
+
+    private fun stubStoredEntry(entry: WaterStatisticDto?) {
+        whenever(waterStatisticAccessService.findByIdAndUser(ENTRY_ID, EXTERNAL_USER_ID)).thenReturn(entry)
+    }
+
+    // The access layer returns the record as it was persisted, so the stub echoes the merged DTO back.
+    private fun stubSaveEcho() {
+        whenever(waterStatisticAccessService.save(any())).thenAnswer { it.getArgument<WaterStatisticDto>(0) }
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("provideZoneBoundaryCases")
+    @DisplayName("getHistory(): reads the range as civil days of the user timezone")
+    fun `getHistory computes day bounds in user TZ`(
+        zone: String,
+        from: LocalDate,
+        to: LocalDate,
+        expectedStart: LocalDateTime,
+        expectedEnd: LocalDateTime,
+    ) {
+        stubZone(zone)
+        stubEvents()
+
+        service.getHistory(EXTERNAL_USER_ID, from, to)
+
+        verify(waterStatisticAccessService).findByUserAndTypesAndEventTimeBetween(
+            eq(EXTERNAL_USER_ID),
+            any(),
+            any(),
+            eq(expectedStart),
+            eq(expectedEnd),
+        )
+    }
+
+    @Test
+    @DisplayName("getHistory(): asks the access layer only for journal sources and event types")
+    fun `getHistory narrows the query to journal entries`() {
+        stubZone()
+        stubEvents()
+
+        service.getHistory(EXTERNAL_USER_ID, LocalDate.of(2026, 5, 4), LocalDate.of(2026, 5, 4))
+
+        // Snoozed answers and manual entries are cut off by the query itself, not in memory.
+        verify(waterStatisticAccessService).findByUserAndTypesAndEventTimeBetween(
+            eq(EXTERNAL_USER_ID),
+            argThat { toSet() == setOf(WaterEntrySourceType.NOTIFICATION) },
+            argThat { toSet() == setOf(AnswerNotificationType.YES, AnswerNotificationType.CANCEL) },
+            any(),
+            any(),
+        )
+    }
+
+    @Test
+    @DisplayName("getHistory(): groups entries by their local date, not by the UTC one")
+    fun `getHistory groups by local date`() {
+        stubZone("Europe/Moscow")
+        stubEvents(
+            // 00:30 of May 4th locally
+            entry(id = 1L, eventTime = LocalDateTime.of(2026, 5, 3, 21, 30, 0)),
+            // 23:59 of May 4th locally
+            entry(id = 2L, eventTime = LocalDateTime.of(2026, 5, 4, 20, 59, 0)),
+            // 00:00 of May 5th locally
+            entry(
+                id = 3L,
+                eventTime = LocalDateTime.of(2026, 5, 4, 21, 0, 0),
+                eventType = AnswerNotificationType.CANCEL,
+            ),
+        )
+
+        val actual = service.getHistory(EXTERNAL_USER_ID, LocalDate.of(2026, 5, 4), LocalDate.of(2026, 5, 5))
+
+        assertEquals(listOf(LocalDate.of(2026, 5, 4), LocalDate.of(2026, 5, 5)), actual.days.map { it.date })
+        assertEquals(listOf(1L, 2L), actual.days[0].events.map { it.id })
+        assertEquals(listOf(3L), actual.days[1].events.map { it.id })
+        assertEquals(Instant.parse("2026-05-03T21:30:00Z"), actual.days[0].events[0].eventTime)
+        assertEquals(NotificationHistoryStatus.CONFIRMED, actual.days[0].events[0].status)
+        assertEquals(NotificationHistoryStatus.MISSED, actual.days[1].events[0].status)
+    }
+
+    @Test
+    @DisplayName("getHistory(): groups by the offset effective at the event, across a DST switch")
+    fun `getHistory groups across DST switch`() {
+        stubZone("America/New_York")
+        stubEvents(
+            // 23:30 of March 7th locally (UTC-5, before the switch)
+            entry(id = 1L, eventTime = LocalDateTime.of(2026, 3, 8, 4, 30, 0)),
+            // 00:30 of March 9th locally (UTC-4, after the switch)
+            entry(id = 2L, eventTime = LocalDateTime.of(2026, 3, 9, 4, 30, 0)),
+        )
+
+        val actual = service.getHistory(EXTERNAL_USER_ID, LocalDate.of(2026, 3, 7), LocalDate.of(2026, 3, 9))
+
+        assertEquals(listOf(LocalDate.of(2026, 3, 7), LocalDate.of(2026, 3, 9)), actual.days.map { it.date })
+        assertEquals(listOf(1L), actual.days[0].events.map { it.id })
+        assertEquals(listOf(2L), actual.days[1].events.map { it.id })
+    }
+
+    @Test
+    @DisplayName("getHistory(): returns no days when the user has no matching entries")
+    fun `getHistory returns empty days`() {
+        stubZone()
+        stubEvents()
+
+        val actual = service.getHistory(EXTERNAL_USER_ID, LocalDate.of(2026, 5, 4), LocalDate.of(2026, 5, 10))
+
+        assertTrue(actual.days.isEmpty())
+    }
+
+    @Test
+    @DisplayName("getHistory(): returns days in ascending order")
+    fun `getHistory sorts days ascending`() {
+        stubZone()
+        stubEvents(
+            entry(id = 2L, eventTime = LocalDateTime.of(2026, 5, 5, 10, 0, 0)),
+            entry(id = 1L, eventTime = LocalDateTime.of(2026, 5, 4, 10, 0, 0)),
+        )
+
+        val actual = service.getHistory(EXTERNAL_USER_ID, LocalDate.of(2026, 5, 4), LocalDate.of(2026, 5, 5))
+
+        assertEquals(listOf(LocalDate.of(2026, 5, 4), LocalDate.of(2026, 5, 5)), actual.days.map { it.date })
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}, eventTime={1} -> editable={2}")
+    @MethodSource("provideEditWindowCases")
+    @DisplayName("getHistory(): marks an entry editable by the calendar date of the user timezone")
+    fun `getHistory marks entries by the calendar edit window`(
+        zone: String,
+        eventTime: LocalDateTime,
+        expectedEditable: Boolean,
+    ) {
+        stubZone(zone)
+        stubEvents(entry(eventTime = eventTime))
+
+        val actual = service.getHistory(EXTERNAL_USER_ID, WINDOW_CASE_FROM, WINDOW_CASE_TO)
+
+        val events = actual.days.single().events
+        assertEquals(expectedEditable, events.single().editable)
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("provideLocalDayEdges")
+    @DisplayName("getHistory(): gives every entry of one local day the same editable flag")
+    fun `getHistory keeps the editable flag uniform inside a day`(
+        zone: String,
+        dayOutsideWindow: List<LocalDateTime>,
+        dayInsideWindow: List<LocalDateTime>,
+    ) {
+        stubZone(zone)
+        stubEvents(
+            // The first and the last second of May 2nd locally - the whole day is one day too old
+            entry(id = 1L, eventTime = dayOutsideWindow[0]),
+            entry(id = 2L, eventTime = dayOutsideWindow[1]),
+            // The first and the last second of May 3rd locally - the oldest day still inside the window
+            entry(id = 3L, eventTime = dayInsideWindow[0]),
+            entry(id = 4L, eventTime = dayInsideWindow[1]),
+        )
+
+        val actual = service.getHistory(EXTERNAL_USER_ID, LocalDate.of(2026, 5, 2), LocalDate.of(2026, 5, 3))
+
+        // A day is indivisible: the client draws a single lock per day, so a day never mixes both flags.
+        assertEquals(listOf(LocalDate.of(2026, 5, 2), LocalDate.of(2026, 5, 3)), actual.days.map { it.date })
+        assertEquals(listOf(false, false), actual.days[0].events.map { it.editable })
+        assertEquals(listOf(true, true), actual.days[1].events.map { it.editable })
+    }
+
+    @Test
+    @DisplayName("getHistory(): rejects a range whose start is after its end")
+    fun `getHistory rejects reversed range`() {
+        assertThrows<IllegalArgumentException> {
+            service.getHistory(EXTERNAL_USER_ID, LocalDate.of(2026, 5, 11), LocalDate.of(2026, 5, 10))
+        }
+
+        verifyNoInteractions(waterStatisticAccessService)
+    }
+
+    @Test
+    @DisplayName("getHistory(): rejects a range longer than the allowed maximum")
+    fun `getHistory rejects too long range`() {
+        val from = LocalDate.of(2026, 1, 1)
+
+        assertThrows<IllegalArgumentException> {
+            service.getHistory(
+                EXTERNAL_USER_ID,
+                from,
+                from.plusDays(NotificationHistoryServiceImpl.MAX_RANGE_DAYS),
+            )
+        }
+
+        verifyNoInteractions(waterStatisticAccessService)
+    }
+
+    @Test
+    @DisplayName("getHistory(): rejects a range beyond the supported year")
+    fun `getHistory rejects a range beyond the supported year`() {
+        assertThrows<IllegalArgumentException> {
+            service.getHistory(EXTERNAL_USER_ID, LocalDate.MAX.minusDays(1), LocalDate.MAX)
+        }
+
+        verifyNoInteractions(waterStatisticAccessService)
+    }
+
+    @Test
+    @DisplayName("getHistory(): rejects a range before the supported year")
+    fun `getHistory rejects a range before the supported year`() {
+        // The zone is stubbed on purpose: shifting the start of such a range into UTC underflows with a
+        // DateTimeException, which is a server error, so the range has to be turned down as an invalid one.
+        stubZone("Europe/Moscow")
+
+        assertThrows<IllegalArgumentException> {
+            service.getHistory(EXTERNAL_USER_ID, LocalDate.MIN, LocalDate.MIN.plusDays(1))
+        }
+
+        verifyNoInteractions(waterStatisticAccessService)
+    }
+
+    @Test
+    @DisplayName("getHistory(): returns no days for a range that lies entirely in the future")
+    fun `getHistory returns no days for a future range`() {
+        stubZone()
+        stubEvents()
+
+        val actual = service.getHistory(EXTERNAL_USER_ID, LocalDate.of(2030, 1, 1), LocalDate.of(2030, 1, 31))
+
+        assertEquals(0, actual.days.size)
+        verify(waterStatisticAccessService)
+            .findByUserAndTypesAndEventTimeBetween(any(), any(), any(), any(), any())
+    }
+
+    @Test
+    @DisplayName("getHistory(): accepts the longest allowed range")
+    fun `getHistory accepts the longest allowed range`() {
+        stubZone()
+        stubEvents()
+        val from = LocalDate.of(2026, 1, 1)
+
+        val actual =
+            service.getHistory(
+                EXTERNAL_USER_ID,
+                from,
+                from.plusDays(NotificationHistoryServiceImpl.MAX_RANGE_DAYS - 1),
+            )
+
+        assertTrue(actual.days.isEmpty())
+        verify(waterStatisticAccessService)
+            .findByUserAndTypesAndEventTimeBetween(any(), any(), any(), any(), any())
+    }
+
+    @Test
+    @DisplayName("updateEntry(): stores the confirmed amount and returns the updated entry")
+    fun `updateEntry stores confirmed amount`() {
+        val stored =
+            entry(
+                eventTime = LocalDateTime.of(2026, 5, 10, 8, 0, 0),
+                eventType = AnswerNotificationType.CANCEL,
+                waterAmountMl = 0,
+            )
+        stubStoredEntry(stored)
+        stubSaveEcho()
+
+        val actual = service.updateEntry(EXTERNAL_USER_ID, ENTRY_ID, NotificationHistoryStatus.CONFIRMED, 300)
+
+        // Only the status and the volume change, every other field of the stored record is kept as is.
+        verify(waterStatisticAccessService)
+            .save(stored.copy(eventType = AnswerNotificationType.YES, waterAmountMl = 300))
+        assertEquals(
+            DtoGenerator.generateNotificationHistoryEvent(
+                id = ENTRY_ID,
+                eventTime = Instant.parse("2026-05-10T08:00:00Z"),
+                status = NotificationHistoryStatus.CONFIRMED,
+                amountMl = 300,
+            ),
+            actual,
+        )
+        // The record arrives with its owner, so the settings are never read on this path.
+        verifyNoInteractions(notificationAccessService)
+    }
+
+    @ParameterizedTest(name = "[{index}] requested amountMl={0} is ignored")
+    @NullSource
+    @ValueSource(ints = [300])
+    @DisplayName("updateEntry(): stores zero millilitres for a missed entry")
+    fun `updateEntry zeroes amount on missed`(amountMl: Int?) {
+        val stored = entry(eventTime = LocalDateTime.of(2026, 5, 10, 8, 0, 0), waterAmountMl = 300)
+        stubStoredEntry(stored)
+        stubSaveEcho()
+
+        val actual = service.updateEntry(EXTERNAL_USER_ID, ENTRY_ID, NotificationHistoryStatus.MISSED, amountMl)
+
+        verify(waterStatisticAccessService)
+            .save(stored.copy(eventType = AnswerNotificationType.CANCEL, waterAmountMl = 0))
+        assertEquals(0, actual.amountMl)
+        assertEquals(NotificationHistoryStatus.MISSED, actual.status)
+    }
+
+    @ParameterizedTest(name = "[{index}] amountMl={0}")
+    @ValueSource(ints = [50, 1000])
+    @DisplayName("updateEntry(): accepts the inclusive bounds of the allowed amount range")
+    fun `updateEntry accepts the amount range bounds`(amountMl: Int) {
+        val stored =
+            entry(
+                eventTime = LocalDateTime.of(2026, 5, 10, 8, 0, 0),
+                eventType = AnswerNotificationType.CANCEL,
+                waterAmountMl = 0,
+            )
+        stubStoredEntry(stored)
+        stubSaveEcho()
+
+        val actual = service.updateEntry(EXTERNAL_USER_ID, ENTRY_ID, NotificationHistoryStatus.CONFIRMED, amountMl)
+
+        assertEquals(amountMl, actual.amountMl)
+    }
+
+    @Test
+    @DisplayName("updateEntry(): rejects a confirmed status without an amount")
+    fun `updateEntry rejects confirmed without amount`() {
+        assertThrows<IllegalArgumentException> {
+            service.updateEntry(EXTERNAL_USER_ID, ENTRY_ID, NotificationHistoryStatus.CONFIRMED, null)
+        }
+
+        verify(waterStatisticAccessService, never()).save(any())
+    }
+
+    // The service is the only place bounding the volume: the request DTO carries no constraint annotations,
+    // because a missed entry ignores the amount and clients send the whole form snapshot, zero included.
+    @ParameterizedTest(name = "[{index}] amountMl={0}")
+    @ValueSource(ints = [49, 1001])
+    @DisplayName("updateEntry(): rejects a confirmed amount outside the allowed range")
+    fun `updateEntry rejects an amount out of range`(amountMl: Int) {
+        assertThrows<IllegalArgumentException> {
+            service.updateEntry(EXTERNAL_USER_ID, ENTRY_ID, NotificationHistoryStatus.CONFIRMED, amountMl)
+        }
+
+        verifyNoInteractions(waterStatisticAccessService)
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("provideInvisibleEntries")
+    @DisplayName("updateEntry(): reports an entry the journal never shows as missing")
+    fun `updateEntry rejects invisible entries`(stored: WaterStatisticDto?) {
+        stubStoredEntry(stored)
+
+        assertThrows<NotificationHistoryEntryNotFoundException> {
+            service.updateEntry(EXTERNAL_USER_ID, ENTRY_ID, NotificationHistoryStatus.CONFIRMED, 300)
+        }
+
+        verify(waterStatisticAccessService, never()).save(any())
+    }
+
+    // Same cases as the 'editable' flag of getHistory above: the flag and the refusal to update are one
+    // predicate, so an entry the journal shows as locked is exactly the entry the update refuses.
+    @ParameterizedTest(name = "[{index}] {0}, eventTime={1} -> editable={2}")
+    @MethodSource("provideEditWindowCases")
+    @DisplayName("updateEntry(): refuses exactly the entries the journal marks read-only")
+    fun `updateEntry follows the editable flag`(
+        zone: String,
+        eventTime: LocalDateTime,
+        expectedEditable: Boolean,
+    ) {
+        stubStoredEntry(entry(eventTime = eventTime, userTimeZone = zone))
+        stubSaveEcho()
+
+        if (expectedEditable) {
+            val actual = service.updateEntry(EXTERNAL_USER_ID, ENTRY_ID, NotificationHistoryStatus.MISSED, null)
+
+            assertTrue(actual.editable)
+            assertEquals(0, actual.amountMl)
+            verify(waterStatisticAccessService).save(any())
+        } else {
+            assertThrows<NotificationHistoryEntryNotEditableException> {
+                service.updateEntry(EXTERNAL_USER_ID, ENTRY_ID, NotificationHistoryStatus.MISSED, null)
+            }
+
+            verify(waterStatisticAccessService, never()).save(any())
+        }
+        // The window is measured in the timezone carried by the entry itself, without a lookup of the settings:
+        // the last second of May 2nd in New York, for one, is already May 3rd in UTC.
+        verifyNoInteractions(notificationAccessService)
+    }
+
+    companion object {
+        private const val EXTERNAL_USER_ID = 1L
+        private const val ENTRY_ID = 42L
+        private val NOW = Instant.parse("2026-05-10T12:00:00Z")
+        private val DEFAULT_EVENT_TIME = LocalDateTime.of(2026, 5, 10, 8, 0, 0)
+
+        // Wide enough to cover every edit window case below; the access layer is stubbed, so it does not filter.
+        private val WINDOW_CASE_FROM = LocalDate.of(2026, 5, 1)
+        private val WINDOW_CASE_TO = LocalDate.of(2026, 5, 10)
+
+        // A persisted entry always arrives with its owner, so it carries the very timezone the settings hold.
+        private fun entry(
+            id: Long = ENTRY_ID,
+            eventTime: LocalDateTime = DEFAULT_EVENT_TIME,
+            eventType: AnswerNotificationType = AnswerNotificationType.YES,
+            waterAmountMl: Int = 250,
+            source: WaterEntrySourceType = WaterEntrySourceType.NOTIFICATION,
+            userTimeZone: String = "UTC",
+        ): WaterStatisticDto =
+            DtoGenerator.generateWaterStatisticDto(
+                id = id,
+                externalUserId = EXTERNAL_USER_ID,
+                eventTime = eventTime,
+                eventType = eventType,
+                waterAmountMl = waterAmountMl,
+                source = source,
+                userTimeZone = userTimeZone,
+            )
+
+        @JvmStatic
+        fun provideZoneBoundaryCases(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of(
+                    Named.of("UTC - no offset", "UTC"),
+                    LocalDate.of(2026, 5, 4),
+                    LocalDate.of(2026, 5, 10),
+                    LocalDateTime.of(2026, 5, 4, 0, 0),
+                    LocalDateTime.of(2026, 5, 11, 0, 0),
+                ),
+                Arguments.of(
+                    Named.of("Europe/Moscow - UTC+3, no DST", "Europe/Moscow"),
+                    LocalDate.of(2026, 5, 4),
+                    LocalDate.of(2026, 5, 10),
+                    LocalDateTime.of(2026, 5, 3, 21, 0),
+                    LocalDateTime.of(2026, 5, 10, 21, 0),
+                ),
+                Arguments.of(
+                    Named.of("Asia/Kolkata - UTC+5:30, fractional offset", "Asia/Kolkata"),
+                    LocalDate.of(2026, 5, 4),
+                    LocalDate.of(2026, 5, 10),
+                    LocalDateTime.of(2026, 5, 3, 18, 30),
+                    LocalDateTime.of(2026, 5, 10, 18, 30),
+                ),
+                Arguments.of(
+                    Named.of("America/New_York - DST spring-forward", "America/New_York"),
+                    LocalDate.of(2026, 3, 7),
+                    LocalDate.of(2026, 3, 9),
+                    LocalDateTime.of(2026, 3, 7, 5, 0),
+                    LocalDateTime.of(2026, 3, 10, 4, 0),
+                ),
+                Arguments.of(
+                    Named.of("America/New_York - DST fall-back", "America/New_York"),
+                    LocalDate.of(2026, 10, 31),
+                    LocalDate.of(2026, 11, 2),
+                    LocalDateTime.of(2026, 10, 31, 4, 0),
+                    LocalDateTime.of(2026, 11, 3, 5, 0),
+                ),
+            )
+
+        // With the clock fixed at 2026-05-10T12:00:00Z the local day is May 10th in every zone below,
+        // so the oldest editable local date is May 3rd and May 2nd is already locked.
+        // Event times are stored in UTC; the cases pair the last second of May 2nd with the first second
+        // of May 3rd of each zone, which is where the window flips.
+        @JvmStatic
+        fun provideEditWindowCases(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of(
+                    Named.of("UTC - last second of May 2nd", "UTC"),
+                    LocalDateTime.of(2026, 5, 2, 23, 59, 59),
+                    false,
+                ),
+                Arguments.of(
+                    Named.of("UTC - first second of May 3rd", "UTC"),
+                    LocalDateTime.of(2026, 5, 3, 0, 0, 0),
+                    true,
+                ),
+                Arguments.of(
+                    Named.of("UTC - last second of May 3rd", "UTC"),
+                    LocalDateTime.of(2026, 5, 3, 23, 59, 59),
+                    true,
+                ),
+                Arguments.of(
+                    Named.of("UTC - the current moment", "UTC"),
+                    LocalDateTime.of(2026, 5, 10, 12, 0, 0),
+                    true,
+                ),
+                Arguments.of(
+                    Named.of("Europe/Moscow - May 2nd 23:59:59 local", "Europe/Moscow"),
+                    LocalDateTime.of(2026, 5, 2, 20, 59, 59),
+                    false,
+                ),
+                Arguments.of(
+                    Named.of("Europe/Moscow - May 3rd 00:00 local, still May 2nd in UTC", "Europe/Moscow"),
+                    LocalDateTime.of(2026, 5, 2, 21, 0, 0),
+                    true,
+                ),
+                Arguments.of(
+                    Named.of("Asia/Kolkata - May 2nd 23:59:59 local, half-hour offset", "Asia/Kolkata"),
+                    LocalDateTime.of(2026, 5, 2, 18, 29, 59),
+                    false,
+                ),
+                Arguments.of(
+                    Named.of("Asia/Kolkata - May 3rd 00:00 local, half-hour offset", "Asia/Kolkata"),
+                    LocalDateTime.of(2026, 5, 2, 18, 30, 0),
+                    true,
+                ),
+                Arguments.of(
+                    Named.of("America/New_York - May 2nd 23:59:59 local, already May 3rd in UTC", "America/New_York"),
+                    LocalDateTime.of(2026, 5, 3, 3, 59, 59),
+                    false,
+                ),
+                Arguments.of(
+                    Named.of("America/New_York - May 3rd 00:00 local", "America/New_York"),
+                    LocalDateTime.of(2026, 5, 3, 4, 0, 0),
+                    true,
+                ),
+            )
+
+        // The first and the last second of May 2nd and of May 3rd, in UTC, per zone: two whole local days
+        // around the edge of the edit window.
+        @JvmStatic
+        fun provideLocalDayEdges(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of(
+                    Named.of("UTC - no offset", "UTC"),
+                    listOf(LocalDateTime.of(2026, 5, 2, 0, 0, 0), LocalDateTime.of(2026, 5, 2, 23, 59, 59)),
+                    listOf(LocalDateTime.of(2026, 5, 3, 0, 0, 0), LocalDateTime.of(2026, 5, 3, 23, 59, 59)),
+                ),
+                Arguments.of(
+                    Named.of("Europe/Moscow - UTC+3", "Europe/Moscow"),
+                    listOf(LocalDateTime.of(2026, 5, 1, 21, 0, 0), LocalDateTime.of(2026, 5, 2, 20, 59, 59)),
+                    listOf(LocalDateTime.of(2026, 5, 2, 21, 0, 0), LocalDateTime.of(2026, 5, 3, 20, 59, 59)),
+                ),
+                Arguments.of(
+                    Named.of("Asia/Kolkata - UTC+5:30, fractional offset", "Asia/Kolkata"),
+                    listOf(LocalDateTime.of(2026, 5, 1, 18, 30, 0), LocalDateTime.of(2026, 5, 2, 18, 29, 59)),
+                    listOf(LocalDateTime.of(2026, 5, 2, 18, 30, 0), LocalDateTime.of(2026, 5, 3, 18, 29, 59)),
+                ),
+            )
+
+        @JvmStatic
+        fun provideInvisibleEntries(): Stream<Named<WaterStatisticDto?>> =
+            Stream.of(
+                Named.of<WaterStatisticDto?>("no such entry, or it belongs to another user", null),
+                Named.of<WaterStatisticDto?>("manual entry", entry(source = WaterEntrySourceType.MANUAL)),
+                Named.of<WaterStatisticDto?>("snoozed entry", entry(eventType = AnswerNotificationType.SNOOZE)),
+            )
+    }
+}

--- a/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
@@ -2,6 +2,7 @@ package ru.illine.drinking.ponies.test.generator
 
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
+import ru.illine.drinking.ponies.model.base.NotificationHistoryStatus
 import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
 import ru.illine.drinking.ponies.model.dto.BestDayDto
 import ru.illine.drinking.ponies.model.dto.SettingDto
@@ -13,6 +14,7 @@ import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.model.dto.message.InsightStatsContext
 import ru.illine.drinking.ponies.model.dto.request.WaterEntryRequest
+import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryEvent
 import ru.illine.drinking.ponies.model.dto.response.PauseStateResponse
 import java.time.DayOfWeek
 import java.time.Instant
@@ -62,6 +64,7 @@ class DtoGenerator {
         }
 
         fun generateWaterStatisticDto(
+            id: Long? = null,
             externalUserId: Long = Random.nextLong(),
             eventTime: LocalDateTime = LocalDateTime.now(),
             eventType: AnswerNotificationType = AnswerNotificationType.YES,
@@ -75,6 +78,7 @@ class DtoGenerator {
                     userTimeZone = userTimeZone,
                 )
             return WaterStatisticDto(
+                id = id,
                 telegramUser = user,
                 eventTime = eventTime,
                 eventType = eventType,
@@ -185,6 +189,23 @@ class DtoGenerator {
                 currentStreakDays = currentStreakDays,
                 insightText = insightText,
                 firstEntryAt = firstEntryAt,
+            )
+
+        fun generateNotificationHistoryEvent(
+            id: Long = 1042L,
+            eventTime: Instant = Instant.parse("2026-05-10T09:30:00Z"),
+            status: NotificationHistoryStatus = NotificationHistoryStatus.CONFIRMED,
+            amountMl: Int = 300,
+            source: WaterEntrySourceType = WaterEntrySourceType.NOTIFICATION,
+            editable: Boolean = true,
+        ): NotificationHistoryEvent =
+            NotificationHistoryEvent(
+                id = id,
+                eventTime = eventTime,
+                status = status,
+                amountMl = amountMl,
+                source = source,
+                editable = editable,
             )
 
         fun generatePauseStateResponse(

--- a/src/test/resources/sql/access/WaterStatisticAccessService.sql
+++ b/src/test/resources/sql/access/WaterStatisticAccessService.sql
@@ -3,3 +3,7 @@ values (1, 'Europe/Moscow', now(), false);
 
 insert into telegram_users (external_user_id, user_time_zone, created, deleted)
 values (2, 'Europe/Moscow', now(), false);
+
+-- A timezone of its own, to tell the stored owner apart from the one a test DTO carries.
+insert into telegram_users (external_user_id, user_time_zone, created, deleted)
+values (3, 'Asia/Kolkata', now(), false);


### PR DESCRIPTION
## Summary
- `GET /notifications/history` returns the journal grouped by the user's civil days
- `PATCH /notifications/history/{id}` edits status and volume of a single entry
- no Liquibase migration and no scheduler change: the `CANCEL` row written when retries run out already means "missed"
- only NOTIFICATION-sourced `YES`/`CANCEL` rows reach the journal; snoozed and manual entries never surface
- the edit window spans whole calendar days of the user's timezone, so all entries of one day share the same `editable` flag
- 404 hides a foreign, manual or snoozed entry, 409 marks one outside the window; 403 is deliberately unused

## Test plan
- [x] `./gradlew build` green, 672 tests
- [x] mutation checks on the new guards
- [x] verified locally against the running bot
- [x] deployed to the test stand
