### PR TITLE
DPTB-226: admin api for listing and managing users

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/config/cache/CacheConfig.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/cache/CacheConfig.kt
@@ -15,10 +15,10 @@ class CacheConfig(
     private val cacheProperties: CacheProperties,
 ) {
     companion object {
-        const val USER_IS_ADMIN = "user-is-admin"
+        const val USER_ACCESS_FLAGS = "user-access-flags"
         const val WATER_FIRST_ENTRY = "water-first-entry"
 
-        private val ALL_CACHES = listOf(USER_IS_ADMIN, WATER_FIRST_ENTRY)
+        private val ALL_CACHES = listOf(USER_ACCESS_FLAGS, WATER_FIRST_ENTRY)
     }
 
     // Wraps the underlying Caffeine manager so cache mutations (@CacheEvict, @CachePut) inside a

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptor.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptor.kt
@@ -21,7 +21,9 @@ class AdminAuthInterceptor : HandlerInterceptor {
         handler: Any,
     ): Boolean {
         if (handler !is HandlerMethod) return true
-        handler.getMethodAnnotation(AdminOnly::class.java) ?: return true
+        handler.getMethodAnnotation(AdminOnly::class.java)
+            ?: handler.beanType.getAnnotation(AdminOnly::class.java)
+            ?: return true
 
         val telegramUser =
             request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptor.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptor.kt
@@ -9,6 +9,7 @@ import org.springframework.web.servlet.HandlerInterceptor
 import ru.illine.drinking.ponies.config.web.security.AuthErrorType
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
 import ru.illine.drinking.ponies.exception.InvalidAuthSignatureException
+import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfile
 import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
 import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
 
@@ -52,8 +53,21 @@ class TelegramAuthInterceptor(
 
         if (validSignature) {
             val telegramUser = telegramValidatorService.map(initData)
-            val isAdmin = telegramUserAccessService.findIsAdminByExternalUserId(telegramUser.externalUserId)
-            val enriched = telegramUser.copy(isAdmin = isAdmin)
+            val access =
+                telegramUserAccessService.resolveAccessFlags(
+                    telegramUser.externalUserId,
+                    TelegramUserProfile(
+                        firstName = telegramUser.firstName,
+                        lastName = telegramUser.lastName,
+                        username = telegramUser.username,
+                    ),
+                )
+            val enriched =
+                telegramUser.copy(
+                    isAdmin = access.isAdmin,
+                    isBanned = access.isBanned,
+                    isActive = !access.isDeleted,
+                )
             request.setAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE, enriched)
             return true
         }

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/security/AdminOnly.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/security/AdminOnly.kt
@@ -1,5 +1,7 @@
 package ru.illine.drinking.ponies.config.web.security
 
-@Target(AnnotationTarget.FUNCTION)
+// On a class it guards every handler of that controller, so a new admin endpoint cannot
+// be left open by forgetting the annotation. On a function it guards that handler alone.
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class AdminOnly

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/NotificationController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/NotificationController.kt
@@ -33,7 +33,7 @@ import java.time.LocalDate
 
 @RestController
 @RequestMapping("/notifications")
-@Tag(name = "Notifications", description = "Notification timing")
+@Tag(name = "Notifications", description = "Notification management")
 @Validated
 class NotificationController(
     private val notificationSettingsService: NotificationSettingsService,

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/UserAdminController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/UserAdminController.kt
@@ -1,0 +1,69 @@
+package ru.illine.drinking.ponies.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import ru.illine.drinking.ponies.config.web.security.AdminOnly
+import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
+import ru.illine.drinking.ponies.model.dto.request.UserStateRequest
+import ru.illine.drinking.ponies.model.dto.response.UserDetailsResponse
+import ru.illine.drinking.ponies.model.dto.response.UsersResponse
+import ru.illine.drinking.ponies.service.user.UserAdminService
+
+// Shares the /users path with UserController on purpose: same resource, different audience.
+// @AdminOnly sits on the class so a new endpoint here is closed by default.
+@RestController
+@RequestMapping("/users")
+@Validated
+@AdminOnly
+@Tag(name = "User administration", description = "Operations over other users' accounts")
+class UserAdminController(
+    private val userAdminService: UserAdminService,
+) {
+    @GetMapping
+    @Operation(summary = "List users, soft-deleted ones included")
+    fun getUsers(
+        @Parameter(description = "Free text over name, username and both ids", example = "alice")
+        @RequestParam(name = "search", required = false) search: String?,
+        @Parameter(description = "Status chip to filter by")
+        @RequestParam(name = "status", required = false, defaultValue = "ALL") status: AdminUserStatusFilter,
+        @Parameter(description = "Zero-based page number", example = "0")
+        @RequestParam(name = "page", required = false, defaultValue = "0")
+        @Min(0) page: Int,
+        @Parameter(description = "Page size", example = "20")
+        @RequestParam(name = "size", required = false, defaultValue = "20")
+        @Min(1)
+        @Max(MAX_PAGE_SIZE)
+        size: Int,
+    ): UsersResponse = userAdminService.getUsers(search, status, page, size)
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Get a single user card")
+    fun getUser(
+        @Parameter(description = "Internal user id", example = "1042")
+        @PathVariable(name = "id") id: Long,
+    ): UserDetailsResponse = userAdminService.getUser(id)
+
+    @PatchMapping("/{id}")
+    @Operation(summary = "Update user state: soft delete or restore")
+    fun updateUserState(
+        @Parameter(description = "Internal user id", example = "1042")
+        @PathVariable(name = "id") id: Long,
+        @Valid @RequestBody request: UserStateRequest,
+    ): UserDetailsResponse = userAdminService.updateState(id, request.isActive)
+
+    companion object {
+        private const val MAX_PAGE_SIZE = 100L
+    }
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/UserController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/UserController.kt
@@ -13,7 +13,7 @@ import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
 
 @RestController
 @RequestMapping("/users")
-@Tag(name = "User", description = "Current user identity and profile")
+@Tag(name = "User", description = "Current user identity")
 class UserController {
     @GetMapping("/me")
     @Operation(summary = "Get current user identity")
@@ -24,5 +24,7 @@ class UserController {
         MeResponse(
             externalUserId = telegramUser.externalUserId,
             isAdmin = telegramUser.isAdmin,
+            isBanned = telegramUser.isBanned,
+            isActive = telegramUser.isActive,
         )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessService.kt
@@ -1,5 +1,34 @@
 package ru.illine.drinking.ponies.dao.access
 
+import org.springframework.data.domain.Pageable
+import ru.illine.drinking.ponies.dao.repository.AdminUserProjection
+import ru.illine.drinking.ponies.dao.repository.UserCountsProjection
+import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
+import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfile
+import ru.illine.drinking.ponies.model.dto.internal.UserAccessDto
+
 interface TelegramUserAccessService {
-    fun findIsAdminByExternalUserId(externalUserId: Long): Boolean
+    fun resolveAccessFlags(
+        externalUserId: Long,
+        profile: TelegramUserProfile,
+    ): UserAccessDto
+
+    fun findAllForAdmin(
+        search: String?,
+        status: AdminUserStatusFilter,
+        pageable: Pageable,
+    ): List<AdminUserProjection>
+
+    fun findByIdForAdmin(id: Long): AdminUserProjection?
+
+    fun countForAdmin(search: String?): UserCountsProjection
+
+    fun updateDeleted(
+        id: Long,
+        externalUserId: Long,
+        deleted: Boolean,
+    )
+
+    // Returns true when the user was soft-deleted and has just been brought back.
+    fun restoreIfDeleted(externalUserId: Long): Boolean
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
@@ -34,7 +34,7 @@ class NotificationAccessServiceImpl(
         logger.debug("Finding all notification setting records")
 
         return settingRepository
-            .findAll()
+            .findAllWithUserAndChat()
             .map {
                 val user = TelegramUserMapper.toDto(it.telegramUser)
                 val chat = TelegramChatMapper.toDto(it.telegramChat, user)

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/TelegramUserAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/TelegramUserAccessServiceImpl.kt
@@ -1,12 +1,20 @@
 package ru.illine.drinking.ponies.dao.access.impl
 
 import org.slf4j.LoggerFactory
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import ru.illine.drinking.ponies.config.cache.CacheConfig
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
+import ru.illine.drinking.ponies.dao.repository.AdminUserProjection
 import ru.illine.drinking.ponies.dao.repository.TelegramUserRepository
+import ru.illine.drinking.ponies.dao.repository.UserCountsProjection
+import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
+import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfile
+import ru.illine.drinking.ponies.model.dto.internal.UserAccessDto
+import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 
 @Service
 class TelegramUserAccessServiceImpl(
@@ -14,13 +22,91 @@ class TelegramUserAccessServiceImpl(
 ) : TelegramUserAccessService {
     private val logger = LoggerFactory.getLogger("ACCESS-SERVICE")
 
-    // When admin promote/demote endpoints are added,
-    // annotate them with @CacheEvict(CacheConfig.USER_IS_ADMIN, key = "#externalUserId")
-    @Transactional(readOnly = true)
-    @Cacheable(CacheConfig.USER_IS_ADMIN, key = "#externalUserId")
-    override fun findIsAdminByExternalUserId(externalUserId: Long): Boolean {
-        logger.debug("Resolving isAdmin for externalUserId={}", externalUserId)
+    // Whatever changes these flags has to evict this cache by externalUserId,
+    // otherwise the change only takes effect once the entry expires - see updateDeleted below.
+    @Transactional
+    @Cacheable(CacheConfig.USER_ACCESS_FLAGS, key = "#externalUserId")
+    override fun resolveAccessFlags(
+        externalUserId: Long,
+        profile: TelegramUserProfile,
+    ): UserAccessDto {
+        logger.debug("Resolving access flags for externalUserId={}", externalUserId)
 
-        return telegramUserRepository.findByExternalUserId(externalUserId)?.isAdmin ?: false
+        val user =
+            telegramUserRepository.findByExternalUserIdIncludingDeleted(externalUserId) ?: return UserAccessDto()
+        refreshProfile(user, profile)
+
+        return UserAccessDto(isAdmin = user.isAdmin, isBanned = user.isBanned, isDeleted = user.deleted)
     }
+
+    @Transactional(readOnly = true)
+    override fun findAllForAdmin(
+        search: String?,
+        status: AdminUserStatusFilter,
+        pageable: Pageable,
+    ): List<AdminUserProjection> {
+        logger.debug("Listing users for admin: search={}, status={}, page={}", search, status, pageable.pageNumber)
+
+        return telegramUserRepository.findAllForAdmin(search, status.deleted, status.banned, pageable)
+    }
+
+    @Transactional(readOnly = true)
+    override fun findByIdForAdmin(id: Long): AdminUserProjection? {
+        logger.debug("Loading user [{}] for admin", id)
+
+        return telegramUserRepository.findByIdForAdmin(id)
+    }
+
+    @Transactional(readOnly = true)
+    override fun countForAdmin(search: String?): UserCountsProjection {
+        logger.debug("Counting users for admin: search={}", search)
+
+        return telegramUserRepository.countForAdmin(search)
+    }
+
+    @Transactional
+    @CacheEvict(CacheConfig.USER_ACCESS_FLAGS, key = "#externalUserId")
+    override fun updateDeleted(
+        id: Long,
+        externalUserId: Long,
+        deleted: Boolean,
+    ) {
+        logger.debug("Setting deleted={} for user [{}]", deleted, id)
+
+        telegramUserRepository.updateDeleted(id, deleted)
+    }
+
+    @Transactional
+    @CacheEvict(CacheConfig.USER_ACCESS_FLAGS, key = "#externalUserId")
+    override fun restoreIfDeleted(externalUserId: Long): Boolean {
+        val restored = telegramUserRepository.restoreByExternalUserId(externalUserId) > 0
+        if (restored) {
+            logger.info("Restoring soft deleted user [{}]", externalUserId)
+        }
+
+        return restored
+    }
+
+    // Called on a cache miss only, so the profile is refreshed at most once per cache TTL
+    // instead of on every request. Dirty checking flushes the change on commit.
+    private fun refreshProfile(
+        user: TelegramUserEntity,
+        profile: TelegramUserProfile,
+    ) {
+        // Telegram always sends firstName for a real user; an empty profile means the caller has
+        // nothing to offer, and overwriting the stored one with nulls would lose data.
+        if (profile.firstName == null) return
+
+        if (user.matches(profile)) return
+
+        logger.debug("Refreshing profile for externalUserId={}", user.externalUserId)
+        user.firstName = profile.firstName
+        user.lastName = profile.lastName
+        user.username = profile.username
+    }
+
+    private fun TelegramUserEntity.matches(profile: TelegramUserProfile): Boolean =
+        firstName == profile.firstName &&
+            lastName == profile.lastName &&
+            username == profile.username
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/AdminUserProjections.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/AdminUserProjections.kt
@@ -1,0 +1,26 @@
+package ru.illine.drinking.ponies.dao.repository
+
+import java.time.LocalDateTime
+
+// Property names must match the aliases of the native query - hence admin/banned
+// instead of isAdmin/isBanned, an "is" prefix would rename the getter.
+interface AdminUserProjection {
+    val id: Long
+    val externalUserId: Long
+    val firstName: String?
+    val lastName: String?
+    val username: String?
+    val admin: Boolean
+    val banned: Boolean
+    val deleted: Boolean
+    val timeZone: String
+    val created: LocalDateTime
+    val lastActivity: LocalDateTime?
+}
+
+interface UserCountsProjection {
+    val all: Long
+    val active: Long
+    val inactive: Long
+    val banned: Long
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/NotificationSettingRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/NotificationSettingRepository.kt
@@ -14,9 +14,21 @@ interface NotificationSettingRepository : JpaRepository<NotificationSettingEntit
     @Suppress("ktlint:standard:function-naming")
     fun findByTelegramUser_ExternalUserId(externalUserId: Long): NotificationSettingEntity?
 
+    // The join is what keeps a soft-deleted user out of the mailing: @SQLRestriction(deleted = false)
+    // applies to the joined entity, so their settings drop out of the result entirely. Reading the
+    // association lazily instead would blow up on the hidden row and take the whole batch down.
     @Query(
         value = """
-            select ns.enabled 
+            select ns from NotificationSettingEntity ns
+            join fetch ns.telegramUser
+            join fetch ns.telegramChat
+        """,
+    )
+    fun findAllWithUserAndChat(): List<NotificationSettingEntity>
+
+    @Query(
+        value = """
+            select ns.enabled
             from notification_settings ns
             inner join telegram_users u on ns.telegram_user_id = u.id
             where u.external_user_id = :externalUserId

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/TelegramUserRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/TelegramUserRepository.kt
@@ -1,7 +1,51 @@
 package ru.illine.drinking.ponies.dao.repository
 
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
+
+// The admin queries below are native on purpose: @SQLRestriction(deleted = false) hides soft-deleted
+// users from every JPQL query, and the admin list is the one place that has to see them.
+private const val ADMIN_USER_SELECT = """
+    select u.id               as "id",
+           u.external_user_id as "externalUserId",
+           u.first_name       as "firstName",
+           u.last_name        as "lastName",
+           u.username         as "username",
+           u.is_admin         as "admin",
+           u.is_banned        as "banned",
+           u.deleted          as "deleted",
+           u.user_time_zone   as "timeZone",
+           u.created          as "created",
+           (
+               select max(ws.event_time)
+               from water_statistics ws
+               where ws.user_id = u.id
+                 and ws.event_type in ('YES', 'SNOOZE')
+           )                  as "lastActivity"
+    from telegram_users u
+"""
+
+// The caller passes the pattern already wrapped in wildcards and escaped, or null for "no search".
+// Casts keep Postgres from complaining that it cannot infer the type of a null parameter.
+private const val SEARCH_FILTER = """
+    (
+        cast(:search as text) is null
+        or concat_ws(' ', u.first_name, u.last_name, u.username, u.external_user_id, u.id)
+               ilike cast(:search as text) escape '\'
+    )
+"""
+
+// Nulls come from AdminUserStatusFilter and mean "this column is not constrained".
+private const val STATUS_FILTER = """
+    (
+        (cast(:deleted as boolean) is null or u.deleted = cast(:deleted as boolean))
+        and (cast(:banned as boolean) is null or u.is_banned = cast(:banned as boolean))
+    )
+"""
 
 interface TelegramUserRepository : JpaRepository<TelegramUserEntity, Long> {
     fun findByExternalUserId(externalUserId: Long): TelegramUserEntity?
@@ -9,4 +53,72 @@ interface TelegramUserRepository : JpaRepository<TelegramUserEntity, Long> {
     fun findAllByExternalUserIdIn(externalUserId: Collection<Long>): Set<TelegramUserEntity>
 
     fun existsByExternalUserId(externalUserId: Long): Boolean
+
+    // Native, so that @SQLRestriction does not hide a soft-deleted user from the auth path:
+    // the entity still comes back managed, so profile refresh keeps working through dirty checking.
+    @Query(value = "select * from telegram_users u where u.external_user_id = :externalUserId", nativeQuery = true)
+    fun findByExternalUserIdIncludingDeleted(
+        @Param("externalUserId") externalUserId: Long,
+    ): TelegramUserEntity?
+
+    // No countQuery: the total for any status is already one of the columns of countForAdmin.
+    @Query(
+        value = """
+            $ADMIN_USER_SELECT
+            where $SEARCH_FILTER
+              and $STATUS_FILTER
+            order by "lastActivity" desc nulls last, u.id
+        """,
+        nativeQuery = true,
+    )
+    fun findAllForAdmin(
+        @Param("search") search: String?,
+        @Param("deleted") deleted: Boolean?,
+        @Param("banned") banned: Boolean?,
+        pageable: Pageable,
+    ): List<AdminUserProjection>
+
+    @Query(value = """$ADMIN_USER_SELECT where u.id = :id""", nativeQuery = true)
+    fun findByIdForAdmin(
+        @Param("id") id: Long,
+    ): AdminUserProjection?
+
+    @Query(
+        value = """
+            select count(*)                                                          as "all",
+                   count(*) filter (where u.deleted = false and u.is_banned = false) as "active",
+                   count(*) filter (where u.deleted = true and u.is_banned = false)  as "inactive",
+                   count(*) filter (where u.is_banned = true)                        as "banned"
+            from telegram_users u
+            where $SEARCH_FILTER
+        """,
+        nativeQuery = true,
+    )
+    fun countForAdmin(
+        @Param("search") search: String?,
+    ): UserCountsProjection
+
+    @Modifying(clearAutomatically = true)
+    @Query(value = "update telegram_users set deleted = :deleted where id = :id", nativeQuery = true)
+    fun updateDeleted(
+        @Param("id") id: Long,
+        @Param("deleted") deleted: Boolean,
+    )
+
+    // Native for the same reason: a soft-deleted user is invisible to derived queries, so /start
+    // would take them for a newcomer and hit the unique index on external_user_id.
+    // Returns 0 when there was nothing to restore.
+    @Modifying(clearAutomatically = true)
+    @Query(
+        value = """
+            update telegram_users
+            set deleted = false
+            where external_user_id = :externalUserId
+              and deleted = true
+        """,
+        nativeQuery = true,
+    )
+    fun restoreByExternalUserId(
+        @Param("externalUserId") externalUserId: Long,
+    ): Int
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/exception/TelegramUserNotFoundException.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/exception/TelegramUserNotFoundException.kt
@@ -1,0 +1,5 @@
+package ru.illine.drinking.ponies.exception
+
+class TelegramUserNotFoundException(
+    message: String,
+) : NotFoundException("user not found", message)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/base/AdminUserStatusFilter.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/base/AdminUserStatusFilter.kt
@@ -1,0 +1,14 @@
+package ru.illine.drinking.ponies.model.base
+
+// Categories are mutually exclusive, so the counters add up to ALL: a ban wins over everything
+// else, so a user who is both banned and deleted counts as BANNED only.
+// Null means the column is not constrained.
+enum class AdminUserStatusFilter(
+    val deleted: Boolean?,
+    val banned: Boolean?,
+) {
+    ALL(null, null),
+    ACTIVE(false, false),
+    INACTIVE(true, false),
+    BANNED(null, true),
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/TelegramUserDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/TelegramUserDto.kt
@@ -20,8 +20,12 @@ data class TelegramUserDto(
     val isPremium: Boolean = false,
     @JsonProperty("allows_write_to_pm")
     val allowsWriteToPm: Boolean = false,
-    // Internal-only flag enriched by TelegramAuthInterceptor from DB.
+    // Internal-only flags enriched by TelegramAuthInterceptor from DB.
     // Never accept from incoming JSON (initData) and never expose in API responses.
     @JsonIgnore
     val isAdmin: Boolean = false,
+    @JsonIgnore
+    val isBanned: Boolean = false,
+    @JsonIgnore
+    val isActive: Boolean = false,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/TelegramUserDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/TelegramUserDto.kt
@@ -1,20 +1,31 @@
 package ru.illine.drinking.ponies.model.dto.internal
 
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 data class TelegramUserDto(
     var id: Long? = null,
     var externalUserId: Long,
     var userTimeZone: String,
     var isAdmin: Boolean = false,
-    var created: LocalDateTime = LocalDateTime.now(),
+    var isBanned: Boolean = false,
+    var firstName: String? = null,
+    var lastName: String? = null,
+    var username: String? = null,
+    var created: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC),
     var deleted: Boolean = false,
 ) {
     companion object {
-        fun create(externalUserId: Long): TelegramUserDto =
+        fun create(
+            externalUserId: Long,
+            profile: TelegramUserProfile = TelegramUserProfile(),
+        ): TelegramUserDto =
             TelegramUserDto(
                 externalUserId = externalUserId,
                 userTimeZone = "Europe/Moscow",
+                firstName = profile.firstName,
+                lastName = profile.lastName,
+                username = profile.username,
             )
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/TelegramUserProfile.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/TelegramUserProfile.kt
@@ -1,0 +1,7 @@
+package ru.illine.drinking.ponies.model.dto.internal
+
+data class TelegramUserProfile(
+    val firstName: String? = null,
+    val lastName: String? = null,
+    val username: String? = null,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserAccessDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserAccessDto.kt
@@ -1,0 +1,9 @@
+package ru.illine.drinking.ponies.model.dto.internal
+
+// isDeleted is admin-facing state, not a gate: nothing denies access by it. A soft deleted user
+// keeps working and is brought back by /start; blocking belongs to the ban feature.
+data class UserAccessDto(
+    val isAdmin: Boolean = false,
+    val isBanned: Boolean = false,
+    val isDeleted: Boolean = false,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/UserStateRequest.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/UserStateRequest.kt
@@ -1,0 +1,17 @@
+package ru.illine.drinking.ponies.model.dto.request
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.swagger.v3.oas.annotations.media.Schema
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "User state update payload, one toggle of the admin card per field")
+data class UserStateRequest(
+    // Null means "leave as is" - ban and admin toggles will join as sibling fields.
+    @Schema(
+        description = "False soft deletes the user, true restores them",
+        example = "false",
+        nullable = true,
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val isActive: Boolean?,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/MeResponse.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/MeResponse.kt
@@ -5,11 +5,18 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "Current user identity")
 data class MeResponse(
-    // Kotlin field unified to externalUserId across the codebase (DPTB-140).
+    // Kotlin field unified to externalUserId across the codebase.
     // The JSON key is intentionally kept as "telegramUserId" - it is the public /users/me contract consumed by the MiniApp.
     @JsonProperty("telegramUserId")
     @Schema(description = "Telegram user id", example = "123456789")
     val externalUserId: Long,
     @Schema(description = "Whether the user has admin privileges", example = "false")
     val isAdmin: Boolean,
+    @Schema(description = "Whether the user has been banned", example = "false")
+    val isBanned: Boolean,
+    @Schema(
+        description = "Whether the account is active; false means it was deleted and a /start brings it back",
+        example = "true",
+    )
+    val isActive: Boolean,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/ShortUserInfo.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/ShortUserInfo.kt
@@ -1,0 +1,33 @@
+package ru.illine.drinking.ponies.model.dto.response
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
+
+@Schema(description = "User as shown in the admin user list")
+data class ShortUserInfo(
+    @Schema(description = "Internal identifier, the one admin endpoints operate on", example = "1042")
+    val id: Long,
+    // Kotlin field is externalUserId across the codebase, the JSON key stays
+    // telegramUserId to match the contract the MiniApp already consumes.
+    @JsonProperty("telegramUserId")
+    @Schema(description = "Telegram user id", example = "482719301")
+    val externalUserId: Long,
+    @Schema(description = "Telegram first name", example = "Алиса")
+    val firstName: String?,
+    @Schema(description = "Telegram last name, null if not set", example = "Петрова")
+    val lastName: String?,
+    @Schema(description = "Telegram username without the leading @, null if not set", example = "alice")
+    val username: String?,
+    @Schema(description = "Whether the user has admin privileges", example = "false")
+    val isAdmin: Boolean,
+    @Schema(description = "Whether the user has been banned", example = "false")
+    val isBanned: Boolean,
+    @Schema(description = "Whether the user has not been deleted", example = "true")
+    val isActive: Boolean,
+    @Schema(
+        description = "Time of the last water intake or snooze, null if the user has never answered",
+        example = "2026-08-07T21:14:03Z",
+    )
+    val lastActivity: Instant?,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/UserCounts.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/UserCounts.kt
@@ -1,0 +1,19 @@
+package ru.illine.drinking.ponies.model.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description =
+        "How many users fall into each status, counted over the whole search result and " +
+            "regardless of the requested status - the admin page shows all counters at once",
+)
+data class UserCounts(
+    @Schema(description = "Every user, deleted and banned included", example = "11")
+    val all: Long,
+    @Schema(description = "Neither deleted nor banned", example = "8")
+    val active: Long,
+    @Schema(description = "Deleted", example = "1")
+    val inactive: Long,
+    @Schema(description = "Banned", example = "2")
+    val banned: Long,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/UserDetailsResponse.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/UserDetailsResponse.kt
@@ -1,0 +1,35 @@
+package ru.illine.drinking.ponies.model.dto.response
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
+
+@Schema(description = "Full user card for the admin page")
+data class UserDetailsResponse(
+    @Schema(description = "Internal identifier, the one admin endpoints operate on", example = "1042")
+    val id: Long,
+    @JsonProperty("telegramUserId")
+    @Schema(description = "Telegram user id", example = "482719301")
+    val externalUserId: Long,
+    @Schema(description = "Telegram first name", example = "Алиса")
+    val firstName: String?,
+    @Schema(description = "Telegram last name, null if not set", example = "Петрова")
+    val lastName: String?,
+    @Schema(description = "Telegram username without the leading @, null if not set", example = "alice")
+    val username: String?,
+    @Schema(description = "Whether the user has admin privileges", example = "false")
+    val isAdmin: Boolean,
+    @Schema(description = "Whether the user has been banned", example = "false")
+    val isBanned: Boolean,
+    @Schema(description = "Whether the user has not been deleted", example = "true")
+    val isActive: Boolean,
+    @Schema(
+        description = "Time of the last water intake or snooze, null if the user has never answered",
+        example = "2026-08-07T21:14:03Z",
+    )
+    val lastActivity: Instant?,
+    @Schema(description = "Timezone the user receives notifications in", example = "Europe/Moscow")
+    val timeZone: String,
+    @Schema(description = "Time the user was registered", example = "2026-05-10T01:22:00Z")
+    val registeredAt: Instant,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/UsersResponse.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/UsersResponse.kt
@@ -1,0 +1,17 @@
+package ru.illine.drinking.ponies.model.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "A page of users for the admin page")
+data class UsersResponse(
+    @Schema(description = "Users of the requested page, most recently active first")
+    val users: List<ShortUserInfo>,
+    @Schema(description = "Zero-based page number", example = "0")
+    val page: Int,
+    @Schema(description = "Page size", example = "20")
+    val size: Int,
+    @Schema(description = "How many users match the request, all pages included", example = "8")
+    val total: Long,
+    @Schema(description = "Counters for the status chips")
+    val counts: UserCounts,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/entity/TelegramUserEntity.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/entity/TelegramUserEntity.kt
@@ -17,6 +17,7 @@ import jakarta.persistence.Table
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @Entity
 @Table(
@@ -46,9 +47,17 @@ class TelegramUserEntity(
     var userTimeZone: String,
     @Column(name = "is_admin", nullable = false)
     var isAdmin: Boolean = false,
+    @Column(name = "is_banned", nullable = false)
+    var isBanned: Boolean = false,
+    @Column(name = "first_name")
+    var firstName: String? = null,
+    @Column(name = "last_name")
+    var lastName: String? = null,
+    @Column(name = "username")
+    var username: String? = null,
     @Column(name = "created", nullable = false, updatable = false)
     @JsonIgnore
-    var created: LocalDateTime = LocalDateTime.now(),
+    var created: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC),
     @Column(name = "deleted", nullable = false)
     var deleted: Boolean = false,
     @OneToMany(

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
@@ -6,9 +6,11 @@ import org.telegram.telegrambots.abilitybots.api.objects.MessageContext
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfile
 import ru.illine.drinking.ponies.model.dto.message.DefaultSettingsContext
 import ru.illine.drinking.ponies.model.dto.message.GreetingContext
 import ru.illine.drinking.ponies.service.message.MessageProvider
@@ -20,6 +22,7 @@ import ru.illine.drinking.ponies.util.message.MessageSpec
 class NotificationServiceImpl(
     private val sender: TelegramClient,
     private val notificationAccessService: NotificationAccessService,
+    private val telegramUserAccessService: TelegramUserAccessService,
     private val messageProvider: MessageProvider,
 ) : NotificationService {
     private val logger = LoggerFactory.getLogger("SERVICE")
@@ -32,6 +35,11 @@ class NotificationServiceImpl(
 
         val externalUserId = messageContext.user().id
         val chatId = messageContext.chatId()
+        val profile = with(messageContext.user()) { TelegramUserProfile(firstName, lastName, userName) }
+
+        // An admin may have soft deleted this user: derived queries do not see such a row, so
+        // without bringing it back /start would treat them as new and hit the unique index.
+        telegramUserAccessService.restoreIfDeleted(externalUserId)
 
         val setting =
             notificationAccessService.existsByExternalUserId(externalUserId).check(
@@ -39,7 +47,7 @@ class NotificationServiceImpl(
                     notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
                 },
                 ifFalse = {
-                    createNewUser(externalUserId, chatId)
+                    createNewUser(externalUserId, chatId, profile)
                 },
             )
 
@@ -56,8 +64,9 @@ class NotificationServiceImpl(
     private fun createNewUser(
         externalUserId: Long,
         chatId: Long,
+        profile: TelegramUserProfile,
     ): NotificationSettingDto {
-        val user = TelegramUserDto.create(externalUserId)
+        val user = TelegramUserDto.create(externalUserId, profile)
         val chat = TelegramChatDto.create(chatId, user)
         val setting = NotificationSettingDto.create(user, chat)
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/user/UserAdminService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/user/UserAdminService.kt
@@ -1,0 +1,21 @@
+package ru.illine.drinking.ponies.service.user
+
+import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
+import ru.illine.drinking.ponies.model.dto.response.UserDetailsResponse
+import ru.illine.drinking.ponies.model.dto.response.UsersResponse
+
+interface UserAdminService {
+    fun getUsers(
+        search: String?,
+        status: AdminUserStatusFilter,
+        page: Int,
+        size: Int,
+    ): UsersResponse
+
+    fun getUser(id: Long): UserDetailsResponse
+
+    fun updateState(
+        id: Long,
+        isActive: Boolean?,
+    ): UserDetailsResponse
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/user/impl/UserAdminServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/user/impl/UserAdminServiceImpl.kt
@@ -1,0 +1,113 @@
+package ru.illine.drinking.ponies.service.user.impl
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.jpa.repository.query.EscapeCharacter
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
+import ru.illine.drinking.ponies.dao.repository.AdminUserProjection
+import ru.illine.drinking.ponies.exception.TelegramUserNotFoundException
+import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
+import ru.illine.drinking.ponies.model.dto.response.ShortUserInfo
+import ru.illine.drinking.ponies.model.dto.response.UserCounts
+import ru.illine.drinking.ponies.model.dto.response.UserDetailsResponse
+import ru.illine.drinking.ponies.model.dto.response.UsersResponse
+import ru.illine.drinking.ponies.service.user.UserAdminService
+import ru.illine.drinking.ponies.util.statistics.toUtcInstant
+
+@Service
+class UserAdminServiceImpl(
+    private val telegramUserAccessService: TelegramUserAccessService,
+) : UserAdminService {
+    private val logger = LoggerFactory.getLogger("SERVICE")
+
+    override fun getUsers(
+        search: String?,
+        status: AdminUserStatusFilter,
+        page: Int,
+        size: Int,
+    ): UsersResponse {
+        val query = search?.takeIf { it.isNotBlank() }?.toSearchPattern()
+        val users = telegramUserAccessService.findAllForAdmin(query, status, PageRequest.of(page, size))
+
+        // Counted without the status filter on purpose: the admin page shows every chip at once.
+        // The total of the requested status is one of those counters, so no extra count query.
+        val counts =
+            telegramUserAccessService.countForAdmin(query).let {
+                UserCounts(it.all, it.active, it.inactive, it.banned)
+            }
+
+        return UsersResponse(
+            users = users.map { it.toShortUserInfo() },
+            page = page,
+            size = size,
+            total = counts.of(status),
+            counts = counts,
+        )
+    }
+
+    override fun getUser(id: Long): UserDetailsResponse = requireUser(id).toDetails()
+
+    @Transactional
+    override fun updateState(
+        id: Long,
+        isActive: Boolean?,
+    ): UserDetailsResponse {
+        require(isActive != null) { "At least one state field is required, got an empty payload" }
+
+        val user = requireUser(id)
+
+        logger.info("Setting isActive={} for user [{}]", isActive, id)
+        telegramUserAccessService.updateDeleted(id, user.externalUserId, deleted = !isActive)
+
+        return user.toDetails(isActive)
+    }
+
+    // Telegram usernames legitimately contain "_", which LIKE reads as "any character" - without
+    // escaping, a search for alice_p would also match aliceXp. EscapeCharacter.DEFAULT escapes with
+    // a backslash, which is what the query declares in its "escape" clause.
+    private fun String.toSearchPattern(): String = "%${EscapeCharacter.DEFAULT.escape(this)}%"
+
+    private fun requireUser(id: Long): AdminUserProjection =
+        telegramUserAccessService.findByIdForAdmin(id)
+            ?: throw TelegramUserNotFoundException("No user with id: [$id]")
+
+    private fun UserCounts.of(status: AdminUserStatusFilter): Long =
+        when (status) {
+            AdminUserStatusFilter.ALL -> all
+            AdminUserStatusFilter.ACTIVE -> active
+            AdminUserStatusFilter.INACTIVE -> inactive
+            AdminUserStatusFilter.BANNED -> banned
+        }
+
+    private fun AdminUserProjection.toShortUserInfo(): ShortUserInfo =
+        ShortUserInfo(
+            id = id,
+            externalUserId = externalUserId,
+            firstName = firstName,
+            lastName = lastName,
+            username = username,
+            isAdmin = admin,
+            isBanned = banned,
+            isActive = !deleted,
+            lastActivity = lastActivity?.toUtcInstant(),
+        )
+
+    // isActive is passed in when the caller has just changed it, so the freshly written value
+    // is returned without reading the row again.
+    private fun AdminUserProjection.toDetails(isActive: Boolean = !deleted): UserDetailsResponse =
+        UserDetailsResponse(
+            id = id,
+            externalUserId = externalUserId,
+            firstName = firstName,
+            lastName = lastName,
+            username = username,
+            isAdmin = admin,
+            isBanned = banned,
+            isActive = isActive,
+            lastActivity = lastActivity?.toUtcInstant(),
+            timeZone = timeZone,
+            registeredAt = created.toUtcInstant(),
+        )
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -88,7 +88,7 @@ cache:
     maximum-size: ${CACHE_DEFAULT_MAXIMUM_SIZE:100}
   # Per-cache overrides (optional). Example:
   # overrides:
-  #   user-is-admin:
+  #   user-access-flags:
   #     ttl: 10m
 
 springdoc:

--- a/src/main/resources/liquibase/8.8.0/changes.yaml
+++ b/src/main/resources/liquibase/8.8.0/changes.yaml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+  - changeSet:
+      id: 8.8.0
+      author: illine
+      comment: Release 8.8.0
+      changes:
+        - tagDatabase:
+            tag: 8.8.0
+
+  # DDL
+  - include:
+      file: ddl/01_telegram_users_add_is_banned.sql
+      relativeToChangelogFile: true
+  - include:
+      file: ddl/02_telegram_users_add_profile.sql
+      relativeToChangelogFile: true
+  - include:
+      file: ddl/03_telegram_users_created_without_time_zone.sql
+      relativeToChangelogFile: true

--- a/src/main/resources/liquibase/8.8.0/ddl/01_telegram_users_add_is_banned.sql
+++ b/src/main/resources/liquibase/8.8.0/ddl/01_telegram_users_add_is_banned.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+
+--changeset illine:8.8.0/ddl/telegram_users_add_is_banned
+--rollback alter table telegram_users drop column is_banned;
+
+alter table telegram_users
+    add column is_banned boolean not null default false;
+
+comment on column telegram_users.is_banned is 'Whether the user has been banned; bootstrapped manually via SQL after deploy';

--- a/src/main/resources/liquibase/8.8.0/ddl/02_telegram_users_add_profile.sql
+++ b/src/main/resources/liquibase/8.8.0/ddl/02_telegram_users_add_profile.sql
@@ -1,0 +1,20 @@
+--liquibase formatted sql
+
+--changeset illine:8.8.0/ddl/telegram_users_add_profile
+/* liquibase rollback
+ alter table telegram_users drop column first_name;
+ alter table telegram_users drop column last_name;
+ alter table telegram_users drop column username;
+ alter table telegram_users drop column avatar_url;
+*/
+
+alter table telegram_users
+    add column first_name text null,
+    add column last_name  text null,
+    add column username   text null,
+    add column avatar_url  text null;
+
+comment on column telegram_users.first_name is 'Telegram first name, refreshed on user activity';
+comment on column telegram_users.last_name is 'Telegram last name, refreshed on user activity; null if not set';
+comment on column telegram_users.username is 'Telegram @username without the leading @, refreshed on user activity; null if not set';
+comment on column telegram_users.avatar_url is 'Avatar URL taken from MiniApp initData; null for users who never opened the MiniApp';

--- a/src/main/resources/liquibase/8.8.0/ddl/03_telegram_users_created_without_time_zone.sql
+++ b/src/main/resources/liquibase/8.8.0/ddl/03_telegram_users_created_without_time_zone.sql
@@ -1,0 +1,14 @@
+--liquibase formatted sql
+
+--changeset illine:8.8.0/ddl/telegram_users_created_without_time_zone
+/* liquibase rollback
+ alter table telegram_users
+     alter column created type timestamp(0) with time zone using created at time zone 'UTC',
+     alter column created set default now();
+*/
+
+alter table telegram_users
+    alter column created type timestamp(0) using created at time zone 'UTC',
+    alter column created set default (now() at time zone 'UTC');
+
+comment on column telegram_users.created is 'Time when the record was created, stored in UTC';

--- a/src/main/resources/liquibase/changelog.yaml
+++ b/src/main/resources/liquibase/changelog.yaml
@@ -31,3 +31,6 @@ databaseChangeLog:
   - include:
       file: 8.3.0/changes.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 8.8.0/changes.yaml
+      relativeToChangelogFile: true

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/cache/CacheConfigTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/cache/CacheConfigTest.kt
@@ -26,9 +26,9 @@ class CacheConfigTest {
 
         val manager = CacheConfig(properties).cacheManager()
 
-        assertTrue(manager.cacheNames.contains(CacheConfig.USER_IS_ADMIN))
+        assertTrue(manager.cacheNames.contains(CacheConfig.USER_ACCESS_FLAGS))
         assertTrue(manager.cacheNames.contains(CacheConfig.WATER_FIRST_ENTRY))
-        assertNotNull(manager.getCache(CacheConfig.USER_IS_ADMIN))
+        assertNotNull(manager.getCache(CacheConfig.USER_ACCESS_FLAGS))
         assertNotNull(manager.getCache(CacheConfig.WATER_FIRST_ENTRY))
         assertEquals(2, manager.cacheNames.size)
     }
@@ -60,7 +60,7 @@ class CacheConfigTest {
                 default = CacheEntry(ttl = Duration.ofMinutes(7), maximumSize = 50),
                 overrides =
                     mapOf(
-                        CacheConfig.USER_IS_ADMIN to
+                        CacheConfig.USER_ACCESS_FLAGS to
                             CacheEntryOverride(
                                 ttl = Duration.ofMinutes(15),
                                 maximumSize = 200,
@@ -70,7 +70,7 @@ class CacheConfigTest {
 
         val manager = CacheConfig(properties).cacheManager()
 
-        assertNotNull(manager.getCache(CacheConfig.USER_IS_ADMIN))
+        assertNotNull(manager.getCache(CacheConfig.USER_ACCESS_FLAGS))
         assertNotNull(manager.getCache(CacheConfig.WATER_FIRST_ENTRY))
         assertEquals(2, manager.cacheNames.size)
     }
@@ -83,7 +83,7 @@ class CacheConfigTest {
                 default = CacheEntry(ttl = Duration.ofMinutes(7), maximumSize = 50),
                 overrides =
                     mapOf(
-                        CacheConfig.USER_IS_ADMIN to
+                        CacheConfig.USER_ACCESS_FLAGS to
                             CacheEntryOverride(
                                 ttl = null,
                                 maximumSize = null,
@@ -93,7 +93,7 @@ class CacheConfigTest {
 
         val manager = CacheConfig(properties).cacheManager()
 
-        assertNotNull(manager.getCache(CacheConfig.USER_IS_ADMIN))
+        assertNotNull(manager.getCache(CacheConfig.USER_ACCESS_FLAGS))
         assertNotNull(manager.getCache(CacheConfig.WATER_FIRST_ENTRY))
         assertEquals(2, manager.cacheNames.size)
     }

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorIntegrationTest.kt
@@ -64,7 +64,7 @@ class AdminAuthInterceptorIntegrationTest
 
         @BeforeEach
         fun setUp() {
-            cacheManager.getCache(CacheConfig.USER_IS_ADMIN)?.clear()
+            cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)?.clear()
             whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
             whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
         }

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -64,14 +65,46 @@ class AdminAuthInterceptorTest {
     }
 
     @Test
-    @DisplayName("preHandle(): handler without @AdminOnly - returns true")
+    @DisplayName("preHandle(): handler with @AdminOnly neither on the method nor on the class - returns true")
     fun `handler without AdminOnly returns true`() {
         whenever(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(null)
+        doReturn(OpenController::class.java).whenever(handlerMethod).beanType
 
         val result = interceptor.preHandle(request, response, handlerMethod)
 
         assertTrue(result)
         verifyNoInteractions(response)
+    }
+
+    @Test
+    @DisplayName("preHandle(): @AdminOnly on the controller class + admin user - returns true")
+    fun `class level AdminOnly lets an admin through`() {
+        whenever(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(null)
+        doReturn(GuardedController::class.java).whenever(handlerMethod).beanType
+        whenever(request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)).thenReturn(adminUser)
+
+        val result = interceptor.preHandle(request, response, handlerMethod)
+
+        assertTrue(result)
+        verifyNoInteractions(response)
+    }
+
+    @Test
+    @DisplayName(
+        "preHandle(): @AdminOnly on the controller class + non-admin - returns false, 403, forbidden_admin",
+    )
+    fun `class level AdminOnly rejects a non admin`() {
+        // The annotation guards every handler of the controller, so an endpoint that carries
+        // none of its own is closed all the same.
+        whenever(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(null)
+        doReturn(GuardedController::class.java).whenever(handlerMethod).beanType
+        whenever(request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)).thenReturn(nonAdminUser)
+
+        val result = interceptor.preHandle(request, response, handlerMethod)
+
+        assertFalse(result)
+        verify(response).status = HttpServletResponse.SC_FORBIDDEN
+        verify(response).setHeader(AuthErrorType.HEADER_NAME, AuthErrorType.FORBIDDEN_ADMIN.value)
     }
 
     @Test
@@ -109,4 +142,10 @@ class AdminAuthInterceptorTest {
             interceptor.preHandle(request, response, handlerMethod)
         }
     }
+
+    // Stand-ins for the two kinds of controller the interceptor has to tell apart.
+    @AdminOnly
+    private class GuardedController
+
+    private class OpenController
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptorTest.kt
@@ -2,6 +2,7 @@ package ru.illine.drinking.ponies.config.web.interceptor
 
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -9,8 +10,11 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -20,6 +24,8 @@ import ru.illine.drinking.ponies.config.web.security.AuthErrorType
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
 import ru.illine.drinking.ponies.exception.InvalidAuthSignatureException
 import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfile
+import ru.illine.drinking.ponies.model.dto.internal.UserAccessDto
 import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
@@ -111,46 +117,95 @@ class TelegramAuthInterceptorTest {
         verifyNoInteractions(telegramUserAccessService)
     }
 
-    @Test
-    @DisplayName("preHandle(): valid signature - enriches isAdmin=true and sets telegramUser attribute")
-    fun `preHandle valid signature enriches isAdmin true`() {
+    @ParameterizedTest(name = "[{index}] isAdmin={0}, isBanned={1}, isDeleted={2}")
+    @CsvSource(
+        "true,  false, false",
+        "false, true,  false",
+        "false, false, true",
+        "true,  true,  true",
+    )
+    @DisplayName("preHandle(): valid signature - enriches the access flags and sets telegramUser attribute")
+    fun `preHandle valid signature enriches access flags`(
+        isAdmin: Boolean,
+        isBanned: Boolean,
+        isDeleted: Boolean,
+    ) {
         val initData = "valid-init-data"
         val telegramUser = TelegramUserDto(externalUserId = 1L, firstName = "Test", lastName = null, username = null)
         whenever(request.method).thenReturn("POST")
         whenever(request.getHeader(headerName)).thenReturn(initData)
         whenever(validatorService.verifySignature(any())).thenReturn(true)
         whenever(validatorService.map(initData)).thenReturn(telegramUser)
-        whenever(telegramUserAccessService.findIsAdminByExternalUserId(1L)).thenReturn(true)
+        whenever(telegramUserAccessService.resolveAccessFlags(any(), any()))
+            .thenReturn(UserAccessDto(isAdmin = isAdmin, isBanned = isBanned, isDeleted = isDeleted))
 
         val result = interceptor.preHandle(request, response, Any())
 
         assertTrue(result)
         verify(request).setAttribute(
             TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE,
-            telegramUser.copy(isAdmin = true),
+            // isActive is the opposite of the isDeleted the access service reports, and both
+            // rows of the matrix would fail if that negation were dropped.
+            telegramUser.copy(isAdmin = isAdmin, isBanned = isBanned, isActive = !isDeleted),
         )
         verifyNoMoreInteractions(response)
     }
 
-    @Test
-    @DisplayName("preHandle(): valid signature - enriches isAdmin=false when access service returns false")
-    fun `preHandle valid signature enriches isAdmin false`() {
+    @ParameterizedTest(name = "[{index}] isDeleted={0} - isActive={1}")
+    @CsvSource("true, false", "false, true")
+    @DisplayName("preHandle(): valid signature - a deleted account is reported as inactive, not the other way round")
+    fun `preHandle inverts isDeleted into isActive`(
+        isDeleted: Boolean,
+        expectedIsActive: Boolean,
+    ) {
+        // Spelled out on its own because the sign is easy to lose: the access service speaks in
+        // isDeleted, the request attribute speaks in isActive, and equality on the whole DTO
+        // makes for a poor failure message when only that one flag is wrong.
         val initData = "valid-init-data"
-        val telegramUser = TelegramUserDto(externalUserId = 2L, firstName = "Test", lastName = null, username = null)
+        val telegramUser = TelegramUserDto(externalUserId = 1L, firstName = "Test", lastName = null, username = null)
         whenever(request.method).thenReturn("POST")
         whenever(request.getHeader(headerName)).thenReturn(initData)
         whenever(validatorService.verifySignature(any())).thenReturn(true)
         whenever(validatorService.map(initData)).thenReturn(telegramUser)
-        whenever(telegramUserAccessService.findIsAdminByExternalUserId(2L)).thenReturn(false)
+        whenever(telegramUserAccessService.resolveAccessFlags(any(), any()))
+            .thenReturn(UserAccessDto(isDeleted = isDeleted))
 
-        val result = interceptor.preHandle(request, response, Any())
+        interceptor.preHandle(request, response, Any())
 
-        assertTrue(result)
-        verify(request).setAttribute(
-            TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE,
-            telegramUser.copy(isAdmin = false),
+        val captor = argumentCaptor<TelegramUserDto>()
+        verify(request).setAttribute(eq(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE), captor.capture())
+        assertEquals(expectedIsActive, captor.firstValue.isActive)
+    }
+
+    @Test
+    @DisplayName("preHandle(): valid signature - forwards the initData profile to the access service")
+    fun `preHandle valid signature forwards initData profile`() {
+        val initData = "valid-init-data"
+        val telegramUser =
+            TelegramUserDto(
+                externalUserId = 42L,
+                firstName = "Alisa",
+                lastName = "Petrova",
+                username = "alisaadmin",
+            )
+        whenever(request.method).thenReturn("POST")
+        whenever(request.getHeader(headerName)).thenReturn(initData)
+        whenever(validatorService.verifySignature(any())).thenReturn(true)
+        whenever(validatorService.map(initData)).thenReturn(telegramUser)
+        whenever(telegramUserAccessService.resolveAccessFlags(any(), any())).thenReturn(UserAccessDto())
+
+        interceptor.preHandle(request, response, Any())
+
+        verify(telegramUserAccessService).resolveAccessFlags(
+            eq(42L),
+            eq(
+                TelegramUserProfile(
+                    firstName = "Alisa",
+                    lastName = "Petrova",
+                    username = "alisaadmin",
+                ),
+            ),
         )
-        verifyNoMoreInteractions(response)
     }
 
     @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/UserAdminControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/UserAdminControllerTest.kt
@@ -1,0 +1,512 @@
+package ru.illine.drinking.ponies.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.cache.CacheManager
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.context.jdbc.SqlConfig
+import ru.illine.drinking.ponies.config.cache.CacheConfig
+import ru.illine.drinking.ponies.config.web.security.AuthErrorType
+import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
+import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfile
+import ru.illine.drinking.ponies.model.dto.response.UserDetailsResponse
+import ru.illine.drinking.ponies.model.dto.response.UsersResponse
+import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
+import ru.illine.drinking.ponies.test.generator.DtoGenerator
+import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
+import java.time.Instant
+import java.util.stream.Stream
+
+@SpringIntegrationTest
+@DisplayName("UserAdminController Spring Integration Test")
+@Sql(
+    scripts = ["classpath:sql/access/TelegramUserAccessService.sql"],
+    config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+)
+@Sql(
+    scripts = ["classpath:sql/clear.sql"],
+    config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
+)
+class UserAdminControllerTest
+    @Autowired
+    constructor(
+        private val restTemplate: TestRestTemplate,
+        private val objectMapper: ObjectMapper,
+        private val cacheManager: CacheManager,
+        private val telegramUserAccessService: TelegramUserAccessService,
+    ) {
+        @MockitoBean
+        private lateinit var telegramValidatorService: TelegramValidatorService
+
+        // Mirrors the stored profile of the fixture admin: authenticating refreshes the profile of the
+        // caller, and an identical one keeps the row the list assertions rely on untouched.
+        private val adminUser =
+            DtoGenerator.generateTelegramUserDto(
+                externalUserId = ADMIN_EXTERNAL_ID,
+                firstName = "Alisa",
+                lastName = "Petrova",
+                username = "alisaadmin",
+            )
+
+        private val nonAdminUser =
+            DtoGenerator.generateTelegramUserDto(
+                externalUserId = PLAIN_EXTERNAL_ID,
+                firstName = "Bob",
+                lastName = "Smith",
+                username = "bobsmith",
+            )
+
+        @BeforeEach
+        fun setUp() {
+            cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)?.clear()
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
+            whenever(telegramValidatorService.map(any())).thenReturn(adminUser)
+        }
+
+        private fun buildHeaders(): HttpHeaders =
+            HttpHeaders().apply {
+                set("X-Authorization-Telegram-Data", "test-init-data")
+                contentType = MediaType.APPLICATION_JSON
+            }
+
+        private fun getUsers(query: String = ""): UsersResponse {
+            val response =
+                restTemplate.exchange(
+                    "/users$query",
+                    HttpMethod.GET,
+                    HttpEntity<Void>(buildHeaders()),
+                    UsersResponse::class.java,
+                )
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            return response.body!!
+        }
+
+        // Goes through a URI variable so that characters like % survive instead of being read
+        // as a broken percent-encoding by the URI template handler.
+        private fun searchFor(search: String): UsersResponse {
+            val response =
+                restTemplate.exchange(
+                    "/users?search={search}",
+                    HttpMethod.GET,
+                    HttpEntity<Void>(buildHeaders()),
+                    UsersResponse::class.java,
+                    mapOf("search" to search),
+                )
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            return response.body!!
+        }
+
+        private fun getUser(id: Long): UserDetailsResponse {
+            val response =
+                restTemplate.exchange(
+                    "/users/$id",
+                    HttpMethod.GET,
+                    HttpEntity<Void>(buildHeaders()),
+                    UserDetailsResponse::class.java,
+                )
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            return response.body!!
+        }
+
+        private fun patchState(
+            id: Long,
+            body: String,
+        ) = restTemplate.exchange(
+            "/users/$id",
+            HttpMethod.PATCH,
+            HttpEntity(body, buildHeaders()),
+            String::class.java,
+        )
+
+        @Nested
+        @DisplayName("GET /users")
+        inner class GetUsers {
+            @Test
+            @DisplayName("no parameters - returns every user including the soft-deleted one, newest activity first")
+            fun `returns the whole first page`() {
+                val body = getUsers()
+
+                assertEquals(listOf(3L, 2L, 1L, 4L, 5L, 6L, 7L, 8L), body.users.map { it.id })
+                assertEquals(0, body.page)
+                assertEquals(20, body.size)
+                assertEquals(8L, body.total)
+                assertEquals(8L, body.counts.all)
+                assertEquals(5L, body.counts.active)
+                assertEquals(1L, body.counts.inactive)
+                assertEquals(2L, body.counts.banned)
+            }
+
+            @ParameterizedTest(name = "[{index}] status={0} - ids {1}, total {2}")
+            @CsvSource(
+                "ALL,      '3,2,1,4,5,6,7,8', 8",
+                "ACTIVE,   '2,1,5,7,8',       5",
+                "INACTIVE, '3',               1",
+                "BANNED,   '4,6',             2",
+            )
+            @DisplayName("narrows the page down to the requested status chip and reports its counter as total")
+            fun `filters by status`(
+                status: String,
+                expectedIds: String,
+                expectedTotal: Long,
+            ) {
+                val body = getUsers("?status=$status")
+
+                assertEquals(expectedIds.split(",").map { it.toLong() }, body.users.map { it.id })
+                assertEquals(expectedTotal, body.total)
+            }
+
+            @Test
+            @DisplayName("a banned and deleted user shows on the BANNED chip only, a ban winning over a deletion")
+            fun `a ban wins over a deletion`() {
+                assertTrue(getUsers("?status=BANNED").users.map { it.id }.contains(BANNED_DELETED_USER_ID))
+                assertFalse(getUsers("?status=INACTIVE").users.map { it.id }.contains(BANNED_DELETED_USER_ID))
+                assertTrue(getUsers().users.map { it.id }.contains(BANNED_DELETED_USER_ID))
+            }
+
+            @Test
+            @DisplayName("status only filters the page - the chip counters keep covering everyone")
+            fun `counts ignore the requested status`() {
+                val body = getUsers("?status=BANNED")
+
+                assertEquals(listOf(4L, 6L), body.users.map { it.id })
+                assertEquals(8L, body.counts.all)
+                assertEquals(5L, body.counts.active)
+                assertEquals(1L, body.counts.inactive)
+                assertEquals(2L, body.counts.banned)
+            }
+
+            @Test
+            @DisplayName("the chip counters do follow the search")
+            fun `counts follow the search`() {
+                val body = getUsers("?search=777")
+
+                assertEquals(4L, body.counts.all)
+                assertEquals(1L, body.counts.active)
+                assertEquals(1L, body.counts.inactive)
+                assertEquals(2L, body.counts.banned)
+            }
+
+            @ParameterizedTest(name = "[{index}] search={0} - ids {1}")
+            @CsvSource(
+                "bob,      '2'",
+                "petrova,  '1'",
+                "evefresh, '5'",
+                "777002,   '4'",
+                "5,        '5'",
+            )
+            @DisplayName("searches over name, username, telegram id and internal id")
+            fun `searches over name username and both ids`(
+                search: String,
+                expectedIds: String,
+            ) {
+                val body = getUsers("?search=$search")
+
+                assertEquals(expectedIds.split(",").map { it.toLong() }, body.users.map { it.id })
+            }
+
+            @ParameterizedTest(name = "[{index}] search=[{0}]")
+            @ValueSource(strings = ["", "   "])
+            @DisplayName("a blank search is the same as no search at all")
+            fun `blank search matches everyone`(search: String) {
+                val body = searchFor(search)
+
+                assertEquals(8L, body.total)
+                assertEquals(8, body.users.size)
+            }
+
+            @ParameterizedTest(name = "[{index}] search=[{0}] - ids {1}")
+            @CsvSource(
+                // A literal underscore, not LIKE's single-character wildcard: aliceXp stays out.
+                "alice_p, '7'",
+                // A search made of nothing but wildcard characters matches the users who really
+                // carry them, not the whole table.
+                "_,       '7'",
+                "%,       ''",
+                """\,      ''""",
+            )
+            @DisplayName("escapes the LIKE wildcards a user may type into the search box")
+            fun `escapes the wildcards of the search box`(
+                search: String,
+                expectedIds: String,
+            ) {
+                val body = searchFor(search)
+
+                assertEquals(
+                    expectedIds.split(",").filter { it.isNotBlank() }.map { it.toLong() },
+                    body.users.map { it.id },
+                )
+            }
+
+            @ParameterizedTest(name = "[{index}] page={0}, size={1} - ids {2}")
+            @CsvSource(
+                "0, 2, '3,2'",
+                "1, 2, '1,4'",
+                "2, 2, '5,6'",
+                "3, 2, '7,8'",
+            )
+            @DisplayName("paginates while total and the counters stay over the whole result")
+            fun `paginates the result`(
+                page: Int,
+                size: Int,
+                expectedIds: String,
+            ) {
+                val body = getUsers("?page=$page&size=$size")
+
+                assertEquals(expectedIds.split(",").map { it.toLong() }, body.users.map { it.id })
+                assertEquals(page, body.page)
+                assertEquals(size, body.size)
+                assertEquals(8L, body.total)
+                assertEquals(8L, body.counts.all)
+            }
+
+            @ParameterizedTest(name = "[{index}] query={0}")
+            @ValueSource(strings = ["?page=-1", "?size=0", "?size=101", "?status=BOGUS"])
+            @DisplayName("rejects parameters outside of the contract with 400")
+            fun `rejects invalid parameters`(query: String) {
+                val response =
+                    restTemplate.exchange(
+                        "/users$query",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(buildHeaders()),
+                        String::class.java,
+                    )
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+            }
+
+            @Test
+            @DisplayName("serializes a row with the telegram id under telegramUserId and UTC timestamps")
+            fun `serializes a row under the published keys`() {
+                val response =
+                    restTemplate.exchange(
+                        "/users?status=INACTIVE",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(buildHeaders()),
+                        String::class.java,
+                    )
+
+                val row = objectMapper.readTree(response.body).path("users").path(0)
+                assertEquals(DELETED_USER_ID, row.path("id").asLong())
+                assertEquals(DELETED_EXTERNAL_ID, row.path("telegramUserId").asLong())
+                assertEquals("Carol", row.path("firstName").asText())
+                assertEquals("carolgone", row.path("username").asText())
+                assertFalse(row.path("isActive").asBoolean())
+                assertEquals("2026-03-06T12:00:00Z", row.path("lastActivity").asText())
+            }
+        }
+
+        @Nested
+        @DisplayName("GET /users/{id}")
+        inner class GetUserCard {
+            @Test
+            @DisplayName("returns 200 with the full card of an existing user")
+            fun `returns 200 with the card`() {
+                val body = getUser(ADMIN_USER_ID)
+
+                assertEquals(ADMIN_USER_ID, body.id)
+                assertEquals(ADMIN_EXTERNAL_ID, body.externalUserId)
+                assertEquals("Alisa", body.firstName)
+                assertEquals("Petrova", body.lastName)
+                assertEquals("alisaadmin", body.username)
+                assertTrue(body.isAdmin)
+                assertFalse(body.isBanned)
+                assertTrue(body.isActive)
+                assertEquals("Europe/Moscow", body.timeZone)
+                assertEquals(Instant.parse("2026-01-01T10:00:00Z"), body.registeredAt)
+                assertEquals(Instant.parse("2026-03-04T09:00:00Z"), body.lastActivity)
+            }
+
+            @Test
+            @DisplayName("returns 200 for a soft-deleted user - they stay reachable for the admin")
+            fun `returns 200 for a soft deleted user`() {
+                val body = getUser(DELETED_USER_ID)
+
+                assertEquals(DELETED_USER_ID, body.id)
+                assertFalse(body.isActive)
+            }
+
+            @Test
+            @DisplayName("returns 200 with a null last activity for a user who never answered")
+            fun `returns 200 with null last activity`() {
+                assertNull(getUser(ACTIVE_USER_ID).lastActivity)
+            }
+
+            @Test
+            @DisplayName("unknown id - returns 404")
+            fun `returns 404 for an unknown id`() {
+                val response =
+                    restTemplate.exchange(
+                        "/users/$MISSING_USER_ID",
+                        HttpMethod.GET,
+                        HttpEntity<Void>(buildHeaders()),
+                        String::class.java,
+                    )
+
+                assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+            }
+        }
+
+        @Nested
+        @DisplayName("PATCH /users/{id}")
+        inner class UpdateUserState {
+            @Test
+            @DisplayName("isActive=false - returns 200 with the soft-deleted card and moves the user to INACTIVE")
+            fun `soft deletes the user`() {
+                val response = patchState(ACTIVE_USER_ID, """{"isActive": false}""")
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertFalse(objectMapper.readTree(response.body).path("isActive").asBoolean())
+                assertFalse(getUser(ACTIVE_USER_ID).isActive)
+                assertEquals(listOf(DELETED_USER_ID, ACTIVE_USER_ID), getUsers("?status=INACTIVE").users.map { it.id })
+            }
+
+            @Test
+            @DisplayName("isActive=true - returns 200 with the restored card and moves the user back to ACTIVE")
+            fun `restores the user`() {
+                val response = patchState(DELETED_USER_ID, """{"isActive": true}""")
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertTrue(objectMapper.readTree(response.body).path("isActive").asBoolean())
+                assertTrue(getUser(DELETED_USER_ID).isActive)
+                assertTrue(getUsers("?status=INACTIVE").users.isEmpty())
+            }
+
+            @Test
+            @DisplayName("the returned card carries the rest of the profile untouched")
+            fun `returns the rest of the card unchanged`() {
+                val response = patchState(DELETED_USER_ID, """{"isActive": true}""")
+
+                val body = objectMapper.readTree(response.body)
+                assertEquals(DELETED_USER_ID, body.path("id").asLong())
+                assertEquals(DELETED_EXTERNAL_ID, body.path("telegramUserId").asLong())
+                assertEquals("Carol", body.path("firstName").asText())
+                assertEquals("Asia/Kolkata", body.path("timeZone").asText())
+                assertEquals("2026-03-06T12:00:00Z", body.path("lastActivity").asText())
+                assertEquals("2026-01-03T12:00:00Z", body.path("registeredAt").asText())
+            }
+
+            @ParameterizedTest(name = "[{index}] isActive={0}")
+            @CsvSource("true", "false")
+            @DisplayName("repeating the same update is idempotent")
+            fun `repeating the same update is idempotent`(isActive: Boolean) {
+                patchState(ACTIVE_USER_ID, """{"isActive": $isActive}""")
+
+                val response = patchState(ACTIVE_USER_ID, """{"isActive": $isActive}""")
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertEquals(isActive, getUser(ACTIVE_USER_ID).isActive)
+            }
+
+            @Test
+            @DisplayName("empty payload - returns 400 and leaves the user alone")
+            fun `returns 400 for an empty payload`() {
+                val response = patchState(ACTIVE_USER_ID, "{}")
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                assertTrue(getUser(ACTIVE_USER_ID).isActive)
+            }
+
+            @Test
+            @DisplayName("unknown id - returns 404")
+            fun `returns 404 for an unknown id`() {
+                val response = patchState(MISSING_USER_ID, """{"isActive": false}""")
+
+                assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+            }
+
+            @Test
+            @DisplayName("evicts the cached access flags, so the next request of that user is resolved afresh")
+            fun `evicts the cached access flags of the updated user`() {
+                val cache = cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)!!
+                telegramUserAccessService.resolveAccessFlags(ACTIVE_EXTERNAL_ID, TelegramUserProfile())
+                assertNotNull(cache.get(ACTIVE_EXTERNAL_ID))
+
+                patchState(ACTIVE_USER_ID, """{"isActive": false}""")
+
+                assertNull(cache.get(ACTIVE_EXTERNAL_ID))
+            }
+        }
+
+        @Nested
+        @DisplayName("class-level @AdminOnly guard")
+        inner class AdminGuard {
+            @ParameterizedTest(name = "[{index}] {0} {1}")
+            @MethodSource("ru.illine.drinking.ponies.controller.UserAdminControllerTest#provideAdminEndpoints")
+            @DisplayName("non-admin caller - returns 403 with X-Auth-Error-Code forbidden_admin on every route")
+            fun `rejects a non admin on every admin endpoint`(
+                method: HttpMethod,
+                path: String,
+                body: String?,
+            ) {
+                whenever(telegramValidatorService.map(any())).thenReturn(nonAdminUser)
+
+                val response =
+                    restTemplate.exchange(path, method, HttpEntity<String?>(body, buildHeaders()), String::class.java)
+
+                assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
+                assertEquals(
+                    AuthErrorType.FORBIDDEN_ADMIN.value,
+                    response.headers.getFirst(AuthErrorType.HEADER_NAME),
+                )
+            }
+
+            @Test
+            @DisplayName("non-admin caller - the rejected update never reaches the database")
+            fun `rejected update leaves the user untouched`() {
+                whenever(telegramValidatorService.map(any())).thenReturn(nonAdminUser)
+                patchState(ACTIVE_USER_ID, """{"isActive": false}""")
+
+                whenever(telegramValidatorService.map(any())).thenReturn(adminUser)
+                assertTrue(getUser(ACTIVE_USER_ID).isActive)
+            }
+        }
+
+        companion object {
+            private const val ADMIN_USER_ID = 1L
+            private const val DELETED_USER_ID = 3L
+            private const val ACTIVE_USER_ID = 5L
+            private const val BANNED_DELETED_USER_ID = 6L
+            private const val MISSING_USER_ID = 999L
+
+            private const val ADMIN_EXTERNAL_ID = 1L
+            private const val PLAIN_EXTERNAL_ID = 2L
+            private const val DELETED_EXTERNAL_ID = 777001L
+            private const val ACTIVE_EXTERNAL_ID = 777003L
+
+            @JvmStatic
+            fun provideAdminEndpoints(): Stream<Arguments> =
+                Stream.of(
+                    Arguments.of(HttpMethod.GET, "/users", null),
+                    Arguments.of(HttpMethod.GET, "/users/$ADMIN_USER_ID", null),
+                    Arguments.of(HttpMethod.PATCH, "/users/$ADMIN_USER_ID", """{"isActive": false}"""),
+                )
+        }
+    }

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/UserControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/UserControllerTest.kt
@@ -1,11 +1,15 @@
 package ru.illine.drinking.ponies.controller
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
@@ -41,16 +45,17 @@ class UserControllerTest
     @Autowired
     constructor(
         private val restTemplate: TestRestTemplate,
+        private val objectMapper: ObjectMapper,
         private val cacheManager: CacheManager,
     ) {
         @MockitoBean
         private lateinit var telegramValidatorService: TelegramValidatorService
 
-        private val telegramUser = DtoGenerator.generateTelegramUserDto(externalUserId = ADMIN_USER_ID)
+        private val telegramUser = DtoGenerator.generateTelegramUserDto(externalUserId = ADMIN_EXTERNAL_ID)
 
         @BeforeEach
         fun setUp() {
-            cacheManager.getCache(CacheConfig.USER_IS_ADMIN)?.clear()
+            cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)?.clear()
             whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
             whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
         }
@@ -60,115 +65,140 @@ class UserControllerTest
                 set("X-Authorization-Telegram-Data", "test-init-data")
             }
 
-        @Nested
-        @DisplayName("GET /users/me")
-        inner class GetMe {
-            @Test
-            @DisplayName("admin user - returns 200 with isAdmin=true")
-            fun `returns 200 with isAdmin true for admin`() {
-                val headers = buildHeaders()
+        @ParameterizedTest(name = "[{index}] externalUserId={0} - isAdmin={1}, isBanned={2}, isActive={3}")
+        @CsvSource(
+            // admin, plain, banned-but-present, soft deleted, banned and deleted, unknown caller
+            "1,      true,  false, true",
+            "2,      false, false, true",
+            "777002, false, true,  true",
+            "777001, false, false, false",
+            "777004, false, true,  false",
+            "0,      false, false, true",
+        )
+        @DisplayName("getMe(): returns 200 with the access flags of the caller, unknown callers included")
+        fun `returns 200 with access flags`(
+            externalUserId: Long,
+            isAdmin: Boolean,
+            isBanned: Boolean,
+            isActive: Boolean,
+        ) {
+            whenever(telegramValidatorService.map(any()))
+                .thenReturn(telegramUser.copy(externalUserId = externalUserId))
 
-                val response =
-                    restTemplate.exchange(
-                        "/users/me",
-                        HttpMethod.GET,
-                        HttpEntity<Void>(headers),
-                        MeResponse::class.java,
-                    )
-
-                assertEquals(HttpStatus.OK, response.statusCode)
-                assertNotNull(response.body)
-                assertEquals(ADMIN_USER_ID, response.body!!.externalUserId)
-                assertEquals(true, response.body!!.isAdmin)
-            }
-
-            @Test
-            @DisplayName("non-admin user - returns 200 with isAdmin=false")
-            fun `returns 200 with isAdmin false for non-admin`() {
-                whenever(
-                    telegramValidatorService.map(any()),
-                ).thenReturn(telegramUser.copy(externalUserId = NON_ADMIN_USER_ID))
-                val headers = buildHeaders()
-
-                val response =
-                    restTemplate.exchange(
-                        "/users/me",
-                        HttpMethod.GET,
-                        HttpEntity<Void>(headers),
-                        MeResponse::class.java,
-                    )
-
-                assertEquals(HttpStatus.OK, response.statusCode)
-                assertNotNull(response.body)
-                assertEquals(NON_ADMIN_USER_ID, response.body!!.externalUserId)
-                assertEquals(false, response.body!!.isAdmin)
-            }
-
-            @Test
-            @DisplayName("user not in DB - returns 200 with isAdmin=false")
-            fun `returns 200 with isAdmin false for user not in db`() {
-                whenever(
-                    telegramValidatorService.map(any()),
-                ).thenReturn(telegramUser.copy(externalUserId = MISSING_USER_ID))
-                val headers = buildHeaders()
-
-                val response =
-                    restTemplate.exchange(
-                        "/users/me",
-                        HttpMethod.GET,
-                        HttpEntity<Void>(headers),
-                        MeResponse::class.java,
-                    )
-
-                assertEquals(HttpStatus.OK, response.statusCode)
-                assertNotNull(response.body)
-                assertEquals(MISSING_USER_ID, response.body!!.externalUserId)
-                assertEquals(false, response.body!!.isAdmin)
-            }
-
-            @Test
-            @DisplayName("missing auth header - returns 401 with X-Auth-Error-Code invalid_auth_signature")
-            fun `returns 401 with invalid_auth_signature header`() {
-                val response =
-                    restTemplate.exchange(
-                        "/users/me",
-                        HttpMethod.GET,
-                        HttpEntity<Void>(HttpHeaders()),
-                        Void::class.java,
-                    )
-
-                assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
-                assertEquals(
-                    AuthErrorType.INVALID_AUTH_SIGNATURE.value,
-                    response.headers.getFirst(AuthErrorType.HEADER_NAME),
+            val response =
+                restTemplate.exchange(
+                    "/users/me",
+                    HttpMethod.GET,
+                    HttpEntity<Void>(buildHeaders()),
+                    MeResponse::class.java,
                 )
-            }
 
-            @Test
-            @DisplayName("expired auth_date - returns 403 with X-Auth-Error-Code session_expired")
-            fun `returns 403 with session_expired header`() {
-                whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
-                val headers = buildHeaders()
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertNotNull(response.body)
+            assertEquals(externalUserId, response.body!!.externalUserId)
+            assertEquals(isAdmin, response.body!!.isAdmin)
+            assertEquals(isBanned, response.body!!.isBanned)
+            assertEquals(isActive, response.body!!.isActive)
+        }
 
-                val response =
-                    restTemplate.exchange(
-                        "/users/me",
-                        HttpMethod.GET,
-                        HttpEntity<Void>(headers),
-                        Void::class.java,
-                    )
+        @Test
+        @DisplayName("getMe(): a soft-deleted caller still reaches the endpoint and learns they are inactive")
+        fun `stays open for a soft deleted caller`() {
+            // Access is deliberately not cut off for a deleted account: the MiniApp needs the flag
+            // to explain the state and to offer the /start that brings the account back.
+            whenever(telegramValidatorService.map(any()))
+                .thenReturn(telegramUser.copy(externalUserId = DELETED_EXTERNAL_ID))
 
-                assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
-                assertEquals(
-                    AuthErrorType.SESSION_EXPIRED.value,
-                    response.headers.getFirst(AuthErrorType.HEADER_NAME),
+            val response =
+                restTemplate.exchange(
+                    "/users/me",
+                    HttpMethod.GET,
+                    HttpEntity<Void>(buildHeaders()),
+                    MeResponse::class.java,
                 )
-            }
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertFalse(response.body!!.isActive)
+        }
+
+        @Test
+        @DisplayName("getMe(): stays open for a non-admin, unlike the endpoints of UserAdminController")
+        fun `stays open for a non admin`() {
+            whenever(telegramValidatorService.map(any()))
+                .thenReturn(telegramUser.copy(externalUserId = PLAIN_EXTERNAL_ID))
+
+            val response =
+                restTemplate.exchange(
+                    "/users/me",
+                    HttpMethod.GET,
+                    HttpEntity<Void>(buildHeaders()),
+                    MeResponse::class.java,
+                )
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertFalse(response.body!!.isAdmin)
+        }
+
+        @Test
+        @DisplayName("getMe(): keeps the telegramUserId key the MiniApp consumes")
+        fun `serializes the identity under the published keys`() {
+            val response =
+                restTemplate.exchange(
+                    "/users/me",
+                    HttpMethod.GET,
+                    HttpEntity<Void>(buildHeaders()),
+                    String::class.java,
+                )
+
+            val body = objectMapper.readTree(response.body)
+            assertEquals(ADMIN_EXTERNAL_ID, body.path("telegramUserId").asLong())
+            assertTrue(body.path("isAdmin").asBoolean())
+            assertFalse(body.path("isBanned").asBoolean())
+            assertTrue(body.path("isActive").asBoolean())
+            assertFalse(body.path("isActive").isMissingNode, "The MiniApp reads the flag under this exact key")
+        }
+
+        @Test
+        @DisplayName("getMe(): missing auth header - returns 401 with X-Auth-Error-Code invalid_auth_signature")
+        fun `returns 401 with invalid_auth_signature header`() {
+            val response =
+                restTemplate.exchange(
+                    "/users/me",
+                    HttpMethod.GET,
+                    HttpEntity<Void>(HttpHeaders()),
+                    Void::class.java,
+                )
+
+            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+            assertEquals(
+                AuthErrorType.INVALID_AUTH_SIGNATURE.value,
+                response.headers.getFirst(AuthErrorType.HEADER_NAME),
+            )
+        }
+
+        @Test
+        @DisplayName("getMe(): expired auth_date - returns 403 with X-Auth-Error-Code session_expired")
+        fun `returns 403 with session_expired header`() {
+            whenever(telegramValidatorService.verifySignature(any())).thenReturn(false)
+
+            val response =
+                restTemplate.exchange(
+                    "/users/me",
+                    HttpMethod.GET,
+                    HttpEntity<Void>(buildHeaders()),
+                    Void::class.java,
+                )
+
+            assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
+            assertEquals(
+                AuthErrorType.SESSION_EXPIRED.value,
+                response.headers.getFirst(AuthErrorType.HEADER_NAME),
+            )
         }
 
         companion object {
-            private const val ADMIN_USER_ID = 1L
-            private const val NON_ADMIN_USER_ID = 2L
-            private const val MISSING_USER_ID = 0L
+            private const val ADMIN_EXTERNAL_ID = 1L
+            private const val PLAIN_EXTERNAL_ID = 2L
+            private const val DELETED_EXTERNAL_ID = 777001L
         }
     }

--- a/src/test/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessServiceTest.kt
@@ -56,6 +56,31 @@ class NotificationAccessServiceTest
         }
 
         @Test
+        @DisplayName("findAllNotificationSettings(): survives a soft-deleted user instead of failing the whole batch")
+        fun `findAllNotificationSettings survives a soft deleted user`() {
+            // Reading the user through the lazy association threw EntityNotFoundException here:
+            // @SQLRestriction hides the row even from a load by id, and the mailing died for
+            // everyone on every tick, not just for the deleted user.
+            val settings = assertDoesNotThrow(ThrowingSupplier { accessService.findAllNotificationSettings() })
+
+            assertFalse(settings.isEmpty(), "The users who are still around have to survive the deleted one")
+        }
+
+        @Test
+        @DisplayName("findAllNotificationSettings(): leaves the soft-deleted user out and keeps the live ones")
+        fun `findAllNotificationSettings returns the live users only`() {
+            val externalUserIds = accessService.findAllNotificationSettings().map { it.telegramUser.externalUserId }
+
+            // Only the live user who still has notifications on: the deleted one is dropped by the
+            // join, the disabled one by @SQLRestriction(enabled = true) on the settings themselves.
+            assertEquals(listOf(DEFAULT_EXTERNAL_USER_ID), externalUserIds)
+            assertFalse(
+                externalUserIds.contains(DELETED_EXTERNAL_USER_ID),
+                "A deleted user must not be reminded to drink, even with notifications enabled",
+            )
+        }
+
+        @Test
         @DisplayName("findNotificationSettingByExternalUserId(): returns a found record")
         fun `successful findNotificationSettingByExternalUserId`() {
             assertDoesNotThrow { accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID) }
@@ -629,6 +654,7 @@ class NotificationAccessServiceTest
             private const val NOT_EXISTED_USER_ID = 0L
             private const val DEFAULT_EXTERNAL_USER_ID = 1L
             private const val DISABLED_EXTERNAL_USER_ID = 2L
+            private const val DELETED_EXTERNAL_USER_ID = 3L
             private const val WITHOUT_NOTIFICATION_ATTEMPTS = 0
         }
     }

--- a/src/test/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessServiceTest.kt
@@ -7,14 +7,23 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.CacheManager
+import org.springframework.data.domain.PageRequest
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlConfig
 import ru.illine.drinking.ponies.config.cache.CacheConfig
 import ru.illine.drinking.ponies.dao.repository.TelegramUserRepository
+import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
+import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfile
+import ru.illine.drinking.ponies.model.dto.internal.UserAccessDto
+import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
+import java.time.LocalDateTime
 
 @SpringIntegrationTest
 @DisplayName("TelegramUserAccessService Spring Integration Test")
@@ -37,71 +46,483 @@ class TelegramUserAccessServiceTest
     ) {
         @BeforeEach
         fun clearCache() {
-            cacheManager.getCache(CacheConfig.USER_IS_ADMIN)?.clear()
+            cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)?.clear()
         }
 
-        @Test
-        @DisplayName("findIsAdminByExternalUserId(): admin user - returns true")
-        fun `returns true for admin`() {
-            assertTrue(accessService.findIsAdminByExternalUserId(ADMIN_USER_ID))
-        }
-
-        @Test
-        @DisplayName("findIsAdminByExternalUserId(): non-admin user - returns false")
-        fun `returns false for non-admin`() {
-            assertFalse(accessService.findIsAdminByExternalUserId(NON_ADMIN_USER_ID))
-        }
-
-        @Test
-        @DisplayName("findIsAdminByExternalUserId(): missing user - returns false")
-        fun `returns false for missing user`() {
-            assertFalse(accessService.findIsAdminByExternalUserId(MISSING_USER_ID))
-        }
-
-        @Test
-        @DisplayName("findIsAdminByExternalUserId(): caches result after first call")
-        fun `caches true result after first call`() {
-            val cache = cacheManager.getCache(CacheConfig.USER_IS_ADMIN)
-            assertNotNull(cache)
-            assertNull(cache!!.get(ADMIN_USER_ID))
-
-            accessService.findIsAdminByExternalUserId(ADMIN_USER_ID)
-
-            assertEquals(true, cache.get(ADMIN_USER_ID)?.get())
-        }
-
-        @Test
-        @DisplayName("findIsAdminByExternalUserId(): caches false for missing user")
-        fun `caches false result for missing user`() {
-            val cache = cacheManager.getCache(CacheConfig.USER_IS_ADMIN)!!
-
-            accessService.findIsAdminByExternalUserId(MISSING_USER_ID)
-
-            assertEquals(false, cache.get(MISSING_USER_ID)?.get())
-        }
-
-        @Test
-        @DisplayName("findIsAdminByExternalUserId(): returns stale value from cache after DB change until eviction")
-        fun `returns stale value from cache after db change`() {
-            assertTrue(accessService.findIsAdminByExternalUserId(ADMIN_USER_ID))
-
-            val entity = telegramUserRepository.findByExternalUserId(ADMIN_USER_ID)!!
-            entity.isAdmin = false
-            telegramUserRepository.saveAndFlush(entity)
-
-            assertTrue(
-                accessService.findIsAdminByExternalUserId(ADMIN_USER_ID),
-                "Expected stale cached value (true) before manual cache eviction",
+        @Nested
+        @DisplayName("resolveAccessFlags()")
+        inner class ResolveAccessFlags {
+            @ParameterizedTest(name = "[{index}] externalUserId={0} - admin={1}, banned={2}, deleted={3}")
+            @CsvSource(
+                "1,      true,  false, false",
+                "2,      false, false, false",
+                "777001, false, false, true",
+                "777002, false, true,  false",
+                "777004, false, true,  true",
+                "0,      false, false, false",
             )
+            @DisplayName("returns the stored flags, a soft-deleted user resolves as well")
+            fun `returns stored flags`(
+                externalUserId: Long,
+                isAdmin: Boolean,
+                isBanned: Boolean,
+                isDeleted: Boolean,
+            ) {
+                val access = accessService.resolveAccessFlags(externalUserId, TelegramUserProfile())
 
-            cacheManager.getCache(CacheConfig.USER_IS_ADMIN)?.clear()
+                assertEquals(UserAccessDto(isAdmin, isBanned, isDeleted), access)
+            }
 
-            assertFalse(accessService.findIsAdminByExternalUserId(ADMIN_USER_ID))
+            @Test
+            @DisplayName("caches the resolved flags after the first call")
+            fun `caches resolved flags`() {
+                val cache = cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)!!
+                assertNull(cache.get(ADMIN_EXTERNAL_ID))
+
+                accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID, TelegramUserProfile())
+
+                assertEquals(UserAccessDto(isAdmin = true), cache.get(ADMIN_EXTERNAL_ID)?.get())
+            }
+
+            @Test
+            @DisplayName("caches the default flags for a user that is not stored at all")
+            fun `caches default flags for missing user`() {
+                val cache = cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)!!
+
+                accessService.resolveAccessFlags(MISSING_EXTERNAL_ID, TelegramUserProfile())
+
+                assertEquals(UserAccessDto(), cache.get(MISSING_EXTERNAL_ID)?.get())
+            }
+
+            @Test
+            @DisplayName("keeps serving the cached flags after a DB change until the entry is evicted")
+            fun `returns stale value from cache after db change`() {
+                assertTrue(accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID, TelegramUserProfile()).isAdmin)
+
+                val entity = telegramUserRepository.findByExternalUserId(ADMIN_EXTERNAL_ID)!!
+                entity.isAdmin = false
+                telegramUserRepository.saveAndFlush(entity)
+
+                assertTrue(
+                    accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID, TelegramUserProfile()).isAdmin,
+                    "Expected stale cached value (true) before eviction",
+                )
+
+                cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)?.clear()
+
+                assertFalse(accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID, TelegramUserProfile()).isAdmin)
+            }
+
+            @Test
+            @DisplayName("stores the profile from initData when it differs from the stored one")
+            fun `refreshes profile on mismatch`() {
+                val profile =
+                    DtoGenerator.generateTelegramUserProfile(
+                        firstName = "Alisa",
+                        lastName = "Sidorova",
+                        username = "alisamoved",
+                    )
+
+                accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID, profile)
+
+                val stored = telegramUserRepository.findByExternalUserIdIncludingDeleted(ADMIN_EXTERNAL_ID)!!
+                assertEquals("Alisa", stored.firstName)
+                assertEquals("Sidorova", stored.lastName)
+                assertEquals("alisamoved", stored.username)
+            }
+
+            @Test
+            @DisplayName("leaves the stored profile alone when the caller has no first name to offer")
+            fun `keeps profile when caller sends nothing`() {
+                accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID, TelegramUserProfile())
+
+                val stored = telegramUserRepository.findByExternalUserIdIncludingDeleted(ADMIN_EXTERNAL_ID)!!
+                assertEquals("Alisa", stored.firstName)
+                assertEquals("Petrova", stored.lastName)
+                assertEquals("alisaadmin", stored.username)
+            }
+
+            @Test
+            @DisplayName("drops the optional fields Telegram stopped sending, first name being present")
+            fun `drops the fields telegram no longer sends`() {
+                val profile =
+                    DtoGenerator.generateTelegramUserProfile(
+                        firstName = "Alisa",
+                        lastName = null,
+                        username = null,
+                    )
+
+                accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID, profile)
+
+                val stored = telegramUserRepository.findByExternalUserIdIncludingDeleted(ADMIN_EXTERNAL_ID)!!
+                assertEquals("Alisa", stored.firstName)
+                assertNull(stored.lastName, "A name Telegram no longer sends has to be dropped")
+                assertNull(stored.username, "A username Telegram no longer sends has to be dropped")
+            }
+
+            @Test
+            @DisplayName("refreshes the profile of a soft-deleted user as well")
+            fun `refreshes profile of soft deleted user`() {
+                val profile =
+                    DtoGenerator.generateTelegramUserProfile(
+                        firstName = "Carol",
+                        lastName = "Renamed",
+                        username = "carolback",
+                    )
+
+                accessService.resolveAccessFlags(DELETED_EXTERNAL_ID, profile)
+
+                val stored = telegramUserRepository.findByExternalUserIdIncludingDeleted(DELETED_EXTERNAL_ID)!!
+                assertEquals("Carol", stored.firstName)
+                assertEquals("Renamed", stored.lastName)
+                assertEquals("carolback", stored.username)
+            }
         }
+
+        @Nested
+        @DisplayName("findAllForAdmin()")
+        inner class FindAllForAdmin {
+            @Test
+            @DisplayName("lists soft-deleted users too, most recently active first and never-active last")
+            fun `lists every user ordered by last activity`() {
+                val users = accessService.findAllForAdmin(null, AdminUserStatusFilter.ALL, PageRequest.of(0, PAGE_SIZE))
+
+                assertEquals(listOf(3L, 2L, 1L, 4L, 5L, 6L, 7L, 8L), users.map { it.id })
+            }
+
+            @ParameterizedTest(name = "[{index}] status={0} - ids {1}")
+            @CsvSource(
+                "ALL,      '3,2,1,4,5,6,7,8'",
+                "ACTIVE,   '2,1,5,7,8'",
+                "INACTIVE, '3'",
+                "BANNED,   '4,6'",
+            )
+            @DisplayName("filters by status, the categories being mutually exclusive")
+            fun `filters by status`(
+                status: AdminUserStatusFilter,
+                expectedIds: String,
+            ) {
+                val users = accessService.findAllForAdmin(null, status, PageRequest.of(0, PAGE_SIZE))
+
+                assertEquals(expectedIds.toIds(), users.map { it.id })
+            }
+
+            @Test
+            @DisplayName("a user who is both banned and deleted belongs to BANNED, never to INACTIVE")
+            fun `a ban wins over a deletion`() {
+                val banned = accessService.findAllForAdmin(null, AdminUserStatusFilter.BANNED, PAGE)
+                val inactive = accessService.findAllForAdmin(null, AdminUserStatusFilter.INACTIVE, PAGE)
+                val all = accessService.findAllForAdmin(null, AdminUserStatusFilter.ALL, PAGE)
+
+                assertTrue(banned.map { it.id }.contains(BANNED_DELETED_USER_ID))
+                assertFalse(inactive.map { it.id }.contains(BANNED_DELETED_USER_ID))
+                assertTrue(all.map { it.id }.contains(BANNED_DELETED_USER_ID), "Still one of the users, though")
+            }
+
+            // The caller hands in a ready pattern, wildcards included - the DAO does not add them.
+            @ParameterizedTest(name = "[{index}] search={0} - ids {1}")
+            @CsvSource(
+                "%bob%,        '2'",
+                "%BOB%,        '2'",
+                "%petrova%,    '1'",
+                "%evefresh%,   '5'",
+                "%777002%,     '4'",
+                "%5%,          '5'",
+                "%777%,        '3,4,5,6'",
+                "'%bob smith%', '2'",
+            )
+            @DisplayName("searches over first name, last name, username and both ids, across field borders")
+            fun `searches over name username and both ids`(
+                search: String,
+                expectedIds: String,
+            ) {
+                val users =
+                    accessService.findAllForAdmin(search, AdminUserStatusFilter.ALL, PageRequest.of(0, PAGE_SIZE))
+
+                assertEquals(expectedIds.toIds(), users.map { it.id })
+            }
+
+            @Test
+            @DisplayName("returns nothing when the search matches no one")
+            fun `returns empty result for a search matching nothing`() {
+                val users =
+                    accessService.findAllForAdmin("%zzz%", AdminUserStatusFilter.ALL, PageRequest.of(0, PAGE_SIZE))
+
+                assertTrue(users.isEmpty())
+            }
+
+            @Test
+            @DisplayName("an exact pattern without wildcards matches nothing on its own")
+            fun `an unwrapped pattern does not match`() {
+                val users =
+                    accessService.findAllForAdmin("bob", AdminUserStatusFilter.ALL, PageRequest.of(0, PAGE_SIZE))
+
+                assertTrue(users.isEmpty(), "Wrapping the pattern is the caller's job, not the DAO's")
+            }
+
+            @ParameterizedTest(name = "[{index}] search={0} - ids {1}")
+            @CsvSource(
+                // An escaped underscore is a literal one, so only the user who really has it matches.
+                """%alice\_p%, '7'""",
+                // Left unescaped it is LIKE's single-character wildcard and catches the twin as well.
+                "%alice_p%,   '7,8'",
+                // A lone escaped wildcard finds the rows that truly contain that character.
+                """%\_%,       '7'""",
+                """%\%%,       ''""",
+            )
+            @DisplayName("honours the backslash escape, so a literal underscore is not a wildcard")
+            fun `honours the escape character`(
+                search: String,
+                expectedIds: String,
+            ) {
+                val users =
+                    accessService.findAllForAdmin(search, AdminUserStatusFilter.ALL, PageRequest.of(0, PAGE_SIZE))
+
+                assertEquals(expectedIds.toIds(), users.map { it.id })
+            }
+
+            @ParameterizedTest(name = "[{index}] page={0}, size={1} - ids {2}")
+            @CsvSource(
+                "0, 2, '3,2'",
+                "1, 2, '1,4'",
+                "2, 2, '5,6'",
+                "3, 2, '7,8'",
+            )
+            @DisplayName("paginates without losing the ordering")
+            fun `paginates keeping the order`(
+                page: Int,
+                size: Int,
+                expectedIds: String,
+            ) {
+                val users = accessService.findAllForAdmin(null, AdminUserStatusFilter.ALL, PageRequest.of(page, size))
+
+                assertEquals(expectedIds.toIds(), users.map { it.id })
+            }
+
+            @Test
+            @DisplayName("a page past the last one comes back empty")
+            fun `a page past the end is empty`() {
+                val users = accessService.findAllForAdmin(null, AdminUserStatusFilter.ALL, PageRequest.of(4, 2))
+
+                assertTrue(users.isEmpty())
+            }
+
+            @Test
+            @DisplayName("maps every column of a soft-deleted row, its last activity included")
+            fun `maps the row of a soft deleted user`() {
+                val users = accessService.findAllForAdmin(null, AdminUserStatusFilter.ALL, PageRequest.of(0, PAGE_SIZE))
+
+                val row = users.first { it.id == DELETED_USER_ID }
+                assertEquals(DELETED_EXTERNAL_ID, row.externalUserId)
+                assertEquals("Carol", row.firstName)
+                assertEquals("Ivanova", row.lastName)
+                assertEquals("carolgone", row.username)
+                assertFalse(row.admin)
+                assertFalse(row.banned)
+                assertTrue(row.deleted)
+                assertEquals("Asia/Kolkata", row.timeZone)
+                assertEquals(LocalDateTime.of(2026, 1, 3, 12, 0), row.created)
+                assertEquals(LocalDateTime.of(2026, 3, 6, 12, 0), row.lastActivity)
+            }
+
+            @Test
+            @DisplayName("counts only YES and SNOOZE as activity, so a user who only cancelled has none")
+            fun `last activity ignores cancel events`() {
+                val users = accessService.findAllForAdmin(null, AdminUserStatusFilter.ALL, PageRequest.of(0, PAGE_SIZE))
+
+                assertNull(users.first { it.id == BANNED_USER_ID }.lastActivity)
+            }
+        }
+
+        @Nested
+        @DisplayName("countForAdmin()")
+        inner class CountForAdmin {
+            @Test
+            @DisplayName("counts each status over the whole table, the three adding up to all")
+            fun `counts every status`() {
+                val counts = accessService.countForAdmin(null)
+
+                assertEquals(8L, counts.all)
+                assertEquals(5L, counts.active)
+                // The banned-and-deleted user is counted once, under banned - otherwise the sum
+                // below would overshoot all by exactly that one row.
+                assertEquals(1L, counts.inactive)
+                assertEquals(2L, counts.banned)
+                assertEquals(counts.all, counts.active + counts.inactive + counts.banned)
+            }
+
+            @Test
+            @DisplayName("narrows every counter down to the search result")
+            fun `counts follow the search`() {
+                val counts = accessService.countForAdmin("%777%")
+
+                assertEquals(4L, counts.all)
+                assertEquals(1L, counts.active)
+                assertEquals(1L, counts.inactive)
+                assertEquals(2L, counts.banned)
+                assertEquals(counts.all, counts.active + counts.inactive + counts.banned)
+            }
+
+            @Test
+            @DisplayName("returns zeros when the search matches nothing")
+            fun `counts are zero when nothing matches`() {
+                val counts = accessService.countForAdmin("%zzz%")
+
+                assertEquals(0L, counts.all)
+                assertEquals(0L, counts.active)
+                assertEquals(0L, counts.inactive)
+                assertEquals(0L, counts.banned)
+            }
+        }
+
+        @Nested
+        @DisplayName("findByIdForAdmin()")
+        inner class FindByIdForAdmin {
+            @Test
+            @DisplayName("returns the card of an active user")
+            fun `returns an active user`() {
+                val user = accessService.findByIdForAdmin(ADMIN_USER_ID)
+
+                assertNotNull(user)
+                assertEquals(ADMIN_EXTERNAL_ID, user!!.externalUserId)
+                assertTrue(user.admin)
+                assertFalse(user.deleted)
+                assertEquals(LocalDateTime.of(2026, 1, 1, 10, 0), user.created)
+                assertEquals(LocalDateTime.of(2026, 3, 4, 9, 0), user.lastActivity)
+            }
+
+            @Test
+            @DisplayName("returns a soft-deleted user instead of hiding them")
+            fun `returns a soft deleted user`() {
+                val user = accessService.findByIdForAdmin(DELETED_USER_ID)
+
+                assertNotNull(user)
+                assertTrue(user!!.deleted)
+            }
+
+            @Test
+            @DisplayName("returns null for an unknown id")
+            fun `returns null for an unknown id`() {
+                assertNull(accessService.findByIdForAdmin(MISSING_USER_ID))
+            }
+        }
+
+        @Nested
+        @DisplayName("updateDeleted()")
+        inner class UpdateDeleted {
+            @ParameterizedTest(name = "[{index}] id={0} - deleted={2}")
+            @CsvSource(
+                "5, 777003, true",
+                "3, 777001, false",
+            )
+            @DisplayName("writes the flag and the admin card reflects it")
+            fun `updates the deleted flag`(
+                id: Long,
+                externalUserId: Long,
+                deleted: Boolean,
+            ) {
+                accessService.updateDeleted(id, externalUserId, deleted)
+
+                assertEquals(deleted, accessService.findByIdForAdmin(id)!!.deleted)
+            }
+
+            @Test
+            @DisplayName("repeating the same update leaves the flag as it is")
+            fun `repeating the same update is idempotent`() {
+                accessService.updateDeleted(ACTIVE_USER_ID, ACTIVE_EXTERNAL_ID, deleted = true)
+                accessService.updateDeleted(ACTIVE_USER_ID, ACTIVE_EXTERNAL_ID, deleted = true)
+
+                assertTrue(accessService.findByIdForAdmin(ACTIVE_USER_ID)!!.deleted)
+                assertEquals(2L, accessService.countForAdmin(null).inactive)
+            }
+
+            @Test
+            @DisplayName("an unknown id changes nothing")
+            fun `unknown id changes nothing`() {
+                accessService.updateDeleted(MISSING_USER_ID, MISSING_EXTERNAL_ID, deleted = true)
+
+                val counts = accessService.countForAdmin(null)
+                assertEquals(8L, counts.all)
+                assertEquals(1L, counts.inactive)
+            }
+
+            @Test
+            @DisplayName("evicts the cached access flags of the user it touches")
+            fun `evicts the cached access flags`() {
+                val cache = cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)!!
+                accessService.resolveAccessFlags(ACTIVE_EXTERNAL_ID, TelegramUserProfile())
+                assertNotNull(cache.get(ACTIVE_EXTERNAL_ID))
+
+                accessService.updateDeleted(ACTIVE_USER_ID, ACTIVE_EXTERNAL_ID, deleted = true)
+
+                assertNull(cache.get(ACTIVE_EXTERNAL_ID))
+            }
+        }
+
+        @Nested
+        @DisplayName("restoreIfDeleted()")
+        inner class RestoreIfDeleted {
+            @Test
+            @DisplayName("brings a soft-deleted user back and reports that it did")
+            fun `restores a soft deleted user`() {
+                val restored = accessService.restoreIfDeleted(DELETED_EXTERNAL_ID)
+
+                assertTrue(restored)
+                assertFalse(accessService.findByIdForAdmin(DELETED_USER_ID)!!.deleted)
+            }
+
+            @ParameterizedTest(name = "[{index}] externalUserId={0}")
+            @CsvSource(
+                "1",
+                "777003",
+                "0",
+            )
+            @DisplayName("leaves a live or unknown user alone and reports that nothing happened")
+            fun `restores nothing when there is nothing to restore`(externalUserId: Long) {
+                val restored = accessService.restoreIfDeleted(externalUserId)
+
+                assertFalse(restored)
+                assertEquals(1L, accessService.countForAdmin(null).inactive, "No one else may be revived")
+            }
+
+            @Test
+            @DisplayName("repeating the call is idempotent, only the first one restores")
+            fun `repeating the call is idempotent`() {
+                assertTrue(accessService.restoreIfDeleted(DELETED_EXTERNAL_ID))
+
+                assertFalse(accessService.restoreIfDeleted(DELETED_EXTERNAL_ID))
+                assertFalse(accessService.findByIdForAdmin(DELETED_USER_ID)!!.deleted)
+            }
+
+            @Test
+            @DisplayName("evicts the cached access flags, so the stale isDeleted is not served on")
+            fun `evicts the cached access flags`() {
+                val cache = cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)!!
+                accessService.resolveAccessFlags(DELETED_EXTERNAL_ID, TelegramUserProfile())
+                assertNotNull(cache.get(DELETED_EXTERNAL_ID))
+
+                accessService.restoreIfDeleted(DELETED_EXTERNAL_ID)
+
+                assertNull(cache.get(DELETED_EXTERNAL_ID))
+            }
+        }
+
+        private fun String.toIds(): List<Long> = split(",").filter { it.isNotBlank() }.map { it.trim().toLong() }
 
         companion object {
+            private const val PAGE_SIZE = 20
+            private val PAGE = PageRequest.of(0, PAGE_SIZE)
+
             private const val ADMIN_USER_ID = 1L
-            private const val NON_ADMIN_USER_ID = 2L
-            private const val MISSING_USER_ID = 0L
+            private const val DELETED_USER_ID = 3L
+            private const val BANNED_USER_ID = 4L
+            private const val ACTIVE_USER_ID = 5L
+            private const val BANNED_DELETED_USER_ID = 6L
+            private const val MISSING_USER_ID = 999L
+
+            private const val ADMIN_EXTERNAL_ID = 1L
+            private const val DELETED_EXTERNAL_ID = 777001L
+            private const val ACTIVE_EXTERNAL_ID = 777003L
+            private const val MISSING_EXTERNAL_ID = 0L
         }
     }

--- a/src/test/kotlin/ru/illine/drinking/ponies/scheduler/NotificationSchedulerIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/scheduler/NotificationSchedulerIntegrationTest.kt
@@ -1,0 +1,76 @@
+package ru.illine.drinking.ponies.scheduler
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.context.jdbc.SqlConfig
+import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
+import ru.illine.drinking.ponies.service.notification.NotificationSenderService
+import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
+import ru.illine.drinking.ponies.test.util.ClockHelperTest
+import java.time.Clock
+
+@SpringIntegrationTest
+@DisplayName("NotificationScheduler Spring Integration Test")
+@Sql(
+    scripts = ["classpath:sql/scheduler/NotificationScheduler.sql"],
+    config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+)
+@Sql(
+    scripts = ["classpath:sql/clear.sql"],
+    config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
+)
+class NotificationSchedulerIntegrationTest
+    @Autowired
+    constructor(
+        private val scheduler: NotificationScheduler,
+        private val clock: Clock,
+    ) {
+        // The real one would talk to Telegram; mocked, it also records who was about to be reminded.
+        @MockitoBean
+        private lateinit var notificationSenderService: NotificationSenderService
+
+        @BeforeEach
+        fun resetClock() {
+            (clock as ClockHelperTest.MutableClock).setTime(ClockHelperTest.DEFAULT_TIME)
+        }
+
+        @Test
+        @DisplayName("sendDrinkingReminders(): a soft-deleted account no longer silences the reminders of everyone")
+        fun `a deleted user does not stop the mailing`() {
+            // The scheduler swallows exceptions, so the old failure was invisible from the outside:
+            // loading the deleted user through the lazy association threw EntityNotFoundException
+            // before a single reminder went out, and the bot just went quiet for all users.
+            scheduler.sendDrinkingReminders()
+
+            val captor = argumentCaptor<List<NotificationSettingDto>>()
+            verify(notificationSenderService).sendNotifications(captor.capture())
+            assertEquals(
+                listOf(LIVE_EXTERNAL_USER_ID),
+                captor.firstValue.map { it.telegramUser.externalUserId },
+                "The live user has to be reminded, and the deleted one left out",
+            )
+        }
+
+        @Test
+        @DisplayName("sendDrinkingReminders(): nothing is suspended when no one ran out of attempts")
+        fun `nothing is suspended`() {
+            scheduler.sendDrinkingReminders()
+
+            verify(notificationSenderService, never()).suspendNotifications(any())
+        }
+
+        companion object {
+            private const val LIVE_EXTERNAL_USER_ID = 2L
+        }
+    }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceIntegrationTest.kt
@@ -1,0 +1,182 @@
+package ru.illine.drinking.ponies.service.notification
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cache.CacheManager
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.context.jdbc.SqlConfig
+import org.telegram.telegrambots.abilitybots.api.objects.MessageContext
+import org.telegram.telegrambots.meta.api.objects.User
+import org.telegram.telegrambots.meta.generics.TelegramClient
+import ru.illine.drinking.ponies.config.cache.CacheConfig
+import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
+import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfile
+import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
+
+@SpringIntegrationTest
+@DisplayName("NotificationService Spring Integration Test")
+@Sql(
+    scripts = ["classpath:sql/clear.sql"],
+    config = SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
+)
+class NotificationServiceIntegrationTest
+    @Autowired
+    constructor(
+        private val notificationService: NotificationService,
+        private val notificationAccessService: NotificationAccessService,
+        private val telegramUserAccessService: TelegramUserAccessService,
+        private val cacheManager: CacheManager,
+        private val jdbcTemplate: JdbcTemplate,
+    ) {
+        // The greeting would otherwise go out over the network on every /start.
+        @MockitoBean
+        private lateinit var sender: TelegramClient
+
+        @BeforeEach
+        fun clearCache() {
+            cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)?.clear()
+        }
+
+        @Test
+        @DisplayName("start(): a soft-deleted user says /start again - the account comes back instead of blowing up")
+        fun `start brings a soft deleted user back`() {
+            notificationService.start(messageContext())
+            softDelete()
+
+            // Before the restore existed this threw DataIntegrityViolationException: the soft-deleted
+            // row is hidden from the existence check, so /start tried to insert a second row and the
+            // unique index on external_user_id refused it.
+            assertDoesNotThrow { notificationService.start(messageContext()) }
+
+            assertFalse(isDeleted(), "The account has to be usable again after /start")
+        }
+
+        @Test
+        @DisplayName("start(): the returning user keeps a single account, chat and settings row")
+        fun `start does not duplicate anything`() {
+            notificationService.start(messageContext())
+            softDelete()
+
+            notificationService.start(messageContext())
+
+            assertEquals(1, countUsers(), "A second telegram_users row would break the unique index")
+            assertEquals(1, countChats())
+            assertEquals(1, countSettings())
+        }
+
+        @Test
+        @DisplayName("start(): drops the cached access flags, so the stale isDeleted is not served on")
+        fun `start evicts the cached access flags`() {
+            notificationService.start(messageContext())
+            softDelete()
+            val cache = cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)!!
+            telegramUserAccessService.resolveAccessFlags(EXTERNAL_USER_ID, TelegramUserProfile())
+            assertNotNull(cache.get(EXTERNAL_USER_ID))
+
+            notificationService.start(messageContext())
+
+            assertNull(cache.get(EXTERNAL_USER_ID))
+        }
+
+        @Test
+        @DisplayName("start(): the restored user is back in the mailing selection")
+        fun `start puts the user back into the mailing`() {
+            notificationService.start(messageContext())
+            softDelete()
+            assertTrue(mailingRecipients().isEmpty(), "A deleted user is not reminded to drink")
+
+            notificationService.start(messageContext())
+
+            assertEquals(listOf(EXTERNAL_USER_ID), mailingRecipients())
+        }
+
+        @Test
+        @DisplayName("start(): a live user is untouched - no restore, no second account")
+        fun `start leaves a live user alone`() {
+            notificationService.start(messageContext())
+
+            notificationService.start(messageContext())
+
+            assertFalse(isDeleted())
+            assertEquals(1, countUsers())
+            assertEquals(1, countSettings())
+        }
+
+        @Test
+        @DisplayName("start(): a first-time user gets an account, a chat and settings")
+        fun `start registers a newcomer`() {
+            notificationService.start(messageContext())
+
+            assertEquals(1, countUsers())
+            assertEquals(1, countChats())
+            assertEquals(1, countSettings())
+            assertFalse(isDeleted())
+        }
+
+        private fun mailingRecipients(): List<Long> =
+            notificationAccessService.findAllNotificationSettings().map { it.telegramUser.externalUserId }
+
+        private fun softDelete() {
+            val id = jdbcTemplate.queryForObject(SELECT_ID, Long::class.java, EXTERNAL_USER_ID)!!
+            telegramUserAccessService.updateDeleted(id, EXTERNAL_USER_ID, deleted = true)
+            assertTrue(isDeleted(), "Arrange step must really have soft deleted the user")
+        }
+
+        private fun isDeleted(): Boolean =
+            jdbcTemplate.queryForObject(SELECT_DELETED, Boolean::class.java, EXTERNAL_USER_ID)!!
+
+        private fun countUsers(): Int = jdbcTemplate.queryForObject(COUNT_USERS, Int::class.java, EXTERNAL_USER_ID)!!
+
+        private fun countChats(): Int = jdbcTemplate.queryForObject(COUNT_CHATS, Int::class.java, EXTERNAL_USER_ID)!!
+
+        private fun countSettings(): Int =
+            jdbcTemplate.queryForObject(COUNT_SETTINGS, Int::class.java, EXTERNAL_USER_ID)!!
+
+        private fun messageContext(): MessageContext {
+            val user = mock<User>()
+            whenever(user.id).thenReturn(EXTERNAL_USER_ID)
+            whenever(user.userName).thenReturn("carolgone")
+            whenever(user.firstName).thenReturn("Carol")
+            whenever(user.lastName).thenReturn("Ivanova")
+
+            val context = mock<MessageContext>()
+            whenever(context.user()).thenReturn(user)
+            whenever(context.chatId()).thenReturn(CHAT_ID)
+            return context
+        }
+
+        companion object {
+            private const val EXTERNAL_USER_ID = 777001L
+            private const val CHAT_ID = 424242L
+
+            private const val SELECT_ID = "select id from telegram_users where external_user_id = ?"
+            private const val SELECT_DELETED = "select deleted from telegram_users where external_user_id = ?"
+            private const val COUNT_USERS = "select count(*) from telegram_users where external_user_id = ?"
+            private const val COUNT_CHATS = """
+                select count(*)
+                from telegram_chats c
+                         join telegram_users u on u.id = c.telegram_user_id
+                where u.external_user_id = ?
+            """
+            private const val COUNT_SETTINGS = """
+                select count(*)
+                from notification_settings s
+                         join telegram_users u on u.id = s.telegram_user_id
+                where u.external_user_id = ?
+            """
+        }
+    }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -15,6 +16,7 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.User
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
+import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
 import ru.illine.drinking.ponies.service.message.impl.LocalMessageProvider
 import ru.illine.drinking.ponies.service.notification.impl.NotificationServiceImpl
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
@@ -29,16 +31,19 @@ class NotificationServiceTest {
 
     private lateinit var sender: TelegramClient
     private lateinit var notificationAccessService: NotificationAccessService
+    private lateinit var telegramUserAccessService: TelegramUserAccessService
     private lateinit var service: NotificationService
 
     @BeforeEach
     fun setUp() {
         sender = mock<TelegramClient>()
         notificationAccessService = mock<NotificationAccessService>()
+        telegramUserAccessService = mock<TelegramUserAccessService>()
         service =
             NotificationServiceImpl(
                 sender,
                 notificationAccessService,
+                telegramUserAccessService,
                 LocalMessageProvider(Random(42)),
             )
     }
@@ -69,6 +74,24 @@ class NotificationServiceTest {
         verify(notificationAccessService).save(any(), any(), any())
         verify(notificationAccessService).findNotificationSettingByExternalUserId(externalUserId)
         verify(sender, times(2)).execute(any<SendMessage>())
+    }
+
+    @Test
+    @DisplayName("start(): asks to undo a soft delete before deciding whether the user is new")
+    fun `start restores a soft deleted user before the existence check`() {
+        // Order is the whole point: a soft-deleted row is invisible to the existence check, so
+        // asking afterwards would still take the user for a newcomer and hit the unique index.
+        val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
+        doReturn(true).whenever(notificationAccessService).existsByExternalUserId(externalUserId)
+        whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)
+
+        service.start(buildMessageContext())
+
+        inOrder(telegramUserAccessService, notificationAccessService) {
+            verify(telegramUserAccessService).restoreIfDeleted(externalUserId)
+            verify(notificationAccessService).existsByExternalUserId(externalUserId)
+        }
+        verify(notificationAccessService, never()).save(any(), any(), any())
     }
 
     private fun buildMessageContext(): MessageContext {

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/user/UserAdminServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/user/UserAdminServiceTest.kt
@@ -1,0 +1,176 @@
+package ru.illine.drinking.ponies.service.user
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageRequest
+import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
+import ru.illine.drinking.ponies.dao.repository.AdminUserProjection
+import ru.illine.drinking.ponies.dao.repository.UserCountsProjection
+import ru.illine.drinking.ponies.exception.TelegramUserNotFoundException
+import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
+import ru.illine.drinking.ponies.service.user.impl.UserAdminServiceImpl
+import ru.illine.drinking.ponies.test.tag.UnitTest
+import java.time.LocalDateTime
+
+@UnitTest
+@DisplayName("UserAdminService Unit Test")
+class UserAdminServiceTest {
+    private lateinit var telegramUserAccessService: TelegramUserAccessService
+    private lateinit var userAdminService: UserAdminService
+
+    @BeforeEach
+    fun setUp() {
+        telegramUserAccessService = mock<TelegramUserAccessService>()
+        userAdminService = UserAdminServiceImpl(telegramUserAccessService)
+    }
+
+    @ParameterizedTest(name = "[{index}] search=[{0}]")
+    @NullSource
+    @ValueSource(strings = ["", "   "])
+    @DisplayName("getUsers(): a blank search reaches the DAO as no search, for the page and the counters alike")
+    fun `getUsers normalizes a blank search`(search: String?) {
+        stubEmptyPage()
+
+        userAdminService.getUsers(search, AdminUserStatusFilter.BANNED, page = 1, size = 5)
+
+        verify(telegramUserAccessService).findAllForAdmin(null, AdminUserStatusFilter.BANNED, PageRequest.of(1, 5))
+        // The counters cover every chip of the admin page, so the status must not narrow them down.
+        verify(telegramUserAccessService).countForAdmin(null)
+    }
+
+    @ParameterizedTest(name = "[{index}] search=[{0}] - pattern [{1}]")
+    @CsvSource(
+        "alice,    %alice%",
+        "' alice ', '% alice %'",
+        // LIKE wildcards a user may legitimately type - a Telegram username often carries "_".
+        """alice_p,  '%alice\_p%'""",
+        """50%,      '%50\%%'""",
+        // The escape character itself has to be escaped first, or it would swallow the next one.
+        """'a\b',    '%a\\b%'""",
+    )
+    @DisplayName("getUsers(): wraps a real search in wildcards and escapes the ones the user typed")
+    fun `getUsers wraps and escapes the search`(
+        search: String,
+        pattern: String,
+    ) {
+        stubEmptyPage()
+
+        userAdminService.getUsers(search, AdminUserStatusFilter.ALL, page = 0, size = 20)
+
+        verify(telegramUserAccessService).findAllForAdmin(pattern, AdminUserStatusFilter.ALL, PageRequest.of(0, 20))
+        verify(telegramUserAccessService).countForAdmin(pattern)
+    }
+
+    @ParameterizedTest(name = "[{index}] status={0} - total {1}")
+    @CsvSource(
+        "ALL,      11",
+        "ACTIVE,    8",
+        "INACTIVE,  1",
+        "BANNED,    2",
+    )
+    @DisplayName("getUsers(): total is the counter of the requested status, no extra count query")
+    fun `getUsers takes total from the matching counter`(
+        status: AdminUserStatusFilter,
+        expectedTotal: Long,
+    ) {
+        val counts =
+            mock<UserCountsProjection> {
+                on { all } doReturn 11L
+                on { active } doReturn 8L
+                on { inactive } doReturn 1L
+                on { banned } doReturn 2L
+            }
+        whenever(telegramUserAccessService.findAllForAdmin(anyOrNull(), any(), any())).thenReturn(emptyList())
+        whenever(telegramUserAccessService.countForAdmin(anyOrNull())).thenReturn(counts)
+
+        val response = userAdminService.getUsers(null, status, page = 0, size = 20)
+
+        assertEquals(expectedTotal, response.total)
+        assertEquals(11L, response.counts.all)
+    }
+
+    @Test
+    @DisplayName("updateState(): an empty payload is rejected before the DAO is touched at all")
+    fun `updateState rejects an empty payload`() {
+        assertThrows<IllegalArgumentException> {
+            userAdminService.updateState(USER_ID, isActive = null)
+        }
+
+        verifyNoInteractions(telegramUserAccessService)
+    }
+
+    @Test
+    @DisplayName("updateState(): an unknown user is reported as not found and nothing is written")
+    fun `updateState reports an unknown user`() {
+        whenever(telegramUserAccessService.findByIdForAdmin(USER_ID)).thenReturn(null)
+
+        assertThrows<TelegramUserNotFoundException> {
+            userAdminService.updateState(USER_ID, isActive = false)
+        }
+
+        verify(telegramUserAccessService).findByIdForAdmin(USER_ID)
+        verify(telegramUserAccessService, never()).updateDeleted(any(), any(), any())
+    }
+
+    @ParameterizedTest(name = "[{index}] isActive={0}")
+    @CsvSource("true", "false")
+    @DisplayName("updateState(): writes the flag, answers with it and reads the row only once")
+    fun `updateState answers with the freshly written flag`(isActive: Boolean) {
+        val user =
+            mock<AdminUserProjection> {
+                on { id } doReturn USER_ID
+                on { externalUserId } doReturn EXTERNAL_USER_ID
+                // Stale on purpose - the row still holds the state from before the update,
+                // so an answer built from it alone would report the opposite of the truth.
+                on { deleted } doReturn isActive
+                on { timeZone } doReturn "Europe/Moscow"
+                on { created } doReturn LocalDateTime.of(2026, 1, 1, 10, 0)
+            }
+        whenever(telegramUserAccessService.findByIdForAdmin(USER_ID)).thenReturn(user)
+
+        val response = userAdminService.updateState(USER_ID, isActive)
+
+        assertEquals(isActive, response.isActive)
+        verify(telegramUserAccessService).updateDeleted(USER_ID, EXTERNAL_USER_ID, !isActive)
+        // The card comes from the row already read, so the update must not trigger a second read.
+        verify(telegramUserAccessService, times(1)).findByIdForAdmin(USER_ID)
+    }
+
+    @Test
+    @DisplayName("getUser(): an unknown user is reported as not found")
+    fun `getUser reports an unknown user`() {
+        whenever(telegramUserAccessService.findByIdForAdmin(USER_ID)).thenReturn(null)
+
+        assertThrows<TelegramUserNotFoundException> {
+            userAdminService.getUser(USER_ID)
+        }
+
+        verify(telegramUserAccessService).findByIdForAdmin(USER_ID)
+    }
+
+    private fun stubEmptyPage() {
+        whenever(telegramUserAccessService.findAllForAdmin(anyOrNull(), any(), any())).thenReturn(emptyList())
+        whenever(telegramUserAccessService.countForAdmin(anyOrNull())).thenReturn(mock<UserCountsProjection>())
+    }
+
+    companion object {
+        private const val USER_ID = 1042L
+        private const val EXTERNAL_USER_ID = 482719301L
+    }
+}

--- a/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
@@ -11,6 +11,7 @@ import ru.illine.drinking.ponies.model.dto.StatisticsPointDto
 import ru.illine.drinking.ponies.model.dto.TelegramUserDto
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
+import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfile
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.model.dto.message.InsightStatsContext
 import ru.illine.drinking.ponies.model.dto.request.WaterEntryRequest
@@ -137,6 +138,17 @@ class DtoGenerator {
         ): TelegramUserDto =
             TelegramUserDto(
                 externalUserId = externalUserId,
+                firstName = firstName,
+                lastName = lastName,
+                username = username,
+            )
+
+        fun generateTelegramUserProfile(
+            firstName: String? = "First Name",
+            lastName: String? = null,
+            username: String? = "username",
+        ): TelegramUserProfile =
+            TelegramUserProfile(
                 firstName = firstName,
                 lastName = lastName,
                 username = username,

--- a/src/test/resources/sql/access/NotificationAccessService.sql
+++ b/src/test/resources/sql/access/NotificationAccessService.sql
@@ -15,3 +15,15 @@ values (1, 1, 'TWO_HOURS', now(), 1, true);
 
 insert into notification_settings (telegram_user_id, telegram_chat_id, notification_interval, time_of_last_notification, notification_attempts, enabled)
 values (2, 2, 'TWO_HOURS', now(), 1, false);
+
+-- An admin soft deleted this one while their chat and settings stayed behind. Reading the user
+-- through the lazy association blows up on @SQLRestriction, so the mailing query has to join
+-- instead - which also drops this user out of the result, and that is the wanted behaviour.
+insert into telegram_users (external_user_id, user_time_zone, created, deleted)
+values (3, 'Europe/Moscow', now(), true);
+
+insert into telegram_chats (telegram_user_id, external_chat_id)
+values (3, 3);
+
+insert into notification_settings (telegram_user_id, telegram_chat_id, notification_interval, time_of_last_notification, notification_attempts, enabled)
+values (3, 3, 'TWO_HOURS', now(), 1, true);

--- a/src/test/resources/sql/access/TelegramUserAccessService.sql
+++ b/src/test/resources/sql/access/TelegramUserAccessService.sql
@@ -1,5 +1,41 @@
-insert into telegram_users (external_user_id, user_time_zone, is_admin, created, deleted)
-values (1, 'Europe/Moscow', true, now(), false);
+-- Users are inserted without an explicit id: clear.sql restarts the sequence, so the internal ids
+-- are 1..8 in insert order. From the third user on, the Telegram id is deliberately far away from
+-- the internal one, so a query that confuses the two cannot stay unnoticed.
+insert into telegram_users (external_user_id, user_time_zone, is_admin, is_banned,
+                            first_name, last_name, username, created, deleted)
+values
+    -- id = 1, admin, active
+    (1, 'Europe/Moscow', true, false,
+     'Alisa', 'Petrova', 'alisaadmin', timestamp '2026-01-01 10:00:00', false),
+    -- id = 2, plain active user
+    (2, 'Europe/Moscow', false, false,
+     'Bob', 'Smith', 'bobsmith', timestamp '2026-01-02 11:00:00', false),
+    -- id = 3, soft deleted - has to stay visible for the admin endpoints
+    (777001, 'Asia/Kolkata', false, false,
+     'Carol', 'Ivanova', 'carolgone', timestamp '2026-01-03 12:00:00', true),
+    -- id = 4, banned
+    (777002, 'Europe/Moscow', false, true,
+     'Dave', 'Jones', 'davebanned', timestamp '2026-01-04 13:00:00', false),
+    -- id = 5, active, never answered a notification
+    (777003, 'Europe/Moscow', false, false,
+     'Eve', 'Watson', 'evefresh', timestamp '2026-01-05 14:00:00', false),
+    -- id = 6, banned AND soft deleted: the overlap that makes the mutual exclusion of the
+    -- counters a real assertion instead of one that holds because the data avoids the case.
+    -- A ban wins, so this one belongs to BANNED and must not appear under INACTIVE.
+    (777004, 'Europe/Moscow', false, true,
+     'Frank', 'Miller', 'frankgone', timestamp '2026-01-06 15:00:00', true),
+    -- id = 7 and id = 8, a pair that only an escaped LIKE can tell apart: "_" is a single-character
+    -- wildcard, so an unescaped search for alice_p would match aliceXp as well.
+    (888001, 'Europe/Moscow', false, false,
+     'Alice', 'Pike', 'alice_p', timestamp '2026-01-07 16:00:00', false),
+    (888002, 'Europe/Moscow', false, false,
+     'Alice', 'Xavier', 'aliceXp', timestamp '2026-01-08 17:00:00', false);
 
-insert into telegram_users (external_user_id, user_time_zone, is_admin, created, deleted)
-values (2, 'Europe/Moscow', false, now(), false);
+-- Last activity is the newest YES or SNOOZE. The CANCEL of user 4 must not count, and users 4 to 8
+-- therefore have no last activity at all - they are the ones expected at the tail of the list.
+insert into water_statistics (user_id, event_time, event_type, water_amount_ml)
+values (1, timestamp '2026-03-04 09:00:00', 'SNOOZE', 0),
+       (2, timestamp '2026-03-01 10:00:00', 'YES', 250),
+       (2, timestamp '2026-03-05 08:00:00', 'YES', 300),
+       (3, timestamp '2026-03-06 12:00:00', 'YES', 200),
+       (4, timestamp '2026-03-07 07:00:00', 'CANCEL', 0);

--- a/src/test/resources/sql/scheduler/NotificationScheduler.sql
+++ b/src/test/resources/sql/scheduler/NotificationScheduler.sql
@@ -1,0 +1,22 @@
+-- Two users whose reminders are long overdue against the fixed test clock, so the scheduler is
+-- bound to pick them up. The soft-deleted one is inserted first on purpose: that is the order the
+-- mailing walks them in, so a failure on the hidden row happens before anyone is notified - which
+-- is exactly how one deleted account used to silence the reminders for everybody.
+insert into telegram_users (external_user_id, user_time_zone, created, deleted)
+values (1, 'Europe/Moscow', now(), true);
+
+insert into telegram_users (external_user_id, user_time_zone, created, deleted)
+values (2, 'Europe/Moscow', now(), false);
+
+insert into telegram_chats (telegram_user_id, external_chat_id)
+values (1, 1);
+
+insert into telegram_chats (telegram_user_id, external_chat_id)
+values (2, 2);
+
+-- No quiet mode and zero attempts, so nothing else filters them out of the batch.
+insert into notification_settings (telegram_user_id, telegram_chat_id, notification_interval, time_of_last_notification, notification_attempts, enabled)
+values (1, 1, 'TWO_HOURS', timestamp '2024-01-01 00:00:00', 0, true);
+
+insert into notification_settings (telegram_user_id, telegram_chat_id, notification_interval, time_of_last_notification, notification_attempts, enabled)
+values (2, 2, 'TWO_HOURS', timestamp '2024-01-01 00:00:00', 0, true);


### PR DESCRIPTION
## Summary
- Add an admin API section guarded by `@AdminOnly` on the controller class: `GET /users` (search, status chips, paging, per-status counters), `GET /users/{id}`, `PATCH /users/{id}` for soft delete and restore. Paths use the internal PK, like the existing `/notifications/history/{id}`.
- Store the Telegram profile (first name, last name, username) in `telegram_users` and refresh it on a cache miss of the access flags, so the admin list has names to show.
- Resolve access flags in one place: cache `user-is-admin` renamed to `user-access-flags`, `/users/me` now also returns `isBanned` and `isActive`.
- Liquibase 8.8.0: `is_banned`, profile columns, an `avatar_url` placeholder, and `created` converted to `timestamp` without time zone, storing UTC like every other timestamp in the schema.
- Fix two ways a soft deleted user broke the bot, both reachable only once deletion became possible through the API: `/start` hit the unique index instead of restoring the row, and the mailing batch died on a lazy association hidden by `@SQLRestriction`, silencing reminders for everyone.

## Test plan
- [x] `./gradlew test` - 808 tests green, Postgres via Testcontainers
- [x] `./gradlew lintKotlinMain lintKotlinTest detekt` clean
- [x] both regressions verified by reverting the fix and watching the new tests fail, then restoring
- [x] non-admin gets 403 on every admin endpoint, `/users/me` stays open for them
- [x] every commit compiles on its own
