### PR TITLE
DPTB-229: normalize layer boundaries and dto packages

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -45,6 +45,53 @@ With that, the native `Reformat Code` (Cmd/Ctrl+Alt+L) picks up `ktlint_official
 - **detekt baseline** currently freezes the existing legacy findings (`config/detekt/baseline.xml`). `MaxLineLength` overlaps with ktlint's line-length rule and is a planned follow-up to disable in detekt (ktlint owns line length).
 - Generated KSP/Konvert sources under `build/generated/**` are excluded from ktlint and are not picked up by detekt.
 
+## Code layout
+
+### Packages
+
+| Package | What lives there |
+|---|---|
+| `bot` | Telegram bot entry point |
+| `config` | Spring configuration: caching, properties, web (interceptors, security, exception handler) |
+| `controller` | REST controllers - the only place that knows about the HTTP wire format |
+| `dao/repository` | Spring Data repositories, plus `projection/` (interface projections of native queries) and `query/` (reusable native SQL fragments) |
+| `dao/access` | Persistence-facing services over repositories: mechanics, no business rules |
+| `service` | Business logic, one sub-package per feature (`notification`, `statistic`, `user`, ...) |
+| `mapper` | Konvert mappers, the only place where one model shape is turned into another |
+| `model/entity` | JPA entities |
+| `model/base` | Enums and other shared value types |
+| `model/dto` | Data carriers, see below |
+| `scheduler` | Scheduled jobs |
+| `util` | Helpers and constant holders, grouped by domain (`util/telegram`, `util/water`, ...) |
+| `exception` | Application exceptions |
+
+### Layer boundaries
+
+Every shape stops at its layer:
+
+- `dao/repository` types (entities, projections) do not leave `dao` - the access layer hands out internal DTOs instead.
+- Services take and return DTOs. A service never returns an HTTP response type.
+- The response is assembled in the controller: a Konvert mapper when the shape is non-trivial, the constructor when it is two or three fields copied as is.
+- A request DTO is unpacked in the controller as well - services take named parameters or an internal DTO, never the request type itself.
+
+### DTO packages
+
+Exactly three packages under `model/dto`, no nesting, nothing in the root:
+
+| Package | Contents | Marker |
+|---|---|---|
+| `request` | What the API accepts | `@Schema` + Jackson annotations |
+| `response` | What the API returns | `@Schema` |
+| `internal` | Everything else: dao ↔ service ↔ controller | no serialization annotations at all |
+
+The question to ask is binary: **is the type visible outside over HTTP?** Yes - `request`/`response`. No - `internal`. There is no other place to put it.
+
+Naming: what an endpoint returns carries the `*Response` suffix; a shape nested inside a response has no suffix (`WaterEntry`, `ShortUserInfo`, `UserCounts`). Internal carriers end with `*Dto`, except message contexts, which end with `*Context`.
+
+### Constants
+
+Hardcoded values do not live in services or controllers. Domain constants go to `util/<domain>/<Feature>Constants.kt`; a value that only makes sense inside a single annotation (`@Max(100)`) stays inline.
+
 ## Tests
 
 Test layout, tags and coverage live in [`TESTING.md`](TESTING.md).

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -17,7 +17,6 @@
     <ID>MagicNumber:IntervalNotificationType.kt:IntervalNotificationType.HOUR_AND_HALF$90</ID>
     <ID>MagicNumber:IntervalNotificationType.kt:IntervalNotificationType.THREE_HOURS$180</ID>
     <ID>MagicNumber:IntervalNotificationType.kt:IntervalNotificationType.TWO_HOURS$120</ID>
-    <ID>MagicNumber:NotificationController.kt:NotificationController$300</ID>
     <ID>MagicNumber:NotificationSettingDto.kt:NotificationSettingDto.Companion$11</ID>
     <ID>MagicNumber:NotificationSettingDto.kt:NotificationSettingDto.Companion$23</ID>
     <ID>MagicNumber:PluralizationHelper.kt:PluralizationHelper$10</ID>

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -679,7 +679,9 @@ style:
     ignoreLocalVariableDeclaration: true
     ignoreConstantDeclaration: true
     ignoreCompanionObjectPropertyDeclaration: true
-    ignoreAnnotation: false
+    # A number inside an annotation is a declaration, not a magic value: @Max(100) already
+    # says what 100 means. Naming it costs a constant and reads worse at the call site.
+    ignoreAnnotation: true
     ignoreNamedArgument: true
     ignoreEnums: false
     ignoreRanges: false

--- a/src/main/kotlin/ru/illine/drinking/ponies/bot/DrinkingPoniesTelegramBot.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/bot/DrinkingPoniesTelegramBot.kt
@@ -29,7 +29,6 @@ class DrinkingPoniesTelegramBot(
         InMemoryDBContext(),
         BareboneToggle(),
     ) {
-    // Sentinel: Privacy.CREATOR is no longer used, but creatorId() is abstract in AbilityBot
     override fun creatorId(): Long = 0L
 
     override fun onRegister() {

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/cache/CacheConfig.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/cache/CacheConfig.kt
@@ -21,9 +21,6 @@ class CacheConfig(
         private val ALL_CACHES = listOf(USER_ACCESS_FLAGS, WATER_FIRST_ENTRY)
     }
 
-    // Wraps the underlying Caffeine manager so cache mutations (@CacheEvict, @CachePut) inside a
-    // @Transactional method are deferred until the transaction commits. Without this, an evict
-    // can happen before commit and a concurrent reader may re-cache the stale value.
     @Bean
     fun cacheManager(): CacheManager {
         val target = CaffeineCacheManager()
@@ -40,6 +37,7 @@ class CacheConfig(
                     .build(),
             )
         }
+        // Defers evictions until commit: without it a concurrent reader can re-cache the stale value.
         return TransactionAwareCacheManagerProxy(target)
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptor.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptor.kt
@@ -8,7 +8,7 @@ import org.springframework.web.method.HandlerMethod
 import org.springframework.web.servlet.HandlerInterceptor
 import ru.illine.drinking.ponies.config.web.security.AdminOnly
 import ru.illine.drinking.ponies.config.web.security.AuthErrorType
-import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.request.TelegramInitDataUser
 import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
 
 @Component
@@ -27,7 +27,7 @@ class AdminAuthInterceptor : HandlerInterceptor {
 
         val telegramUser =
             request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)
-                as? TelegramUserDto ?: error("@AdminOnly used on endpoint without TelegramAuthInterceptor")
+                as? TelegramInitDataUser ?: error("@AdminOnly used on endpoint without TelegramAuthInterceptor")
 
         if (telegramUser.isAdmin) {
             return true

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/security/AdminOnly.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/security/AdminOnly.kt
@@ -1,7 +1,5 @@
 package ru.illine.drinking.ponies.config.web.security
 
-// On a class it guards every handler of that controller, so a new admin endpoint cannot
-// be left open by forgetting the annotation. On a function it guards that handler alone.
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class AdminOnly

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/NotificationController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/NotificationController.kt
@@ -20,8 +20,10 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.mapper.NotificationHistoryResponseMapper
+import ru.illine.drinking.ponies.mapper.PauseStateResponseMapper
 import ru.illine.drinking.ponies.model.dto.request.NotificationHistoryEntryRequest
+import ru.illine.drinking.ponies.model.dto.request.TelegramInitDataUser
 import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryEvent
 import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryResponse
 import ru.illine.drinking.ponies.model.dto.response.NotificationNextResponse
@@ -43,7 +45,7 @@ class NotificationController(
     @Operation(summary = "Get next notification time")
     fun getNextNotification(
         @Parameter(hidden = true)
-        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramInitDataUser,
     ): NotificationNextResponse {
         val nextAt = notificationSettingsService.getNextNotificationAt(telegramUser.externalUserId)
         return NotificationNextResponse(nextNotificationAt = nextAt)
@@ -53,15 +55,16 @@ class NotificationController(
     @Operation(summary = "Get notification pause state")
     fun getPauseState(
         @Parameter(hidden = true)
-        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
-    ): PauseStateResponse = notificationSettingsService.getPauseState(telegramUser.externalUserId)
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramInitDataUser,
+    ): PauseStateResponse =
+        PauseStateResponseMapper.toResponse(notificationSettingsService.getPauseState(telegramUser.externalUserId))
 
     @PutMapping("/pause")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "Pause or cancel pause for notifications")
     fun changePause(
         @Parameter(hidden = true)
-        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramInitDataUser,
         @Parameter(description = "Pause duration in minutes (0 = cancel pause, max 300 = 5 hours)", example = "60")
         @RequestParam(name = "minutes", required = true)
         @Min(0)
@@ -78,7 +81,7 @@ class NotificationController(
     @Operation(summary = "Get the notification journal for the requested period")
     fun getHistory(
         @Parameter(hidden = true)
-        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramInitDataUser,
         @Parameter(
             description = "Range start (inclusive) in yyyy-MM-dd format, in the user's timezone",
             example = "2026-05-01",
@@ -93,21 +96,26 @@ class NotificationController(
         )
         @RequestParam(name = "to", required = true)
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
-    ): NotificationHistoryResponse = notificationHistoryService.getHistory(telegramUser.externalUserId, from, to)
+    ): NotificationHistoryResponse =
+        NotificationHistoryResponseMapper.toResponse(
+            notificationHistoryService.getHistory(telegramUser.externalUserId, from, to),
+        )
 
     @PatchMapping("/history/{id}")
     @Operation(summary = "Update a notification journal entry")
     fun updateHistoryEntry(
         @Parameter(hidden = true)
-        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramInitDataUser,
         @Parameter(description = "Journal entry identifier", example = "1042")
         @PathVariable(name = "id") id: Long,
         @Valid @RequestBody request: NotificationHistoryEntryRequest,
     ): NotificationHistoryEvent =
-        notificationHistoryService.updateEntry(
-            externalUserId = telegramUser.externalUserId,
-            entryId = id,
-            status = request.status,
-            amountMl = request.amountMl,
+        NotificationHistoryResponseMapper.toEvent(
+            notificationHistoryService.updateEntry(
+                externalUserId = telegramUser.externalUserId,
+                entryId = id,
+                status = request.status,
+                amountMl = request.amountMl,
+            ),
         )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/SettingController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/SettingController.kt
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import ru.illine.drinking.ponies.mapper.SettingResponseMapper
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
-import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.request.TelegramInitDataUser
 import ru.illine.drinking.ponies.model.dto.response.SettingResponse
 import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
@@ -31,7 +31,7 @@ class SettingController(
     @Operation(summary = "Get all notification settings")
     fun getSettings(
         @Parameter(hidden = true)
-        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramInitDataUser,
     ): SettingResponse {
         val settings = notificationSettingsService.getAllSettings(telegramUser.externalUserId)
         return SettingResponseMapper.toResponse(settings)
@@ -42,7 +42,7 @@ class SettingController(
     @Operation(summary = "Change quiet mode schedule")
     fun changeQuietMode(
         @Parameter(hidden = true)
-        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramInitDataUser,
         @Parameter(
             description = "Start time in HH:mm format",
             example = "23:00",
@@ -66,7 +66,7 @@ class SettingController(
     @Operation(summary = "Change user timezone")
     fun changeTimezone(
         @Parameter(hidden = true)
-        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramInitDataUser,
         @Parameter(description = "IANA timezone identifier", example = "Europe/Moscow")
         @RequestParam(name = "timezone", required = true) timezone: String,
     ) {
@@ -78,7 +78,7 @@ class SettingController(
     @Operation(summary = "Change notification interval")
     fun changeInterval(
         @Parameter(hidden = true)
-        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramInitDataUser,
         @Parameter(description = "Notification interval enum value", example = "HOUR")
         @RequestParam(name = "interval", required = true) interval: IntervalNotificationType,
     ) {
@@ -90,7 +90,7 @@ class SettingController(
     @Operation(summary = "Change notification enabled status")
     fun changeNotificationStatus(
         @Parameter(hidden = true)
-        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramInitDataUser,
         @Parameter(description = "Enable or disable notifications", example = "true")
         @RequestParam(name = "active", required = true) active: Boolean,
     ) {
@@ -102,7 +102,7 @@ class SettingController(
     @Operation(summary = "Change daily water intake goal")
     fun changeDailyGoal(
         @Parameter(hidden = true)
-        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramInitDataUser,
         @Parameter(
             description = "Daily goal in milliliters. Allowed values: 2000, 2250, 2500, 2750, 3000",
             example = "2000",

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/StatisticsController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/StatisticsController.kt
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import ru.illine.drinking.ponies.mapper.StatisticsMapper
 import ru.illine.drinking.ponies.mapper.WaterStatisticMapper
-import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.request.TelegramInitDataUser
 import ru.illine.drinking.ponies.model.dto.request.WaterEntryRequest
 import ru.illine.drinking.ponies.model.dto.response.StatisticsResponse
 import ru.illine.drinking.ponies.model.dto.response.StatisticsTodayResponse
@@ -39,7 +39,7 @@ class StatisticsController(
     @Operation(summary = "Get today's water intake events")
     fun getToday(
         @Parameter(hidden = true)
-        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramInitDataUser,
     ): StatisticsTodayResponse {
         val entries = statisticsService.getToday(telegramUser.externalUserId)
         return StatisticsTodayResponse(
@@ -51,7 +51,7 @@ class StatisticsController(
     @Operation(summary = "Get aggregated statistics for the requested period")
     fun getStatistics(
         @Parameter(hidden = true)
-        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramInitDataUser,
         @Parameter(
             description = "Range start (inclusive) in yyyy-MM-dd format",
             example = "2026-05-01",
@@ -74,7 +74,7 @@ class StatisticsController(
     @Operation(summary = "Record a manual water intake entry at an arbitrary time")
     fun recordWaterEntry(
         @Parameter(hidden = true)
-        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramInitDataUser,
         @Valid @RequestBody request: WaterEntryRequest,
     ) {
         waterStatisticService.manualRecordEvent(

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/UserAdminController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/UserAdminController.kt
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import ru.illine.drinking.ponies.config.web.security.AdminOnly
+import ru.illine.drinking.ponies.mapper.AdminUserResponseMapper
 import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
+import ru.illine.drinking.ponies.model.dto.internal.UserStateDto
 import ru.illine.drinking.ponies.model.dto.request.UserStateRequest
 import ru.illine.drinking.ponies.model.dto.response.UserDetailsResponse
 import ru.illine.drinking.ponies.model.dto.response.UsersResponse
 import ru.illine.drinking.ponies.service.user.UserAdminService
 
-// Shares the /users path with UserController on purpose: same resource, different audience.
-// @AdminOnly sits on the class so a new endpoint here is closed by default.
 @RestController
 @RequestMapping("/users")
 @Validated
@@ -44,16 +44,16 @@ class UserAdminController(
         @Parameter(description = "Page size", example = "20")
         @RequestParam(name = "size", required = false, defaultValue = "20")
         @Min(1)
-        @Max(MAX_PAGE_SIZE)
+        @Max(100)
         size: Int,
-    ): UsersResponse = userAdminService.getUsers(search, status, page, size)
+    ): UsersResponse = AdminUserResponseMapper.toResponse(userAdminService.getUsers(search, status, page, size))
 
     @GetMapping("/{id}")
     @Operation(summary = "Get a single user card")
     fun getUser(
         @Parameter(description = "Internal user id", example = "1042")
         @PathVariable(name = "id") id: Long,
-    ): UserDetailsResponse = userAdminService.getUser(id)
+    ): UserDetailsResponse = AdminUserResponseMapper.toDetails(userAdminService.getUser(id))
 
     @PatchMapping("/{id}")
     @Operation(summary = "Update user state: soft delete or restore")
@@ -61,9 +61,9 @@ class UserAdminController(
         @Parameter(description = "Internal user id", example = "1042")
         @PathVariable(name = "id") id: Long,
         @Valid @RequestBody request: UserStateRequest,
-    ): UserDetailsResponse = userAdminService.updateState(id, request.isActive)
+    ): UserDetailsResponse {
+        val state = UserStateDto(isActive = request.isActive)
 
-    companion object {
-        private const val MAX_PAGE_SIZE = 100L
+        return AdminUserResponseMapper.toDetails(userAdminService.updateState(id, state))
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/UserController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/UserController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.request.TelegramInitDataUser
 import ru.illine.drinking.ponies.model.dto.response.MeResponse
 import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
 
@@ -19,7 +19,7 @@ class UserController {
     @Operation(summary = "Get current user identity")
     fun getMe(
         @Parameter(hidden = true)
-        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramUserDto,
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) telegramUser: TelegramInitDataUser,
     ): MeResponse =
         MeResponse(
             externalUserId = telegramUser.externalUserId,

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessService.kt
@@ -1,11 +1,11 @@
 package ru.illine.drinking.ponies.dao.access
 
 import org.springframework.data.domain.Pageable
-import ru.illine.drinking.ponies.dao.repository.AdminUserProjection
-import ru.illine.drinking.ponies.dao.repository.UserCountsProjection
 import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
+import ru.illine.drinking.ponies.model.dto.internal.AdminUserDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfile
 import ru.illine.drinking.ponies.model.dto.internal.UserAccessDto
+import ru.illine.drinking.ponies.model.dto.internal.UserCountsDto
 
 interface TelegramUserAccessService {
     fun resolveAccessFlags(
@@ -17,18 +17,17 @@ interface TelegramUserAccessService {
         search: String?,
         status: AdminUserStatusFilter,
         pageable: Pageable,
-    ): List<AdminUserProjection>
+    ): List<AdminUserDto>
 
-    fun findByIdForAdmin(id: Long): AdminUserProjection?
+    fun findByIdForAdmin(id: Long): AdminUserDto?
 
-    fun countForAdmin(search: String?): UserCountsProjection
+    fun countForAdmin(search: String?): UserCountsDto
 
-    fun updateDeleted(
+    fun updateState(
         id: Long,
         externalUserId: Long,
-        deleted: Boolean,
+        deleted: Boolean?,
     )
 
-    // Returns true when the user was soft-deleted and has just been brought back.
     fun restoreIfDeleted(externalUserId: Long): Boolean
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
@@ -99,8 +99,6 @@ class NotificationAccessServiceImpl(
         val settings = requireSettings(externalUserId)
 
         if (settings.notificationInterval != notificationInterval) {
-            // Reset timer so the new interval counts from now, not from the last notification time.
-            // Also clear active pause - changing interval implicitly cancels the pause.
             settings
                 .apply {
                     this.notificationInterval = notificationInterval
@@ -229,11 +227,9 @@ class NotificationAccessServiceImpl(
         return setting
             .apply {
                 if (pauseUntil != null) {
-                    // Pause: shift timeOfLastNotification so scheduler stays silent until pauseUntil.
                     this.pauseUntil = pauseUntil
                     this.timeOfLastNotification = pauseUntil.minusMinutes(setting.notificationInterval.minutes)
                 } else {
-                    // Cancel: reset timer only if there was an active pause to cancel.
                     val hadActivePause = this.pauseUntil?.isAfter(now) == true
                     this.pauseUntil = null
                     if (hadActivePause) {

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/TelegramUserAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/TelegramUserAccessServiceImpl.kt
@@ -8,12 +8,13 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import ru.illine.drinking.ponies.config.cache.CacheConfig
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
-import ru.illine.drinking.ponies.dao.repository.AdminUserProjection
 import ru.illine.drinking.ponies.dao.repository.TelegramUserRepository
-import ru.illine.drinking.ponies.dao.repository.UserCountsProjection
+import ru.illine.drinking.ponies.mapper.AdminUserMapper
 import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
+import ru.illine.drinking.ponies.model.dto.internal.AdminUserDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfile
 import ru.illine.drinking.ponies.model.dto.internal.UserAccessDto
+import ru.illine.drinking.ponies.model.dto.internal.UserCountsDto
 import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 
 @Service
@@ -22,8 +23,6 @@ class TelegramUserAccessServiceImpl(
 ) : TelegramUserAccessService {
     private val logger = LoggerFactory.getLogger("ACCESS-SERVICE")
 
-    // Whatever changes these flags has to evict this cache by externalUserId,
-    // otherwise the change only takes effect once the entry expires - see updateDeleted below.
     @Transactional
     @Cacheable(CacheConfig.USER_ACCESS_FLAGS, key = "#externalUserId")
     override fun resolveAccessFlags(
@@ -44,36 +43,38 @@ class TelegramUserAccessServiceImpl(
         search: String?,
         status: AdminUserStatusFilter,
         pageable: Pageable,
-    ): List<AdminUserProjection> {
+    ): List<AdminUserDto> {
         logger.debug("Listing users for admin: search={}, status={}, page={}", search, status, pageable.pageNumber)
 
-        return telegramUserRepository.findAllForAdmin(search, status.deleted, status.banned, pageable)
+        return telegramUserRepository
+            .findAllForAdmin(search, status.deleted, status.banned, pageable)
+            .map { AdminUserMapper.toDto(it) }
     }
 
     @Transactional(readOnly = true)
-    override fun findByIdForAdmin(id: Long): AdminUserProjection? {
+    override fun findByIdForAdmin(id: Long): AdminUserDto? {
         logger.debug("Loading user [{}] for admin", id)
 
-        return telegramUserRepository.findByIdForAdmin(id)
+        return telegramUserRepository.findByIdForAdmin(id)?.let { AdminUserMapper.toDto(it) }
     }
 
     @Transactional(readOnly = true)
-    override fun countForAdmin(search: String?): UserCountsProjection {
+    override fun countForAdmin(search: String?): UserCountsDto {
         logger.debug("Counting users for admin: search={}", search)
 
-        return telegramUserRepository.countForAdmin(search)
+        return AdminUserMapper.toCounts(telegramUserRepository.countForAdmin(search))
     }
 
     @Transactional
     @CacheEvict(CacheConfig.USER_ACCESS_FLAGS, key = "#externalUserId")
-    override fun updateDeleted(
+    override fun updateState(
         id: Long,
         externalUserId: Long,
-        deleted: Boolean,
+        deleted: Boolean?,
     ) {
         logger.debug("Setting deleted={} for user [{}]", deleted, id)
 
-        telegramUserRepository.updateDeleted(id, deleted)
+        telegramUserRepository.updateState(id, deleted)
     }
 
     @Transactional
@@ -87,14 +88,10 @@ class TelegramUserAccessServiceImpl(
         return restored
     }
 
-    // Called on a cache miss only, so the profile is refreshed at most once per cache TTL
-    // instead of on every request. Dirty checking flushes the change on commit.
     private fun refreshProfile(
         user: TelegramUserEntity,
         profile: TelegramUserProfile,
     ) {
-        // Telegram always sends firstName for a real user; an empty profile means the caller has
-        // nothing to offer, and overwriting the stored one with nulls would lose data.
         if (profile.firstName == null) return
 
         if (user.matches(profile)) return

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/NotificationSettingRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/NotificationSettingRepository.kt
@@ -8,15 +8,9 @@ import ru.illine.drinking.ponies.model.entity.NotificationSettingEntity
 import java.time.LocalTime
 
 interface NotificationSettingRepository : JpaRepository<NotificationSettingEntity, Long> {
-    // Spring Data derived query: the underscore explicitly resolves the nested property path
-    // telegramUser.externalUserId. Renaming it would break query derivation, so the ktlint
-    // naming rule is suppressed here intentionally.
     @Suppress("ktlint:standard:function-naming")
     fun findByTelegramUser_ExternalUserId(externalUserId: Long): NotificationSettingEntity?
 
-    // The join is what keeps a soft-deleted user out of the mailing: @SQLRestriction(deleted = false)
-    // applies to the joined entity, so their settings drop out of the result entirely. Reading the
-    // association lazily instead would blow up on the hidden row and take the whole batch down.
     @Query(
         value = """
             select ns from NotificationSettingEntity ns

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/TelegramUserRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/TelegramUserRepository.kt
@@ -5,47 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import ru.illine.drinking.ponies.dao.repository.projection.AdminUserProjection
+import ru.illine.drinking.ponies.dao.repository.projection.UserCountsProjection
+import ru.illine.drinking.ponies.dao.repository.query.TelegramUserQuery.ADMIN_USER_SELECT
+import ru.illine.drinking.ponies.dao.repository.query.TelegramUserQuery.SEARCH_FILTER
 import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
-
-// The admin queries below are native on purpose: @SQLRestriction(deleted = false) hides soft-deleted
-// users from every JPQL query, and the admin list is the one place that has to see them.
-private const val ADMIN_USER_SELECT = """
-    select u.id               as "id",
-           u.external_user_id as "externalUserId",
-           u.first_name       as "firstName",
-           u.last_name        as "lastName",
-           u.username         as "username",
-           u.is_admin         as "admin",
-           u.is_banned        as "banned",
-           u.deleted          as "deleted",
-           u.user_time_zone   as "timeZone",
-           u.created          as "created",
-           (
-               select max(ws.event_time)
-               from water_statistics ws
-               where ws.user_id = u.id
-                 and ws.event_type in ('YES', 'SNOOZE')
-           )                  as "lastActivity"
-    from telegram_users u
-"""
-
-// The caller passes the pattern already wrapped in wildcards and escaped, or null for "no search".
-// Casts keep Postgres from complaining that it cannot infer the type of a null parameter.
-private const val SEARCH_FILTER = """
-    (
-        cast(:search as text) is null
-        or concat_ws(' ', u.first_name, u.last_name, u.username, u.external_user_id, u.id)
-               ilike cast(:search as text) escape '\'
-    )
-"""
-
-// Nulls come from AdminUserStatusFilter and mean "this column is not constrained".
-private const val STATUS_FILTER = """
-    (
-        (cast(:deleted as boolean) is null or u.deleted = cast(:deleted as boolean))
-        and (cast(:banned as boolean) is null or u.is_banned = cast(:banned as boolean))
-    )
-"""
 
 interface TelegramUserRepository : JpaRepository<TelegramUserEntity, Long> {
     fun findByExternalUserId(externalUserId: Long): TelegramUserEntity?
@@ -54,19 +18,19 @@ interface TelegramUserRepository : JpaRepository<TelegramUserEntity, Long> {
 
     fun existsByExternalUserId(externalUserId: Long): Boolean
 
-    // Native, so that @SQLRestriction does not hide a soft-deleted user from the auth path:
-    // the entity still comes back managed, so profile refresh keeps working through dirty checking.
     @Query(value = "select * from telegram_users u where u.external_user_id = :externalUserId", nativeQuery = true)
     fun findByExternalUserIdIncludingDeleted(
         @Param("externalUserId") externalUserId: Long,
     ): TelegramUserEntity?
 
-    // No countQuery: the total for any status is already one of the columns of countForAdmin.
     @Query(
         value = """
             $ADMIN_USER_SELECT
             where $SEARCH_FILTER
-              and $STATUS_FILTER
+              and (
+                  (cast(:deleted as boolean) is null or u.deleted = cast(:deleted as boolean))
+                  and (cast(:banned as boolean) is null or u.is_banned = cast(:banned as boolean))
+              )
             order by "lastActivity" desc nulls last, u.id
         """,
         nativeQuery = true,
@@ -99,15 +63,19 @@ interface TelegramUserRepository : JpaRepository<TelegramUserEntity, Long> {
     ): UserCountsProjection
 
     @Modifying(clearAutomatically = true)
-    @Query(value = "update telegram_users set deleted = :deleted where id = :id", nativeQuery = true)
-    fun updateDeleted(
+    @Query(
+        value = """
+            update telegram_users
+            set deleted = coalesce(cast(:deleted as boolean), deleted)
+            where id = :id
+        """,
+        nativeQuery = true,
+    )
+    fun updateState(
         @Param("id") id: Long,
-        @Param("deleted") deleted: Boolean,
+        @Param("deleted") deleted: Boolean?,
     )
 
-    // Native for the same reason: a soft-deleted user is invisible to derived queries, so /start
-    // would take them for a newcomer and hit the unique index on external_user_id.
-    // Returns 0 when there was nothing to restore.
     @Modifying(clearAutomatically = true)
     @Query(
         value = """

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/projection/AdminUserProjection.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/projection/AdminUserProjection.kt
@@ -1,9 +1,7 @@
-package ru.illine.drinking.ponies.dao.repository
+package ru.illine.drinking.ponies.dao.repository.projection
 
 import java.time.LocalDateTime
 
-// Property names must match the aliases of the native query - hence admin/banned
-// instead of isAdmin/isBanned, an "is" prefix would rename the getter.
 interface AdminUserProjection {
     val id: Long
     val externalUserId: Long
@@ -16,11 +14,4 @@ interface AdminUserProjection {
     val timeZone: String
     val created: LocalDateTime
     val lastActivity: LocalDateTime?
-}
-
-interface UserCountsProjection {
-    val all: Long
-    val active: Long
-    val inactive: Long
-    val banned: Long
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/projection/UserCountsProjection.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/projection/UserCountsProjection.kt
@@ -1,0 +1,8 @@
+package ru.illine.drinking.ponies.dao.repository.projection
+
+interface UserCountsProjection {
+    val all: Long
+    val active: Long
+    val inactive: Long
+    val banned: Long
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/query/TelegramUserQuery.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/query/TelegramUserQuery.kt
@@ -1,0 +1,31 @@
+package ru.illine.drinking.ponies.dao.repository.query
+
+object TelegramUserQuery {
+    const val ADMIN_USER_SELECT = """
+        select u.id               as "id",
+               u.external_user_id as "externalUserId",
+               u.first_name       as "firstName",
+               u.last_name        as "lastName",
+               u.username         as "username",
+               u.is_admin         as "admin",
+               u.is_banned        as "banned",
+               u.deleted          as "deleted",
+               u.user_time_zone   as "timeZone",
+               u.created          as "created",
+               (
+                   select max(ws.event_time)
+                   from water_statistics ws
+                   where ws.user_id = u.id
+                     and ws.event_type in ('YES', 'SNOOZE')
+               )                  as "lastActivity"
+        from telegram_users u
+    """
+
+    const val SEARCH_FILTER = """
+        (
+            cast(:search as text) is null
+            or concat_ws(' ', u.first_name, u.last_name, u.username, u.external_user_id, u.id)
+                   ilike cast(:search as text) escape '\'
+        )
+    """
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/AdminUserMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/AdminUserMapper.kt
@@ -1,0 +1,24 @@
+package ru.illine.drinking.ponies.mapper
+
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Mapping
+import ru.illine.drinking.ponies.dao.repository.projection.AdminUserProjection
+import ru.illine.drinking.ponies.dao.repository.projection.UserCountsProjection
+import ru.illine.drinking.ponies.model.dto.internal.AdminUserDto
+import ru.illine.drinking.ponies.model.dto.internal.UserCountsDto
+
+@Konverter
+interface AdminUserMapper {
+    @Konvert(
+        mappings = [
+            Mapping(source = "admin", target = "isAdmin"),
+            Mapping(source = "banned", target = "isBanned"),
+        ],
+    )
+    fun toDto(projection: AdminUserProjection): AdminUserDto
+
+    fun toCounts(projection: UserCountsProjection): UserCountsDto
+
+    companion object : AdminUserMapper by Konverter.get<AdminUserMapper>()
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/AdminUserResponseMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/AdminUserResponseMapper.kt
@@ -1,0 +1,38 @@
+package ru.illine.drinking.ponies.mapper
+
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Mapping
+import ru.illine.drinking.ponies.model.dto.internal.AdminUserDto
+import ru.illine.drinking.ponies.model.dto.internal.AdminUserPageDto
+import ru.illine.drinking.ponies.model.dto.internal.UserCountsDto
+import ru.illine.drinking.ponies.model.dto.response.ShortUserInfo
+import ru.illine.drinking.ponies.model.dto.response.UserCounts
+import ru.illine.drinking.ponies.model.dto.response.UserDetailsResponse
+import ru.illine.drinking.ponies.model.dto.response.UsersResponse
+
+@Konverter
+interface AdminUserResponseMapper {
+    fun toResponse(dto: AdminUserPageDto): UsersResponse
+
+    fun toCounts(dto: UserCountsDto): UserCounts
+
+    @Konvert(
+        mappings = [
+            Mapping(target = "isActive", expression = "!it.deleted"),
+            Mapping(target = "lastActivity", expression = "it.lastActivity?.toInstant(java.time.ZoneOffset.UTC)"),
+        ],
+    )
+    fun toShortUserInfo(dto: AdminUserDto): ShortUserInfo
+
+    @Konvert(
+        mappings = [
+            Mapping(target = "isActive", expression = "!it.deleted"),
+            Mapping(target = "lastActivity", expression = "it.lastActivity?.toInstant(java.time.ZoneOffset.UTC)"),
+            Mapping(target = "registeredAt", expression = "it.created.toInstant(java.time.ZoneOffset.UTC)"),
+        ],
+    )
+    fun toDetails(dto: AdminUserDto): UserDetailsResponse
+
+    companion object : AdminUserResponseMapper by Konverter.get<AdminUserResponseMapper>()
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/NotificationHistoryResponseMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/NotificationHistoryResponseMapper.kt
@@ -1,0 +1,20 @@
+package ru.illine.drinking.ponies.mapper
+
+import io.mcarle.konvert.api.Konverter
+import ru.illine.drinking.ponies.model.dto.internal.NotificationHistoryDayDto
+import ru.illine.drinking.ponies.model.dto.internal.NotificationHistoryDto
+import ru.illine.drinking.ponies.model.dto.internal.NotificationHistoryEventDto
+import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryDay
+import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryEvent
+import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryResponse
+
+@Konverter
+interface NotificationHistoryResponseMapper {
+    fun toResponse(dto: NotificationHistoryDto): NotificationHistoryResponse
+
+    fun toDay(dto: NotificationHistoryDayDto): NotificationHistoryDay
+
+    fun toEvent(dto: NotificationHistoryEventDto): NotificationHistoryEvent
+
+    companion object : NotificationHistoryResponseMapper by Konverter.get<NotificationHistoryResponseMapper>()
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/PauseStateResponseMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/PauseStateResponseMapper.kt
@@ -1,0 +1,12 @@
+package ru.illine.drinking.ponies.mapper
+
+import io.mcarle.konvert.api.Konverter
+import ru.illine.drinking.ponies.model.dto.internal.PauseStateDto
+import ru.illine.drinking.ponies.model.dto.response.PauseStateResponse
+
+@Konverter
+interface PauseStateResponseMapper {
+    fun toResponse(dto: PauseStateDto): PauseStateResponse
+
+    companion object : PauseStateResponseMapper by Konverter.get<PauseStateResponseMapper>()
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/SettingMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/SettingMapper.kt
@@ -1,15 +1,9 @@
 package ru.illine.drinking.ponies.mapper
 
-import ru.illine.drinking.ponies.model.dto.SettingDto
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
+import ru.illine.drinking.ponies.model.dto.internal.SettingDto
 import ru.illine.drinking.ponies.util.TimeHelper
 
-// Intentionally hand-written, not migrated to Konvert (DPTB-136): this is a presentation
-// transformation, not a structural mapping - the interval enum is expanded into three fields,
-// LocalTime is formatted to String, and timezone is read from a nested object. Konvert would
-// express all of this as @Mapping(expression=...), which it does not verify, giving no real
-// safety over this named-constructor form. Correctness is guarded by
-// NotificationSettingsServiceTest."getAllSettings returns full dto when enabled", which asserts every field.
 object SettingMapper {
     fun toDto(settings: NotificationSettingDto): SettingDto =
         SettingDto(

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/SettingResponseMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/SettingResponseMapper.kt
@@ -1,7 +1,7 @@
 package ru.illine.drinking.ponies.mapper
 
 import io.mcarle.konvert.api.Konverter
-import ru.illine.drinking.ponies.model.dto.SettingDto
+import ru.illine.drinking.ponies.model.dto.internal.SettingDto
 import ru.illine.drinking.ponies.model.dto.response.SettingResponse
 
 @Konverter

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/StatisticsMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/StatisticsMapper.kt
@@ -3,9 +3,9 @@ package ru.illine.drinking.ponies.mapper
 import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Konverter
 import io.mcarle.konvert.api.Mapping
-import ru.illine.drinking.ponies.model.dto.BestDayDto
-import ru.illine.drinking.ponies.model.dto.StatisticsDto
-import ru.illine.drinking.ponies.model.dto.StatisticsPointDto
+import ru.illine.drinking.ponies.model.dto.internal.BestDayDto
+import ru.illine.drinking.ponies.model.dto.internal.StatisticsDto
+import ru.illine.drinking.ponies.model.dto.internal.StatisticsPointDto
 import ru.illine.drinking.ponies.model.dto.response.BestDayInfo
 import ru.illine.drinking.ponies.model.dto.response.StatisticsPoint
 import ru.illine.drinking.ponies.model.dto.response.StatisticsResponse

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/base/AdminUserStatusFilter.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/base/AdminUserStatusFilter.kt
@@ -1,8 +1,5 @@
 package ru.illine.drinking.ponies.model.base
 
-// Categories are mutually exclusive, so the counters add up to ALL: a ban wins over everything
-// else, so a user who is both banned and deleted counts as BANNED only.
-// Null means the column is not constrained.
 enum class AdminUserStatusFilter(
     val deleted: Boolean?,
     val banned: Boolean?,

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/base/NotificationHistoryStatus.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/base/NotificationHistoryStatus.kt
@@ -8,7 +8,6 @@ enum class NotificationHistoryStatus(
     ;
 
     companion object {
-        // Event types without a status here are not journal entries at all: SNOOZE is such a case.
         fun of(eventType: AnswerNotificationType): NotificationHistoryStatus? =
             entries.find { it.eventType == eventType }
     }

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/AdminUserDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/AdminUserDto.kt
@@ -1,0 +1,17 @@
+package ru.illine.drinking.ponies.model.dto.internal
+
+import java.time.LocalDateTime
+
+data class AdminUserDto(
+    val id: Long,
+    val externalUserId: Long,
+    val firstName: String?,
+    val lastName: String?,
+    val username: String?,
+    val isAdmin: Boolean,
+    val isBanned: Boolean,
+    val deleted: Boolean,
+    val timeZone: String,
+    val created: LocalDateTime,
+    val lastActivity: LocalDateTime?,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/AdminUserPageDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/AdminUserPageDto.kt
@@ -1,0 +1,9 @@
+package ru.illine.drinking.ponies.model.dto.internal
+
+data class AdminUserPageDto(
+    val users: List<AdminUserDto>,
+    val page: Int,
+    val size: Int,
+    val total: Long,
+    val counts: UserCountsDto,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/BestDayDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/BestDayDto.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.model.dto
+package ru.illine.drinking.ponies.model.dto.internal
 
 import java.time.DayOfWeek
 import java.time.LocalDate

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/DefaultSettingsContext.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/DefaultSettingsContext.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.model.dto.message
+package ru.illine.drinking.ponies.model.dto.internal
 
 data class DefaultSettingsContext(
     val intervalDisplayName: String,

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/GreetingContext.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/GreetingContext.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.model.dto.message
+package ru.illine.drinking.ponies.model.dto.internal
 
 data class GreetingContext(
     val userName: String,

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/InsightDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/InsightDto.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.model.dto
+package ru.illine.drinking.ponies.model.dto.internal
 
 data class InsightDto(
     val currentStreakDays: Int,

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/InsightStatsContext.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/InsightStatsContext.kt
@@ -1,6 +1,4 @@
-package ru.illine.drinking.ponies.model.dto.message
-
-import ru.illine.drinking.ponies.model.dto.BestDayDto
+package ru.illine.drinking.ponies.model.dto.internal
 
 data class InsightStatsContext(
     val avgMlPerDay: Int,

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/MessageContext.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/MessageContext.kt
@@ -1,0 +1,3 @@
+package ru.illine.drinking.ponies.model.dto.internal
+
+interface MessageContext

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/MessageDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/MessageDto.kt
@@ -1,0 +1,5 @@
+package ru.illine.drinking.ponies.model.dto.internal
+
+data class MessageDto(
+    val text: String,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/NoContext.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/NoContext.kt
@@ -1,0 +1,3 @@
+package ru.illine.drinking.ponies.model.dto.internal
+
+object NoContext : MessageContext

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/NotificationHistoryDayDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/NotificationHistoryDayDto.kt
@@ -1,0 +1,8 @@
+package ru.illine.drinking.ponies.model.dto.internal
+
+import java.time.LocalDate
+
+data class NotificationHistoryDayDto(
+    val date: LocalDate,
+    val events: List<NotificationHistoryEventDto>,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/NotificationHistoryDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/NotificationHistoryDto.kt
@@ -1,0 +1,5 @@
+package ru.illine.drinking.ponies.model.dto.internal
+
+data class NotificationHistoryDto(
+    val days: List<NotificationHistoryDayDto>,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/NotificationHistoryEventDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/NotificationHistoryEventDto.kt
@@ -1,0 +1,14 @@
+package ru.illine.drinking.ponies.model.dto.internal
+
+import ru.illine.drinking.ponies.model.base.NotificationHistoryStatus
+import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
+import java.time.Instant
+
+data class NotificationHistoryEventDto(
+    val id: Long,
+    val eventTime: Instant,
+    val status: NotificationHistoryStatus,
+    val amountMl: Int,
+    val source: WaterEntrySourceType,
+    val editable: Boolean,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/NotificationQuestionEditedContext.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/NotificationQuestionEditedContext.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.model.dto.message
+package ru.illine.drinking.ponies.model.dto.internal
 
 data class NotificationQuestionEditedContext(
     val answerDisplayName: String,

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/NotificationSuspendContext.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/NotificationSuspendContext.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.model.dto.message
+package ru.illine.drinking.ponies.model.dto.internal
 
 data class NotificationSuspendContext(
     val durationDisplayName: String,

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/PauseStateDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/PauseStateDto.kt
@@ -1,0 +1,8 @@
+package ru.illine.drinking.ponies.model.dto.internal
+
+import java.time.Instant
+
+data class PauseStateDto(
+    val paused: Boolean,
+    val pauseUntil: Instant? = null,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/SettingDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/SettingDto.kt
@@ -1,8 +1,5 @@
-package ru.illine.drinking.ponies.model.dto
+package ru.illine.drinking.ponies.model.dto.internal
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-
-@JsonIgnoreProperties(ignoreUnknown = true)
 data class SettingDto(
     val interval: String? = null,
     val intervalDisplayName: String? = null,

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/StatisticsDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/StatisticsDto.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.model.dto
+package ru.illine.drinking.ponies.model.dto.internal
 
 import java.time.Instant
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/StatisticsPointDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/StatisticsPointDto.kt
@@ -1,4 +1,4 @@
-package ru.illine.drinking.ponies.model.dto
+package ru.illine.drinking.ponies.model.dto.internal
 
 data class StatisticsPointDto(
     val label: String,

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserAccessDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserAccessDto.kt
@@ -1,7 +1,5 @@
 package ru.illine.drinking.ponies.model.dto.internal
 
-// isDeleted is admin-facing state, not a gate: nothing denies access by it. A soft deleted user
-// keeps working and is brought back by /start; blocking belongs to the ban feature.
 data class UserAccessDto(
     val isAdmin: Boolean = false,
     val isBanned: Boolean = false,

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserCountsDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserCountsDto.kt
@@ -1,0 +1,8 @@
+package ru.illine.drinking.ponies.model.dto.internal
+
+data class UserCountsDto(
+    val all: Long,
+    val active: Long,
+    val inactive: Long,
+    val banned: Long,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserStateDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserStateDto.kt
@@ -1,0 +1,5 @@
+package ru.illine.drinking.ponies.model.dto.internal
+
+data class UserStateDto(
+    val isActive: Boolean? = null,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/message/MessageContext.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/message/MessageContext.kt
@@ -1,3 +1,0 @@
-package ru.illine.drinking.ponies.model.dto.message
-
-interface MessageContext

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/message/MessageDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/message/MessageDto.kt
@@ -1,5 +1,0 @@
-package ru.illine.drinking.ponies.model.dto.message
-
-data class MessageDto(
-    val text: String,
-)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/message/NoContext.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/message/NoContext.kt
@@ -1,4 +1,0 @@
-package ru.illine.drinking.ponies.model.dto.message
-
-// Shared context for messages without any substitution (static phrases).
-object NoContext : MessageContext

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/NotificationHistoryEntryRequest.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/NotificationHistoryEntryRequest.kt
@@ -13,8 +13,6 @@ data class NotificationHistoryEntryRequest(
         requiredMode = Schema.RequiredMode.REQUIRED,
     )
     val status: NotificationHistoryStatus,
-    // The range is checked by the service instead of bean validation: a missed entry ignores the amount,
-    // and clients do send the whole form snapshot, zero included.
     @Schema(
         description = "Water amount in milliliters, from 50 to 1000. Required when CONFIRMED, ignored when MISSED.",
         example = "300",

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/TelegramInitDataUser.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/TelegramInitDataUser.kt
@@ -1,11 +1,11 @@
-package ru.illine.drinking.ponies.model.dto
+package ru.illine.drinking.ponies.model.dto.request
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class TelegramUserDto(
+data class TelegramInitDataUser(
     @JsonProperty("id")
     val externalUserId: Long,
     @JsonProperty("first_name")
@@ -20,8 +20,6 @@ data class TelegramUserDto(
     val isPremium: Boolean = false,
     @JsonProperty("allows_write_to_pm")
     val allowsWriteToPm: Boolean = false,
-    // Internal-only flags enriched by TelegramAuthInterceptor from DB.
-    // Never accept from incoming JSON (initData) and never expose in API responses.
     @JsonIgnore
     val isAdmin: Boolean = false,
     @JsonIgnore

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/UserStateRequest.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/UserStateRequest.kt
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(description = "User state update payload, one toggle of the admin card per field")
 data class UserStateRequest(
-    // Null means "leave as is" - ban and admin toggles will join as sibling fields.
     @Schema(
         description = "False soft deletes the user, true restores them",
         example = "false",

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/ErrorResponse.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/ErrorResponse.kt
@@ -1,8 +1,11 @@
 package ru.illine.drinking.ponies.model.dto.response
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Error payload returned for a rejected request")
 data class ErrorResponse(
+    @Schema(description = "Human readable reason", example = "validation failed")
     val message: String,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/MeResponse.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/MeResponse.kt
@@ -5,8 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "Current user identity")
 data class MeResponse(
-    // Kotlin field unified to externalUserId across the codebase.
-    // The JSON key is intentionally kept as "telegramUserId" - it is the public /users/me contract consumed by the MiniApp.
     @JsonProperty("telegramUserId")
     @Schema(description = "Telegram user id", example = "123456789")
     val externalUserId: Long,

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/ShortUserInfo.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/ShortUserInfo.kt
@@ -8,8 +8,6 @@ import java.time.Instant
 data class ShortUserInfo(
     @Schema(description = "Internal identifier, the one admin endpoints operate on", example = "1042")
     val id: Long,
-    // Kotlin field is externalUserId across the codebase, the JSON key stays
-    // telegramUserId to match the contract the MiniApp already consumes.
     @JsonProperty("telegramUserId")
     @Schema(description = "Telegram user id", example = "482719301")
     val externalUserId: Long,

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/AbstractAnswerNotificationReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/AbstractAnswerNotificationReplyButtonStrategy.kt
@@ -4,7 +4,7 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
-import ru.illine.drinking.ponies.model.dto.message.NotificationQuestionEditedContext
+import ru.illine.drinking.ponies.model.dto.internal.NotificationQuestionEditedContext
 import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
 import ru.illine.drinking.ponies.service.message.MessageProvider
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/CancelAnswerNotificationReplyButtonStrategy.kt
@@ -5,8 +5,8 @@ import org.springframework.stereotype.Service
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.dto.internal.NoContext
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
-import ru.illine.drinking.ponies.model.dto.message.NoContext
 import ru.illine.drinking.ponies.service.button.strategy.AbstractAnswerNotificationReplyButtonStrategy
 import ru.illine.drinking.ponies.service.message.MessageProvider
 import ru.illine.drinking.ponies.service.notification.NotificationSettingsService

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/notification/YesAnswerNotificationReplyButtonStrategy.kt
@@ -5,8 +5,8 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
-import ru.illine.drinking.ponies.model.dto.message.NoContext
-import ru.illine.drinking.ponies.model.dto.message.NotificationQuestionEditedContext
+import ru.illine.drinking.ponies.model.dto.internal.NoContext
+import ru.illine.drinking.ponies.model.dto.internal.NotificationQuestionEditedContext
 import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
 import ru.illine.drinking.ponies.service.message.MessageProvider
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeApplyReplyButtonStrategy.kt
@@ -7,7 +7,7 @@ import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.SnoozeNotificationType
-import ru.illine.drinking.ponies.model.dto.message.NotificationSuspendContext
+import ru.illine.drinking.ponies.model.dto.internal.NotificationSuspendContext
 import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
 import ru.illine.drinking.ponies.service.message.MessageProvider
 import ru.illine.drinking.ponies.service.notification.NotificationSettingsService

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeMenuReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/snooze/SnoozeMenuReplyButtonStrategy.kt
@@ -5,8 +5,8 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
-import ru.illine.drinking.ponies.model.dto.message.NoContext
-import ru.illine.drinking.ponies.model.dto.message.NotificationQuestionEditedContext
+import ru.illine.drinking.ponies.model.dto.internal.NoContext
+import ru.illine.drinking.ponies.model.dto.internal.NotificationQuestionEditedContext
 import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
 import ru.illine.drinking.ponies.service.message.MessageProvider
 import ru.illine.drinking.ponies.service.telegram.MessageEditorService

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategy.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/button/strategy/wateramount/WaterAmountApplyReplyButtonStrategy.kt
@@ -7,7 +7,7 @@ import org.telegram.telegrambots.meta.api.objects.CallbackQuery
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.WaterAmountType
-import ru.illine.drinking.ponies.model.dto.message.NoContext
+import ru.illine.drinking.ponies.model.dto.internal.NoContext
 import ru.illine.drinking.ponies.service.button.ReplyButtonStrategy
 import ru.illine.drinking.ponies.service.message.MessageProvider
 import ru.illine.drinking.ponies.service.notification.NotificationSettingsService

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/message/MessageProvider.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/message/MessageProvider.kt
@@ -1,7 +1,7 @@
 package ru.illine.drinking.ponies.service.message
 
-import ru.illine.drinking.ponies.model.dto.message.MessageContext
-import ru.illine.drinking.ponies.model.dto.message.MessageDto
+import ru.illine.drinking.ponies.model.dto.internal.MessageContext
+import ru.illine.drinking.ponies.model.dto.internal.MessageDto
 import ru.illine.drinking.ponies.util.message.MessageSpec
 
 interface MessageProvider {

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/message/impl/LocalMessageProvider.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/message/impl/LocalMessageProvider.kt
@@ -2,8 +2,8 @@ package ru.illine.drinking.ponies.service.message.impl
 
 import org.springframework.stereotype.Service
 import ru.illine.drinking.ponies.exception.MessageTemplateException
-import ru.illine.drinking.ponies.model.dto.message.MessageContext
-import ru.illine.drinking.ponies.model.dto.message.MessageDto
+import ru.illine.drinking.ponies.model.dto.internal.MessageContext
+import ru.illine.drinking.ponies.model.dto.internal.MessageDto
 import ru.illine.drinking.ponies.service.message.MessageProvider
 import ru.illine.drinking.ponies.util.message.MessageSpec
 import ru.illine.drinking.ponies.util.message.RuleBucket
@@ -45,8 +45,6 @@ class LocalMessageProvider(
         val buckets =
             rulesBySpec[spec] as? List<RuleBucket<C>>
                 ?: throw MessageTemplateException("No local templates registered for message spec [${spec.id}]")
-        // Guarantee comes from a `{ true }` fallback bucket placed after the specific ones.
-        // Explicit error makes a missing fallback fail loudly instead of throwing a bare NoSuchElementException.
         val candidates =
             buckets.firstNotNullOfOrNull { bucket ->
                 bucket.filter { it.predicate(context) }.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationHistoryService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationHistoryService.kt
@@ -1,8 +1,8 @@
 package ru.illine.drinking.ponies.service.notification
 
 import ru.illine.drinking.ponies.model.base.NotificationHistoryStatus
-import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryEvent
-import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryResponse
+import ru.illine.drinking.ponies.model.dto.internal.NotificationHistoryDto
+import ru.illine.drinking.ponies.model.dto.internal.NotificationHistoryEventDto
 import java.time.LocalDate
 
 interface NotificationHistoryService {
@@ -10,12 +10,12 @@ interface NotificationHistoryService {
         externalUserId: Long,
         from: LocalDate,
         to: LocalDate,
-    ): NotificationHistoryResponse
+    ): NotificationHistoryDto
 
     fun updateEntry(
         externalUserId: Long,
         entryId: Long,
         status: NotificationHistoryStatus,
         amountMl: Int?,
-    ): NotificationHistoryEvent
+    ): NotificationHistoryEventDto
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSettingsService.kt
@@ -1,9 +1,9 @@
 package ru.illine.drinking.ponies.service.notification
 
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
-import ru.illine.drinking.ponies.model.dto.SettingDto
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
-import ru.illine.drinking.ponies.model.dto.response.PauseStateResponse
+import ru.illine.drinking.ponies.model.dto.internal.PauseStateDto
+import ru.illine.drinking.ponies.model.dto.internal.SettingDto
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -56,7 +56,7 @@ interface NotificationSettingsService {
 
     fun cancelPause(externalUserId: Long)
 
-    fun getPauseState(externalUserId: Long): PauseStateResponse
+    fun getPauseState(externalUserId: Long): PauseStateDto
 
     fun changeDailyGoal(
         externalUserId: Long,

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationHistoryServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationHistoryServiceImpl.kt
@@ -8,10 +8,10 @@ import ru.illine.drinking.ponies.exception.NotificationHistoryEntryNotEditableEx
 import ru.illine.drinking.ponies.exception.NotificationHistoryEntryNotFoundException
 import ru.illine.drinking.ponies.model.base.NotificationHistoryStatus
 import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
+import ru.illine.drinking.ponies.model.dto.internal.NotificationHistoryDayDto
+import ru.illine.drinking.ponies.model.dto.internal.NotificationHistoryDto
+import ru.illine.drinking.ponies.model.dto.internal.NotificationHistoryEventDto
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
-import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryDay
-import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryEvent
-import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryResponse
 import ru.illine.drinking.ponies.service.notification.NotificationHistoryService
 import ru.illine.drinking.ponies.util.statistics.StatisticsPeriodHelper
 import ru.illine.drinking.ponies.util.statistics.toUtcInstant
@@ -34,24 +34,20 @@ class NotificationHistoryServiceImpl(
         externalUserId: Long,
         from: LocalDate,
         to: LocalDate,
-    ): NotificationHistoryResponse {
+    ): NotificationHistoryDto {
         logger.debug("Getting [{} - {}] notification history for telegram user [{}]", from, to, externalUserId)
 
         require(from <= to) { "Invalid parameter: 'from' must be before or equal to 'to'" }
         require(ChronoUnit.DAYS.between(from, to) < MAX_RANGE_DAYS) {
             "Invalid parameter: the range must not exceed $MAX_RANGE_DAYS days"
         }
-        // Without an upper bound, a date near LocalDate.MAX overflows while shifting the end of the range.
         require(to.year < LocalDate.MAX.year) {
             "Invalid parameter: 'to' must not be later than the year ${LocalDate.MAX.year}"
         }
-        // Symmetrically, a date near LocalDate.MIN underflows while shifting the start of the range into UTC:
-        // that raises a DateTimeException, which is not a rejected request but a server error.
         require(from.year > LocalDate.MIN.year) {
             "Invalid parameter: 'from' must not be earlier than the year ${LocalDate.MIN.year}"
         }
 
-        // A range in the future is legitimate - the client may page the calendar forward, it just gets no days.
         val zone = userZone(externalUserId)
         val (startInclusive, endExclusive) =
             StatisticsPeriodHelper.localDayBoundsToUtc(
@@ -71,11 +67,10 @@ class NotificationHistoryServiceImpl(
                     endExclusive,
                 ).map { toEvent(it, isEditable) }
                 .groupBy { it.eventTime.atZone(zone).toLocalDate() }
-                .map { (date, events) -> NotificationHistoryDay(date = date, events = events) }
-                // Days come out ordered by event time, except where a DST fall-back crosses local midnight.
+                .map { (date, events) -> NotificationHistoryDayDto(date = date, events = events) }
                 .sortedBy { it.date }
 
-        return NotificationHistoryResponse(days = days)
+        return NotificationHistoryDto(days = days)
     }
 
     override fun updateEntry(
@@ -83,7 +78,7 @@ class NotificationHistoryServiceImpl(
         entryId: Long,
         status: NotificationHistoryStatus,
         amountMl: Int?,
-    ): NotificationHistoryEvent {
+    ): NotificationHistoryEventDto {
         logger.info(
             "Updating notification history entry [{}] of telegram user [{}] to status [{}]",
             entryId,
@@ -91,7 +86,6 @@ class NotificationHistoryServiceImpl(
             status,
         )
 
-        // A missed entry never holds a volume, so the client's snapshot of the form is ignored for it.
         val newAmountMl =
             if (status == NotificationHistoryStatus.CONFIRMED) {
                 val confirmedAmountMl =
@@ -104,8 +98,6 @@ class NotificationHistoryServiceImpl(
                 0
             }
 
-        // An entry the journal never shows (foreign, manual or snoozed) is reported as missing:
-        // we do not confirm that it exists.
         val entry =
             waterStatisticAccessService
                 .findByIdAndUser(entryId, externalUserId)
@@ -114,7 +106,6 @@ class NotificationHistoryServiceImpl(
                     "Not found a notification history entry by id [$entryId] of externalUserId [$externalUserId]",
                 )
 
-        // The entry is fetched with its owner, so the timezone comes from it instead of a second lookup.
         val isEditable = editWindow(ZoneId.of(entry.telegramUser.userTimeZone))
         if (!isEditable(entry.eventTime.toUtcInstant())) {
             throw NotificationHistoryEntryNotEditableException(
@@ -134,13 +125,9 @@ class NotificationHistoryServiceImpl(
         return ZoneId.of(settings.telegramUser.userTimeZone)
     }
 
-    // Single answer to "is this record a journal entry at all", shared by reading and editing.
     private fun journalStatus(dto: WaterStatisticDto): NotificationHistoryStatus? =
         if (dto.source in JOURNAL_SOURCES) NotificationHistoryStatus.of(dto.eventType) else null
 
-    // The single predicate behind both the 'editable' flag of the journal and the refusal to update.
-    // The window spans whole calendar dates of the user's timezone, so all entries of one local day
-    // always share the same flag: the client draws a single lock per day.
     private fun editWindow(zone: ZoneId): (Instant) -> Boolean {
         val startDate = LocalDate.now(clock.withZone(zone)).minusDays(EDIT_WINDOW_DAYS)
         return { eventTime -> !eventTime.atZone(zone).toLocalDate().isBefore(startDate) }
@@ -149,9 +136,9 @@ class NotificationHistoryServiceImpl(
     private fun toEvent(
         dto: WaterStatisticDto,
         isEditable: (Instant) -> Boolean,
-    ): NotificationHistoryEvent {
+    ): NotificationHistoryEventDto {
         val eventTime = dto.eventTime.toUtcInstant()
-        return NotificationHistoryEvent(
+        return NotificationHistoryEventDto(
             id = checkNotNull(dto.id) { "A persisted water statistic record must have an id" },
             eventTime = eventTime,
             status = checkNotNull(journalStatus(dto)) { "A journal entry must carry a journal status" },
@@ -162,11 +149,9 @@ class NotificationHistoryServiceImpl(
     }
 
     companion object {
-        // Calendar days of the user's timezone: the current local day and that many days before it stay editable.
         const val EDIT_WINDOW_DAYS = 7L
         const val MAX_RANGE_DAYS = 62L
 
-        // Widening the journal to another source is a single addition here: both reading and editing follow it.
         val JOURNAL_SOURCES = setOf(WaterEntrySourceType.NOTIFICATION)
         val JOURNAL_EVENT_TYPES = NotificationHistoryStatus.entries.map { it.eventType }
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSenderServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSenderServiceImpl.kt
@@ -9,9 +9,9 @@ import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.config.property.TelegramBotProperties
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.dto.internal.NoContext
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
-import ru.illine.drinking.ponies.model.dto.message.NoContext
-import ru.illine.drinking.ponies.model.dto.message.NotificationSuspendContext
+import ru.illine.drinking.ponies.model.dto.internal.NotificationSuspendContext
 import ru.illine.drinking.ponies.service.message.MessageProvider
 import ru.illine.drinking.ponies.service.notification.NotificationSenderService
 import ru.illine.drinking.ponies.service.statistic.WaterStatisticService

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
@@ -7,12 +7,12 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
+import ru.illine.drinking.ponies.model.dto.internal.DefaultSettingsContext
+import ru.illine.drinking.ponies.model.dto.internal.GreetingContext
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfile
-import ru.illine.drinking.ponies.model.dto.message.DefaultSettingsContext
-import ru.illine.drinking.ponies.model.dto.message.GreetingContext
 import ru.illine.drinking.ponies.service.message.MessageProvider
 import ru.illine.drinking.ponies.service.notification.NotificationService
 import ru.illine.drinking.ponies.util.FunctionHelper.check
@@ -37,8 +37,6 @@ class NotificationServiceImpl(
         val chatId = messageContext.chatId()
         val profile = with(messageContext.user()) { TelegramUserProfile(firstName, lastName, userName) }
 
-        // An admin may have soft deleted this user: derived queries do not see such a row, so
-        // without bringing it back /start would treat them as new and hit the unique index.
         telegramUserAccessService.restoreIfDeleted(externalUserId)
 
         val setting =

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSettingsServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSettingsServiceImpl.kt
@@ -5,9 +5,9 @@ import org.springframework.stereotype.Service
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.mapper.SettingMapper
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
-import ru.illine.drinking.ponies.model.dto.SettingDto
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
-import ru.illine.drinking.ponies.model.dto.response.PauseStateResponse
+import ru.illine.drinking.ponies.model.dto.internal.PauseStateDto
+import ru.illine.drinking.ponies.model.dto.internal.SettingDto
 import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.notification.NotificationTimeService
 import ru.illine.drinking.ponies.util.statistics.toUtcInstant
@@ -156,7 +156,7 @@ class NotificationSettingsServiceImpl(
         notificationAccessService.updateDailyGoal(externalUserId, goalMl)
     }
 
-    override fun getPauseState(externalUserId: Long): PauseStateResponse {
+    override fun getPauseState(externalUserId: Long): PauseStateDto {
         logger.info("Getting pause state for telegram user [$externalUserId]")
         val settings = notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
         val now = LocalDateTime.now(clock)
@@ -164,7 +164,7 @@ class NotificationSettingsServiceImpl(
             settings.pauseUntil
                 ?.takeIf { it.isAfter(now) }
                 ?.toUtcInstant()
-        return PauseStateResponse(
+        return PauseStateDto(
             paused = activePauseUntil != null,
             pauseUntil = activePauseUntil,
         )

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsService.kt
@@ -1,6 +1,6 @@
 package ru.illine.drinking.ponies.service.statistic
 
-import ru.illine.drinking.ponies.model.dto.StatisticsDto
+import ru.illine.drinking.ponies.model.dto.internal.StatisticsDto
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import java.time.LocalDate
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/impl/StatisticsServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/statistic/impl/StatisticsServiceImpl.kt
@@ -5,10 +5,10 @@ import org.springframework.stereotype.Service
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
-import ru.illine.drinking.ponies.model.dto.StatisticsDto
+import ru.illine.drinking.ponies.model.dto.internal.InsightStatsContext
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
+import ru.illine.drinking.ponies.model.dto.internal.StatisticsDto
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
-import ru.illine.drinking.ponies.model.dto.message.InsightStatsContext
 import ru.illine.drinking.ponies.service.message.MessageProvider
 import ru.illine.drinking.ponies.service.statistic.StatisticsService
 import ru.illine.drinking.ponies.util.message.MessageSpec
@@ -29,7 +29,6 @@ class StatisticsServiceImpl(
 ) : StatisticsService {
     private val logger = LoggerFactory.getLogger("SERVICE")
 
-    // Returns RAW events (unfiltered by YES) for the home widget's per-event diary.
     override fun getToday(externalUserId: Long): List<WaterStatisticDto> {
         logger.debug("Getting today entries for telegram user [{}]", externalUserId)
 
@@ -55,10 +54,6 @@ class StatisticsServiceImpl(
 
         val days = ChronoUnit.DAYS.between(from, to).toInt() + 1
 
-        // Streak counts back from today up to STREAK_LIMIT_DAYS, so we must fetch a window
-        // wide enough to cover both the requested [from..to] range and the streak look-back.
-        // Otherwise byDate would be missing days outside [from..to] and the streak would be wrong
-        // whenever `to != today` or `from > today - STREAK_LIMIT_DAYS`.
         val streakWindowStart = ctx.today.minusDays(StatisticsAggregator.STREAK_LIMIT_DAYS)
         val fetchStart = minOf(from, streakWindowStart)
         val fetchEndExclusive = maxOf(to, ctx.today).plusDays(1)
@@ -66,7 +61,6 @@ class StatisticsServiceImpl(
         val allEvents = fetchYesEvents(externalUserId, fetchStart, fetchEndExclusive, ctx.zone)
         val byDate = StatisticsAggregator.sumByLocalDate(allEvents, ctx.zone)
 
-        // Points are built from events in the requested [from..to] window only.
         val rangeEvents =
             allEvents.filter {
                 val date = StatisticsPeriodHelper.toLocal(it.eventTime, ctx.zone).toLocalDate()

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/telegram/TelegramValidatorService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/telegram/TelegramValidatorService.kt
@@ -1,9 +1,9 @@
 package ru.illine.drinking.ponies.service.telegram
 
-import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.request.TelegramInitDataUser
 
 interface TelegramValidatorService {
     fun verifySignature(initData: String): Boolean
 
-    fun map(initData: String): TelegramUserDto
+    fun map(initData: String): TelegramInitDataUser
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/telegram/impl/TelegramValidatorServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/telegram/impl/TelegramValidatorServiceImpl.kt
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import ru.illine.drinking.ponies.config.property.TelegramBotProperties
 import ru.illine.drinking.ponies.exception.InvalidAuthSignatureException
-import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.request.TelegramInitDataUser
 import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
 import ru.illine.drinking.ponies.util.telegram.TelegramWebAppDataHelper.QUERY_ID_FIELD_NAME
 import ru.illine.drinking.ponies.util.telegram.TelegramWebAppDataHelper.USER_FIELD_NAME
@@ -36,9 +36,9 @@ class TelegramValidatorServiceImpl(
         return validateAuthDate(decodedData, expirationTime) && validateHash(decodedData, token)
     }
 
-    override fun map(initData: String): TelegramUserDto {
+    override fun map(initData: String): TelegramInitDataUser {
         val decodedData = decode(initData)
-        val decodedUser = decodedData[USER_FIELD_NAME]?.let { objectMapper.readValue<TelegramUserDto>(it) }
+        val decodedUser = decodedData[USER_FIELD_NAME]?.let { objectMapper.readValue<TelegramInitDataUser>(it) }
 
         return requireNotNull(decodedUser, { "Failed to map, invalid data: $initData" })
     }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/user/UserAdminService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/user/UserAdminService.kt
@@ -1,8 +1,9 @@
 package ru.illine.drinking.ponies.service.user
 
 import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
-import ru.illine.drinking.ponies.model.dto.response.UserDetailsResponse
-import ru.illine.drinking.ponies.model.dto.response.UsersResponse
+import ru.illine.drinking.ponies.model.dto.internal.AdminUserDto
+import ru.illine.drinking.ponies.model.dto.internal.AdminUserPageDto
+import ru.illine.drinking.ponies.model.dto.internal.UserStateDto
 
 interface UserAdminService {
     fun getUsers(
@@ -10,12 +11,12 @@ interface UserAdminService {
         status: AdminUserStatusFilter,
         page: Int,
         size: Int,
-    ): UsersResponse
+    ): AdminUserPageDto
 
-    fun getUser(id: Long): UserDetailsResponse
+    fun getUser(id: Long): AdminUserDto
 
     fun updateState(
         id: Long,
-        isActive: Boolean?,
-    ): UserDetailsResponse
+        state: UserStateDto,
+    ): AdminUserDto
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/user/impl/UserAdminServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/user/impl/UserAdminServiceImpl.kt
@@ -6,15 +6,13 @@ import org.springframework.data.jpa.repository.query.EscapeCharacter
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
-import ru.illine.drinking.ponies.dao.repository.AdminUserProjection
 import ru.illine.drinking.ponies.exception.TelegramUserNotFoundException
 import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
-import ru.illine.drinking.ponies.model.dto.response.ShortUserInfo
-import ru.illine.drinking.ponies.model.dto.response.UserCounts
-import ru.illine.drinking.ponies.model.dto.response.UserDetailsResponse
-import ru.illine.drinking.ponies.model.dto.response.UsersResponse
+import ru.illine.drinking.ponies.model.dto.internal.AdminUserDto
+import ru.illine.drinking.ponies.model.dto.internal.AdminUserPageDto
+import ru.illine.drinking.ponies.model.dto.internal.UserCountsDto
+import ru.illine.drinking.ponies.model.dto.internal.UserStateDto
 import ru.illine.drinking.ponies.service.user.UserAdminService
-import ru.illine.drinking.ponies.util.statistics.toUtcInstant
 
 @Service
 class UserAdminServiceImpl(
@@ -27,19 +25,14 @@ class UserAdminServiceImpl(
         status: AdminUserStatusFilter,
         page: Int,
         size: Int,
-    ): UsersResponse {
+    ): AdminUserPageDto {
         val query = search?.takeIf { it.isNotBlank() }?.toSearchPattern()
         val users = telegramUserAccessService.findAllForAdmin(query, status, PageRequest.of(page, size))
 
-        // Counted without the status filter on purpose: the admin page shows every chip at once.
-        // The total of the requested status is one of those counters, so no extra count query.
-        val counts =
-            telegramUserAccessService.countForAdmin(query).let {
-                UserCounts(it.all, it.active, it.inactive, it.banned)
-            }
+        val counts = telegramUserAccessService.countForAdmin(query)
 
-        return UsersResponse(
-            users = users.map { it.toShortUserInfo() },
+        return AdminUserPageDto(
+            users = users,
             page = page,
             size = size,
             total = counts.of(status),
@@ -47,67 +40,34 @@ class UserAdminServiceImpl(
         )
     }
 
-    override fun getUser(id: Long): UserDetailsResponse = requireUser(id).toDetails()
+    override fun getUser(id: Long): AdminUserDto = requireUser(id)
 
     @Transactional
     override fun updateState(
         id: Long,
-        isActive: Boolean?,
-    ): UserDetailsResponse {
-        require(isActive != null) { "At least one state field is required, got an empty payload" }
+        state: UserStateDto,
+    ): AdminUserDto {
+        val isActive = requireNotNull(state.isActive) { "At least one state field is required, got an empty payload" }
 
         val user = requireUser(id)
 
         logger.info("Setting isActive={} for user [{}]", isActive, id)
-        telegramUserAccessService.updateDeleted(id, user.externalUserId, deleted = !isActive)
+        telegramUserAccessService.updateState(id, user.externalUserId, deleted = !isActive)
 
-        return user.toDetails(isActive)
+        return user.copy(deleted = !isActive)
     }
 
-    // Telegram usernames legitimately contain "_", which LIKE reads as "any character" - without
-    // escaping, a search for alice_p would also match aliceXp. EscapeCharacter.DEFAULT escapes with
-    // a backslash, which is what the query declares in its "escape" clause.
     private fun String.toSearchPattern(): String = "%${EscapeCharacter.DEFAULT.escape(this)}%"
 
-    private fun requireUser(id: Long): AdminUserProjection =
+    private fun requireUser(id: Long): AdminUserDto =
         telegramUserAccessService.findByIdForAdmin(id)
             ?: throw TelegramUserNotFoundException("No user with id: [$id]")
 
-    private fun UserCounts.of(status: AdminUserStatusFilter): Long =
+    private fun UserCountsDto.of(status: AdminUserStatusFilter): Long =
         when (status) {
             AdminUserStatusFilter.ALL -> all
             AdminUserStatusFilter.ACTIVE -> active
             AdminUserStatusFilter.INACTIVE -> inactive
             AdminUserStatusFilter.BANNED -> banned
         }
-
-    private fun AdminUserProjection.toShortUserInfo(): ShortUserInfo =
-        ShortUserInfo(
-            id = id,
-            externalUserId = externalUserId,
-            firstName = firstName,
-            lastName = lastName,
-            username = username,
-            isAdmin = admin,
-            isBanned = banned,
-            isActive = !deleted,
-            lastActivity = lastActivity?.toUtcInstant(),
-        )
-
-    // isActive is passed in when the caller has just changed it, so the freshly written value
-    // is returned without reading the row again.
-    private fun AdminUserProjection.toDetails(isActive: Boolean = !deleted): UserDetailsResponse =
-        UserDetailsResponse(
-            id = id,
-            externalUserId = externalUserId,
-            firstName = firstName,
-            lastName = lastName,
-            username = username,
-            isAdmin = admin,
-            isBanned = banned,
-            isActive = isActive,
-            lastActivity = lastActivity?.toUtcInstant(),
-            timeZone = timeZone,
-            registeredAt = created.toUtcInstant(),
-        )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/TimeHelper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/TimeHelper.kt
@@ -14,15 +14,13 @@ object TimeHelper {
 
     fun timeToString(time: LocalTime): String = time.format(DEFAULT_TIME_FORMATTER)
 
-    // The scheduler fires when: timeOfLastNotification + interval <= now
-    // To make the next notification fire exactly snoozeMinutes from now:
-    //   timeOfLastNotification + interval = now + snoozeMinutes
-    //   timeOfLastNotification = now - interval + snoozeMinutes
     fun nextNotificationTimeByNow(
         clock: Clock,
         intervalMinutes: Long,
         snoozeMinutes: Long,
     ): LocalDateTime {
+        // The scheduler fires at timeOfLastNotification + interval, so firing in snoozeMinutes
+        // means storing now - interval + snoozeMinutes.
         val now = LocalDateTime.now(clock)
         return now.minusMinutes(intervalMinutes).plusMinutes(snoozeMinutes)
     }

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/message/MessageSpec.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/message/MessageSpec.kt
@@ -1,12 +1,12 @@
 package ru.illine.drinking.ponies.util.message
 
-import ru.illine.drinking.ponies.model.dto.message.DefaultSettingsContext
-import ru.illine.drinking.ponies.model.dto.message.GreetingContext
-import ru.illine.drinking.ponies.model.dto.message.InsightStatsContext
-import ru.illine.drinking.ponies.model.dto.message.MessageContext
-import ru.illine.drinking.ponies.model.dto.message.NoContext
-import ru.illine.drinking.ponies.model.dto.message.NotificationQuestionEditedContext
-import ru.illine.drinking.ponies.model.dto.message.NotificationSuspendContext
+import ru.illine.drinking.ponies.model.dto.internal.DefaultSettingsContext
+import ru.illine.drinking.ponies.model.dto.internal.GreetingContext
+import ru.illine.drinking.ponies.model.dto.internal.InsightStatsContext
+import ru.illine.drinking.ponies.model.dto.internal.MessageContext
+import ru.illine.drinking.ponies.model.dto.internal.NoContext
+import ru.illine.drinking.ponies.model.dto.internal.NotificationQuestionEditedContext
+import ru.illine.drinking.ponies.model.dto.internal.NotificationSuspendContext
 
 sealed class MessageSpec<C : MessageContext>(
     val id: String,

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/message/TemplatePool.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/message/TemplatePool.kt
@@ -1,6 +1,6 @@
 package ru.illine.drinking.ponies.util.message
 
-import ru.illine.drinking.ponies.model.dto.message.MessageContext
+import ru.illine.drinking.ponies.model.dto.internal.MessageContext
 
 /**
  * A pool with one always-matching phrase - the common shape for static or single-substitution

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/message/TemplateRule.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/message/TemplateRule.kt
@@ -1,8 +1,7 @@
 package ru.illine.drinking.ponies.util.message
 
-import ru.illine.drinking.ponies.model.dto.message.MessageContext
+import ru.illine.drinking.ponies.model.dto.internal.MessageContext
 
-// Rules with equal priority - the provider picks first non-empty bucket, then random within it.
 typealias RuleBucket<C> = List<TemplateRule<C>>
 
 data class TemplateRule<C : MessageContext>(

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalDefaultSettings.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalDefaultSettings.kt
@@ -1,6 +1,6 @@
 package ru.illine.drinking.ponies.util.message.templates
 
-import ru.illine.drinking.ponies.model.dto.message.DefaultSettingsContext
+import ru.illine.drinking.ponies.model.dto.internal.DefaultSettingsContext
 import ru.illine.drinking.ponies.util.message.RuleBucket
 import ru.illine.drinking.ponies.util.message.singlePhrase
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalGreeting.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalGreeting.kt
@@ -1,6 +1,6 @@
 package ru.illine.drinking.ponies.util.message.templates
 
-import ru.illine.drinking.ponies.model.dto.message.GreetingContext
+import ru.illine.drinking.ponies.model.dto.internal.GreetingContext
 import ru.illine.drinking.ponies.util.message.RuleBucket
 import ru.illine.drinking.ponies.util.message.singlePhrase
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalInsightStats.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalInsightStats.kt
@@ -1,6 +1,6 @@
 package ru.illine.drinking.ponies.util.message.templates
 
-import ru.illine.drinking.ponies.model.dto.message.InsightStatsContext
+import ru.illine.drinking.ponies.model.dto.internal.InsightStatsContext
 import ru.illine.drinking.ponies.util.PluralizationHelper.pluralizeDays
 import ru.illine.drinking.ponies.util.message.RuleBucket
 import ru.illine.drinking.ponies.util.message.TemplateRule
@@ -8,7 +8,6 @@ import ru.illine.drinking.ponies.util.message.TemplateRule
 object LocalInsightStats {
     val PHRASES: List<RuleBucket<InsightStatsContext>> =
         listOf(
-            // Specific signals
             listOf(
                 TemplateRule(
                     predicate = { it.currentStreakDays in 2..6 },
@@ -63,7 +62,6 @@ object LocalInsightStats {
                             { "День с ${it.bestDay!!.valueMl} мл воды - вот это размах :)" },
                         ),
                 ),
-                // Generic fallback - used only if nothing specific matched
                 TemplateRule(
                     predicate = { true },
                     templates =

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalNotificationAnswerCancel.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalNotificationAnswerCancel.kt
@@ -1,6 +1,6 @@
 package ru.illine.drinking.ponies.util.message.templates
 
-import ru.illine.drinking.ponies.model.dto.message.NoContext
+import ru.illine.drinking.ponies.model.dto.internal.NoContext
 import ru.illine.drinking.ponies.util.message.RuleBucket
 import ru.illine.drinking.ponies.util.message.singlePhrase
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalNotificationAnswerYes.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalNotificationAnswerYes.kt
@@ -1,6 +1,6 @@
 package ru.illine.drinking.ponies.util.message.templates
 
-import ru.illine.drinking.ponies.model.dto.message.NoContext
+import ru.illine.drinking.ponies.model.dto.internal.NoContext
 import ru.illine.drinking.ponies.util.message.RuleBucket
 import ru.illine.drinking.ponies.util.message.singlePhrase
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalNotificationQuestion.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalNotificationQuestion.kt
@@ -1,6 +1,6 @@
 package ru.illine.drinking.ponies.util.message.templates
 
-import ru.illine.drinking.ponies.model.dto.message.NoContext
+import ru.illine.drinking.ponies.model.dto.internal.NoContext
 import ru.illine.drinking.ponies.util.message.RuleBucket
 import ru.illine.drinking.ponies.util.message.singlePhrase
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalNotificationQuestionEdited.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalNotificationQuestionEdited.kt
@@ -1,6 +1,6 @@
 package ru.illine.drinking.ponies.util.message.templates
 
-import ru.illine.drinking.ponies.model.dto.message.NotificationQuestionEditedContext
+import ru.illine.drinking.ponies.model.dto.internal.NotificationQuestionEditedContext
 import ru.illine.drinking.ponies.util.message.RuleBucket
 import ru.illine.drinking.ponies.util.message.singlePhrase
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalNotificationSnoozeMenu.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalNotificationSnoozeMenu.kt
@@ -1,6 +1,6 @@
 package ru.illine.drinking.ponies.util.message.templates
 
-import ru.illine.drinking.ponies.model.dto.message.NoContext
+import ru.illine.drinking.ponies.model.dto.internal.NoContext
 import ru.illine.drinking.ponies.util.message.RuleBucket
 import ru.illine.drinking.ponies.util.message.singlePhrase
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalNotificationSuspend.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalNotificationSuspend.kt
@@ -1,6 +1,6 @@
 package ru.illine.drinking.ponies.util.message.templates
 
-import ru.illine.drinking.ponies.model.dto.message.NotificationSuspendContext
+import ru.illine.drinking.ponies.model.dto.internal.NotificationSuspendContext
 import ru.illine.drinking.ponies.util.message.RuleBucket
 import ru.illine.drinking.ponies.util.message.singlePhrase
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalNotificationWaterAmountMenu.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/message/templates/LocalNotificationWaterAmountMenu.kt
@@ -1,6 +1,6 @@
 package ru.illine.drinking.ponies.util.message.templates
 
-import ru.illine.drinking.ponies.model.dto.message.NoContext
+import ru.illine.drinking.ponies.model.dto.internal.NoContext
 import ru.illine.drinking.ponies.util.message.RuleBucket
 import ru.illine.drinking.ponies.util.message.singlePhrase
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsAggregator.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsAggregator.kt
@@ -1,7 +1,7 @@
 package ru.illine.drinking.ponies.util.statistics
 
-import ru.illine.drinking.ponies.model.dto.BestDayDto
-import ru.illine.drinking.ponies.model.dto.StatisticsPointDto
+import ru.illine.drinking.ponies.model.dto.internal.BestDayDto
+import ru.illine.drinking.ponies.model.dto.internal.StatisticsPointDto
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import java.time.LocalDate
 import java.time.ZoneId
@@ -10,7 +10,6 @@ object StatisticsAggregator {
     private const val HOURS_IN_DAY = 24
     private const val HOUR_LABEL_FORMAT = "%02d:00"
 
-    // 366 (not 365) covers a leap year, so a full year of streak isn't off by one
     const val STREAK_LIMIT_DAYS = 366L
 
     fun sumByLocalDate(
@@ -71,8 +70,6 @@ object StatisticsAggregator {
         today: LocalDate,
         dailyGoalMl: Int,
     ): Int {
-        // Hanging streak: an unfinished today does NOT break the chain - we start counting from
-        // yesterday in that case. The streak only resets to 0 on a real gap (yesterday below goal too).
         var cursor = if ((byDate[today] ?: 0) >= dailyGoalMl) today else today.minusDays(1)
         val earliest = today.minusDays(STREAK_LIMIT_DAYS)
         var streak = 0

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/cache/CacheConfigTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/cache/CacheConfigTest.kt
@@ -36,8 +36,6 @@ class CacheConfigTest {
     @Test
     @DisplayName("cacheManager(): returns a TransactionAwareCacheManagerProxy so evicts defer until commit")
     fun `cacheManager wraps caffeine in transaction aware proxy`() {
-        // Without this proxy, @CacheEvict happens before the @Transactional method commits,
-        // and a concurrent reader can re-cache the stale value. The proxy is load-bearing.
         val properties =
             CacheProperties(
                 default = CacheEntry(ttl = Duration.ofMinutes(7), maximumSize = 50),

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigAuthInterceptorIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigAuthInterceptorIntegrationTest.kt
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import ru.illine.drinking.ponies.config.web.WebConfigAuthInterceptorIntegrationTest.DefaultSecureTestConfig
 import ru.illine.drinking.ponies.config.web.security.AuthErrorType
-import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.request.TelegramInitDataUser
 import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
 import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
 
@@ -52,7 +52,7 @@ class WebConfigAuthInterceptorIntegrationTest
         private lateinit var telegramValidatorService: TelegramValidatorService
 
         private val telegramUser =
-            TelegramUserDto(
+            TelegramInitDataUser(
                 externalUserId = 1L,
                 firstName = "First Name",
                 lastName = null,

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorIntegrationTest.kt
@@ -28,7 +28,7 @@ import ru.illine.drinking.ponies.config.cache.CacheConfig
 import ru.illine.drinking.ponies.config.web.interceptor.AdminAuthInterceptorIntegrationTest.AdminTestConfig
 import ru.illine.drinking.ponies.config.web.security.AdminOnly
 import ru.illine.drinking.ponies.config.web.security.AuthErrorType
-import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.request.TelegramInitDataUser
 import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
 import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
 
@@ -55,7 +55,7 @@ class AdminAuthInterceptorIntegrationTest
         private lateinit var telegramValidatorService: TelegramValidatorService
 
         private val telegramUser =
-            TelegramUserDto(
+            TelegramInitDataUser(
                 externalUserId = ADMIN_USER_ID,
                 firstName = "First Name",
                 lastName = null,

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/AdminAuthInterceptorTest.kt
@@ -16,7 +16,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.web.method.HandlerMethod
 import ru.illine.drinking.ponies.config.web.security.AdminOnly
 import ru.illine.drinking.ponies.config.web.security.AuthErrorType
-import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.request.TelegramInitDataUser
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
 
@@ -29,7 +29,7 @@ class AdminAuthInterceptorTest {
     private lateinit var interceptor: AdminAuthInterceptor
 
     private val adminUser =
-        TelegramUserDto(
+        TelegramInitDataUser(
             externalUserId = 1L,
             firstName = "Admin",
             lastName = null,
@@ -38,7 +38,7 @@ class AdminAuthInterceptorTest {
         )
 
     private val nonAdminUser =
-        TelegramUserDto(
+        TelegramInitDataUser(
             externalUserId = 2L,
             firstName = "User",
             lastName = null,
@@ -94,8 +94,6 @@ class AdminAuthInterceptorTest {
         "preHandle(): @AdminOnly on the controller class + non-admin - returns false, 403, forbidden_admin",
     )
     fun `class level AdminOnly rejects a non admin`() {
-        // The annotation guards every handler of the controller, so an endpoint that carries
-        // none of its own is closed all the same.
         whenever(handlerMethod.getMethodAnnotation(AdminOnly::class.java)).thenReturn(null)
         doReturn(GuardedController::class.java).whenever(handlerMethod).beanType
         whenever(request.getAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE)).thenReturn(nonAdminUser)
@@ -143,7 +141,6 @@ class AdminAuthInterceptorTest {
         }
     }
 
-    // Stand-ins for the two kinds of controller the interceptor has to tell apart.
     @AdminOnly
     private class GuardedController
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptorTest.kt
@@ -23,9 +23,9 @@ import org.mockito.kotlin.whenever
 import ru.illine.drinking.ponies.config.web.security.AuthErrorType
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
 import ru.illine.drinking.ponies.exception.InvalidAuthSignatureException
-import ru.illine.drinking.ponies.model.dto.TelegramUserDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfile
 import ru.illine.drinking.ponies.model.dto.internal.UserAccessDto
+import ru.illine.drinking.ponies.model.dto.request.TelegramInitDataUser
 import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
@@ -131,7 +131,8 @@ class TelegramAuthInterceptorTest {
         isDeleted: Boolean,
     ) {
         val initData = "valid-init-data"
-        val telegramUser = TelegramUserDto(externalUserId = 1L, firstName = "Test", lastName = null, username = null)
+        val telegramUser =
+            TelegramInitDataUser(externalUserId = 1L, firstName = "Test", lastName = null, username = null)
         whenever(request.method).thenReturn("POST")
         whenever(request.getHeader(headerName)).thenReturn(initData)
         whenever(validatorService.verifySignature(any())).thenReturn(true)
@@ -144,8 +145,6 @@ class TelegramAuthInterceptorTest {
         assertTrue(result)
         verify(request).setAttribute(
             TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE,
-            // isActive is the opposite of the isDeleted the access service reports, and both
-            // rows of the matrix would fail if that negation were dropped.
             telegramUser.copy(isAdmin = isAdmin, isBanned = isBanned, isActive = !isDeleted),
         )
         verifyNoMoreInteractions(response)
@@ -158,11 +157,9 @@ class TelegramAuthInterceptorTest {
         isDeleted: Boolean,
         expectedIsActive: Boolean,
     ) {
-        // Spelled out on its own because the sign is easy to lose: the access service speaks in
-        // isDeleted, the request attribute speaks in isActive, and equality on the whole DTO
-        // makes for a poor failure message when only that one flag is wrong.
         val initData = "valid-init-data"
-        val telegramUser = TelegramUserDto(externalUserId = 1L, firstName = "Test", lastName = null, username = null)
+        val telegramUser =
+            TelegramInitDataUser(externalUserId = 1L, firstName = "Test", lastName = null, username = null)
         whenever(request.method).thenReturn("POST")
         whenever(request.getHeader(headerName)).thenReturn(initData)
         whenever(validatorService.verifySignature(any())).thenReturn(true)
@@ -172,7 +169,7 @@ class TelegramAuthInterceptorTest {
 
         interceptor.preHandle(request, response, Any())
 
-        val captor = argumentCaptor<TelegramUserDto>()
+        val captor = argumentCaptor<TelegramInitDataUser>()
         verify(request).setAttribute(eq(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE), captor.capture())
         assertEquals(expectedIsActive, captor.firstValue.isActive)
     }
@@ -182,7 +179,7 @@ class TelegramAuthInterceptorTest {
     fun `preHandle valid signature forwards initData profile`() {
         val initData = "valid-init-data"
         val telegramUser =
-            TelegramUserDto(
+            TelegramInitDataUser(
                 externalUserId = 42L,
                 firstName = "Alisa",
                 lastName = "Petrova",

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/NotificationControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/NotificationControllerTest.kt
@@ -31,6 +31,8 @@ import ru.illine.drinking.ponies.exception.NotificationHistoryEntryNotEditableEx
 import ru.illine.drinking.ponies.exception.NotificationHistoryEntryNotFoundException
 import ru.illine.drinking.ponies.exception.NotificationSettingsNotFoundException
 import ru.illine.drinking.ponies.model.base.NotificationHistoryStatus
+import ru.illine.drinking.ponies.model.dto.internal.NotificationHistoryDayDto
+import ru.illine.drinking.ponies.model.dto.internal.NotificationHistoryDto
 import ru.illine.drinking.ponies.model.dto.response.ErrorResponse
 import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryDay
 import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryEvent
@@ -162,8 +164,8 @@ class NotificationControllerTest
             @DisplayName("paused user - returns 200 with paused=true and pauseUntil")
             fun `returns 200 with paused true`() {
                 val expectedPauseUntil = Instant.parse("2025-01-01T18:00:00Z")
-                val expected = PauseStateResponse(paused = true, pauseUntil = expectedPauseUntil)
-                whenever(notificationSettingsService.getPauseState(any())).thenReturn(expected)
+                val state = DtoGenerator.generatePauseStateDto(paused = true, pauseUntil = expectedPauseUntil)
+                whenever(notificationSettingsService.getPauseState(any())).thenReturn(state)
                 val headers = buildHeaders()
 
                 val response =
@@ -184,8 +186,8 @@ class NotificationControllerTest
             @Test
             @DisplayName("not paused - returns 200 with paused=false and null pauseUntil")
             fun `returns 200 with paused false`() {
-                val expected = PauseStateResponse(paused = false, pauseUntil = null)
-                whenever(notificationSettingsService.getPauseState(any())).thenReturn(expected)
+                val state = DtoGenerator.generatePauseStateDto(paused = false, pauseUntil = null)
+                whenever(notificationSettingsService.getPauseState(any())).thenReturn(state)
                 val headers = buildHeaders()
 
                 val response =
@@ -369,6 +371,24 @@ class NotificationControllerTest
             private val from = LocalDate.of(2026, 5, 4)
             private val to = LocalDate.of(2026, 5, 10)
 
+            private fun journalDto() =
+                NotificationHistoryDto(
+                    days =
+                        listOf(
+                            NotificationHistoryDayDto(
+                                date = from,
+                                events =
+                                    listOf(
+                                        DtoGenerator.generateNotificationHistoryEventDto(
+                                            eventTime = Instant.parse("2026-05-04T09:30:00Z"),
+                                            status = NotificationHistoryStatus.MISSED,
+                                            amountMl = 0,
+                                        ),
+                                    ),
+                            ),
+                        ),
+                )
+
             private fun journal() =
                 NotificationHistoryResponse(
                     days =
@@ -398,13 +418,12 @@ class NotificationControllerTest
             @Test
             @DisplayName("valid range - returns 200 with the journal and forwards from/to")
             fun `returns 200 with the journal`() {
-                whenever(notificationHistoryService.getHistory(any(), any(), any())).thenReturn(journal())
+                whenever(notificationHistoryService.getHistory(any(), any(), any())).thenReturn(journalDto())
 
                 val response = get("from=$from&to=$to")
 
                 assertEquals(HttpStatus.OK, response.statusCode)
                 assertEquals(journal(), objectMapper.readValue(response.body, NotificationHistoryResponse::class.java))
-                // Dates and instants go over the wire as ISO 8601 strings, not as numbers.
                 val day = objectMapper.readTree(response.body).path("days").path(0)
                 val event = day.path("events").path(0)
                 assertEquals("2026-05-04", day.path("date").asText())
@@ -416,7 +435,7 @@ class NotificationControllerTest
             @DisplayName("no entries in the range - returns 200 with an empty days array")
             fun `returns 200 with empty days`() {
                 whenever(notificationHistoryService.getHistory(any(), any(), any()))
-                    .thenReturn(NotificationHistoryResponse(days = emptyList()))
+                    .thenReturn(NotificationHistoryDto(days = emptyList()))
 
                 val response = get("from=$from&to=$to")
 
@@ -492,6 +511,11 @@ class NotificationControllerTest
                 expectedAmountMl: Int?,
             ) {
                 val updated =
+                    DtoGenerator.generateNotificationHistoryEventDto(
+                        status = expectedStatus,
+                        amountMl = expectedAmountMl ?: 0,
+                    )
+                val expected =
                     DtoGenerator.generateNotificationHistoryEvent(
                         status = expectedStatus,
                         amountMl = expectedAmountMl ?: 0,
@@ -501,7 +525,7 @@ class NotificationControllerTest
                 val response = patch("1042", body)
 
                 assertEquals(HttpStatus.OK, response.statusCode)
-                assertEquals(updated, objectMapper.readValue(response.body, NotificationHistoryEvent::class.java))
+                assertEquals(expected, objectMapper.readValue(response.body, NotificationHistoryEvent::class.java))
                 verify(notificationHistoryService)
                     .updateEntry(telegramUser.externalUserId, 1042L, expectedStatus, expectedAmountMl)
             }
@@ -601,7 +625,6 @@ class NotificationControllerTest
                         NotificationHistoryStatus.CONFIRMED,
                         300,
                     ),
-                    // A missed entry ignores the amount, but whatever the form sent still reaches the service.
                     Arguments.of("""{"status":"MISSED"}""", NotificationHistoryStatus.MISSED, null),
                     Arguments.of("""{"status":"MISSED","amountMl":0}""", NotificationHistoryStatus.MISSED, 0),
                 )

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/SettingControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/SettingControllerTest.kt
@@ -20,7 +20,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
-import ru.illine.drinking.ponies.model.dto.SettingDto
+import ru.illine.drinking.ponies.model.dto.internal.SettingDto
 import ru.illine.drinking.ponies.model.dto.response.SettingResponse
 import ru.illine.drinking.ponies.service.notification.NotificationSettingsService
 import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/StatisticsControllerTest.kt
@@ -29,7 +29,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import ru.illine.drinking.ponies.exception.NotificationSettingsNotFoundException
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
-import ru.illine.drinking.ponies.model.dto.StatisticsPointDto
+import ru.illine.drinking.ponies.model.dto.internal.StatisticsPointDto
 import ru.illine.drinking.ponies.model.dto.response.StatisticsResponse
 import ru.illine.drinking.ponies.model.dto.response.StatisticsTodayResponse
 import ru.illine.drinking.ponies.service.statistic.StatisticsService

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/UserAdminControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/UserAdminControllerTest.kt
@@ -63,8 +63,6 @@ class UserAdminControllerTest
         @MockitoBean
         private lateinit var telegramValidatorService: TelegramValidatorService
 
-        // Mirrors the stored profile of the fixture admin: authenticating refreshes the profile of the
-        // caller, and an identical one keeps the row the list assertions rely on untouched.
         private val adminUser =
             DtoGenerator.generateTelegramUserDto(
                 externalUserId = ADMIN_EXTERNAL_ID,
@@ -107,8 +105,6 @@ class UserAdminControllerTest
             return response.body!!
         }
 
-        // Goes through a URI variable so that characters like % survive instead of being read
-        // as a broken percent-encoding by the URI template handler.
         private fun searchFor(search: String): UsersResponse {
             val response =
                 restTemplate.exchange(
@@ -244,10 +240,7 @@ class UserAdminControllerTest
 
             @ParameterizedTest(name = "[{index}] search=[{0}] - ids {1}")
             @CsvSource(
-                // A literal underscore, not LIKE's single-character wildcard: aliceXp stays out.
                 "alice_p, '7'",
-                // A search made of nothing but wildcard characters matches the users who really
-                // carry them, not the whole table.
                 "_,       '7'",
                 "%,       ''",
                 """\,      ''""",
@@ -320,6 +313,15 @@ class UserAdminControllerTest
                 assertEquals("carolgone", row.path("username").asText())
                 assertFalse(row.path("isActive").asBoolean())
                 assertEquals("2026-03-06T12:00:00Z", row.path("lastActivity").asText())
+            }
+
+            @Test
+            @DisplayName("serializes a null last activity as null, not as a fallback timestamp")
+            fun `serializes a null last activity in a row`() {
+                val row = getUsers("?search=$ACTIVE_EXTERNAL_ID").users.single()
+
+                assertEquals(ACTIVE_USER_ID, row.id)
+                assertNull(row.lastActivity)
             }
         }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/UserControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/UserControllerTest.kt
@@ -67,7 +67,6 @@ class UserControllerTest
 
         @ParameterizedTest(name = "[{index}] externalUserId={0} - isAdmin={1}, isBanned={2}, isActive={3}")
         @CsvSource(
-            // admin, plain, banned-but-present, soft deleted, banned and deleted, unknown caller
             "1,      true,  false, true",
             "2,      false, false, true",
             "777002, false, true,  true",
@@ -104,8 +103,6 @@ class UserControllerTest
         @Test
         @DisplayName("getMe(): a soft-deleted caller still reaches the endpoint and learns they are inactive")
         fun `stays open for a soft deleted caller`() {
-            // Access is deliberately not cut off for a deleted account: the MiniApp needs the flag
-            // to explain the state and to offer the /start that brings the account back.
             whenever(telegramValidatorService.map(any()))
                 .thenReturn(telegramUser.copy(externalUserId = DELETED_EXTERNAL_ID))
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessServiceTest.kt
@@ -58,9 +58,6 @@ class NotificationAccessServiceTest
         @Test
         @DisplayName("findAllNotificationSettings(): survives a soft-deleted user instead of failing the whole batch")
         fun `findAllNotificationSettings survives a soft deleted user`() {
-            // Reading the user through the lazy association threw EntityNotFoundException here:
-            // @SQLRestriction hides the row even from a load by id, and the mailing died for
-            // everyone on every tick, not just for the deleted user.
             val settings = assertDoesNotThrow(ThrowingSupplier { accessService.findAllNotificationSettings() })
 
             assertFalse(settings.isEmpty(), "The users who are still around have to survive the deleted one")
@@ -71,8 +68,6 @@ class NotificationAccessServiceTest
         fun `findAllNotificationSettings returns the live users only`() {
             val externalUserIds = accessService.findAllNotificationSettings().map { it.telegramUser.externalUserId }
 
-            // Only the live user who still has notifications on: the deleted one is dropped by the
-            // join, the disabled one by @SQLRestriction(enabled = true) on the settings themselves.
             assertEquals(listOf(DEFAULT_EXTERNAL_USER_ID), externalUserIds)
             assertFalse(
                 externalUserIds.contains(DELETED_EXTERNAL_USER_ID),
@@ -399,7 +394,6 @@ class NotificationAccessServiceTest
         @DisplayName("updatePause(): sets pauseUntil and shifts timeOfLastNotification to pauseUntil minus interval")
         fun `successful updatePause sets pauseUntil and shifts timeOfLastNotification`() {
             val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-            // SQL fixture sets DEFAULT_EXTERNAL_USER_ID with TWO_HOURS interval (120 minutes)
             val expectedTimeOfLastNotification = pauseUntil.minusMinutes(IntervalNotificationType.TWO_HOURS.minutes)
 
             val actual =
@@ -417,7 +411,6 @@ class NotificationAccessServiceTest
         @DisplayName("updatePause(): does NOT reset notificationAttempts when pause is set")
         fun `successful updatePause keeps notificationAttempts`() {
             val pauseUntil = LocalDateTime.of(2025, 6, 15, 14, 0)
-            // SQL fixture seeds notification_attempts = 1 for DEFAULT_EXTERNAL_USER_ID
             val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
 
             val actual =
@@ -435,7 +428,6 @@ class NotificationAccessServiceTest
         fun `successful updatePause cancel resets to now`() {
             getMutableClock().setTime("2025-06-15T14:00:00Z")
             val expectedTime = LocalDateTime.now(clock)
-            // First put user into paused state
             accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, LocalDateTime.of(2025, 6, 15, 18, 0))
 
             val actual =
@@ -574,7 +566,6 @@ class NotificationAccessServiceTest
                     accessService.updateNotificationsDisabled(DEFAULT_EXTERNAL_USER_ID)
                 },
             )
-            // While disabled the entity is filtered out by @SQLRestriction, so re-enable to read it.
             accessService.updateNotificationsEnabled(DEFAULT_EXTERNAL_USER_ID)
 
             val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
@@ -611,7 +602,6 @@ class NotificationAccessServiceTest
         fun `successful updateDailyGoal does not affect other users`() {
             val newGoalForFirst = 2500
             val before = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
-            // DISABLED_EXTERNAL_USER_ID is filtered by @SQLRestriction, so re-enable to read it back.
             accessService.updateNotificationsEnabled(DISABLED_EXTERNAL_USER_ID)
             val secondBefore = accessService.findNotificationSettingByExternalUserId(DISABLED_EXTERNAL_USER_ID)
 
@@ -634,7 +624,6 @@ class NotificationAccessServiceTest
             accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, pauseUntil)
             val timerWhilePaused = pauseUntil.minusMinutes(IntervalNotificationType.TWO_HOURS.minutes)
 
-            // Advance clock past pauseUntil so the pause is expired.
             getMutableClock().setTime("2025-06-15T15:00:00Z")
 
             val actual =
@@ -645,7 +634,6 @@ class NotificationAccessServiceTest
                 )
 
             assertNull(actual.pauseUntil)
-            // Cancel is idempotent for already-expired pause: timer is not bumped.
             assertEquals(timerWhilePaused, actual.timeOfLastNotification)
         }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessServiceTest.kt
@@ -219,7 +219,6 @@ class TelegramUserAccessServiceTest
                 assertTrue(all.map { it.id }.contains(BANNED_DELETED_USER_ID), "Still one of the users, though")
             }
 
-            // The caller hands in a ready pattern, wildcards included - the DAO does not add them.
             @ParameterizedTest(name = "[{index}] search={0} - ids {1}")
             @CsvSource(
                 "%bob%,        '2'",
@@ -262,11 +261,8 @@ class TelegramUserAccessServiceTest
 
             @ParameterizedTest(name = "[{index}] search={0} - ids {1}")
             @CsvSource(
-                // An escaped underscore is a literal one, so only the user who really has it matches.
                 """%alice\_p%, '7'""",
-                // Left unescaped it is LIKE's single-character wildcard and catches the twin as well.
                 "%alice_p%,   '7,8'",
-                // A lone escaped wildcard finds the rows that truly contain that character.
                 """%\_%,       '7'""",
                 """%\%%,       ''""",
             )
@@ -317,8 +313,8 @@ class TelegramUserAccessServiceTest
                 assertEquals("Carol", row.firstName)
                 assertEquals("Ivanova", row.lastName)
                 assertEquals("carolgone", row.username)
-                assertFalse(row.admin)
-                assertFalse(row.banned)
+                assertFalse(row.isAdmin)
+                assertFalse(row.isBanned)
                 assertTrue(row.deleted)
                 assertEquals("Asia/Kolkata", row.timeZone)
                 assertEquals(LocalDateTime.of(2026, 1, 3, 12, 0), row.created)
@@ -344,8 +340,6 @@ class TelegramUserAccessServiceTest
 
                 assertEquals(8L, counts.all)
                 assertEquals(5L, counts.active)
-                // The banned-and-deleted user is counted once, under banned - otherwise the sum
-                // below would overshoot all by exactly that one row.
                 assertEquals(1L, counts.inactive)
                 assertEquals(2L, counts.banned)
                 assertEquals(counts.all, counts.active + counts.inactive + counts.banned)
@@ -385,7 +379,7 @@ class TelegramUserAccessServiceTest
 
                 assertNotNull(user)
                 assertEquals(ADMIN_EXTERNAL_ID, user!!.externalUserId)
-                assertTrue(user.admin)
+                assertTrue(user.isAdmin)
                 assertFalse(user.deleted)
                 assertEquals(LocalDateTime.of(2026, 1, 1, 10, 0), user.created)
                 assertEquals(LocalDateTime.of(2026, 3, 4, 9, 0), user.lastActivity)
@@ -408,8 +402,8 @@ class TelegramUserAccessServiceTest
         }
 
         @Nested
-        @DisplayName("updateDeleted()")
-        inner class UpdateDeleted {
+        @DisplayName("updateState()")
+        inner class UpdateState {
             @ParameterizedTest(name = "[{index}] id={0} - deleted={2}")
             @CsvSource(
                 "5, 777003, true",
@@ -421,16 +415,33 @@ class TelegramUserAccessServiceTest
                 externalUserId: Long,
                 deleted: Boolean,
             ) {
-                accessService.updateDeleted(id, externalUserId, deleted)
+                accessService.updateState(id, externalUserId, deleted)
 
                 assertEquals(deleted, accessService.findByIdForAdmin(id)!!.deleted)
+            }
+
+            @ParameterizedTest(name = "[{index}] id={0}")
+            @CsvSource(
+                "5, 777003",
+                "3, 777001",
+            )
+            @DisplayName("a null field leaves its column as it is, so an untouched toggle keeps its value")
+            fun `a null field changes nothing`(
+                id: Long,
+                externalUserId: Long,
+            ) {
+                val before = accessService.findByIdForAdmin(id)!!.deleted
+
+                accessService.updateState(id, externalUserId, deleted = null)
+
+                assertEquals(before, accessService.findByIdForAdmin(id)!!.deleted)
             }
 
             @Test
             @DisplayName("repeating the same update leaves the flag as it is")
             fun `repeating the same update is idempotent`() {
-                accessService.updateDeleted(ACTIVE_USER_ID, ACTIVE_EXTERNAL_ID, deleted = true)
-                accessService.updateDeleted(ACTIVE_USER_ID, ACTIVE_EXTERNAL_ID, deleted = true)
+                accessService.updateState(ACTIVE_USER_ID, ACTIVE_EXTERNAL_ID, deleted = true)
+                accessService.updateState(ACTIVE_USER_ID, ACTIVE_EXTERNAL_ID, deleted = true)
 
                 assertTrue(accessService.findByIdForAdmin(ACTIVE_USER_ID)!!.deleted)
                 assertEquals(2L, accessService.countForAdmin(null).inactive)
@@ -439,7 +450,7 @@ class TelegramUserAccessServiceTest
             @Test
             @DisplayName("an unknown id changes nothing")
             fun `unknown id changes nothing`() {
-                accessService.updateDeleted(MISSING_USER_ID, MISSING_EXTERNAL_ID, deleted = true)
+                accessService.updateState(MISSING_USER_ID, MISSING_EXTERNAL_ID, deleted = true)
 
                 val counts = accessService.countForAdmin(null)
                 assertEquals(8L, counts.all)
@@ -453,7 +464,19 @@ class TelegramUserAccessServiceTest
                 accessService.resolveAccessFlags(ACTIVE_EXTERNAL_ID, TelegramUserProfile())
                 assertNotNull(cache.get(ACTIVE_EXTERNAL_ID))
 
-                accessService.updateDeleted(ACTIVE_USER_ID, ACTIVE_EXTERNAL_ID, deleted = true)
+                accessService.updateState(ACTIVE_USER_ID, ACTIVE_EXTERNAL_ID, deleted = true)
+
+                assertNull(cache.get(ACTIVE_EXTERNAL_ID))
+            }
+
+            @Test
+            @DisplayName("evicts the flags even when every field is null and nothing is written")
+            fun `evicts the cached access flags on a no-op update`() {
+                val cache = cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)!!
+                accessService.resolveAccessFlags(ACTIVE_EXTERNAL_ID, TelegramUserProfile())
+                assertNotNull(cache.get(ACTIVE_EXTERNAL_ID))
+
+                accessService.updateState(ACTIVE_USER_ID, ACTIVE_EXTERNAL_ID, deleted = null)
 
                 assertNull(cache.get(ACTIVE_EXTERNAL_ID))
             }

--- a/src/test/kotlin/ru/illine/drinking/ponies/dao/access/WaterStatisticAccessServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/dao/access/WaterStatisticAccessServiceTest.kt
@@ -76,8 +76,6 @@ class WaterStatisticAccessServiceTest
                     },
                 )
 
-            // The returned DTO alone cannot tell an update from an insert - a second row would silently double
-            // the drunk volume on every edit of the journal - so the table itself is read back.
             val rows =
                 jdbcTemplate.queryForList(
                     """
@@ -208,14 +206,12 @@ class WaterStatisticAccessServiceTest
         fun `successful findByUserAndEventTimeBetween excludes endExclusive`() {
             val start = LocalDateTime.of(2025, 6, 15, 10, 0)
             val end = LocalDateTime.of(2025, 6, 15, 12, 0)
-            // exactly at endExclusive - must be excluded
             accessService.save(
                 DtoGenerator.generateWaterStatisticDto(
                     externalUserId = DEFAULT_EXTERNAL_USER_ID,
                     eventTime = end,
                 ),
             )
-            // before endExclusive - must be included
             accessService.save(
                 DtoGenerator.generateWaterStatisticDto(
                     externalUserId = DEFAULT_EXTERNAL_USER_ID,
@@ -359,7 +355,6 @@ class WaterStatisticAccessServiceTest
                         source = WaterEntrySourceType.NOTIFICATION,
                     ),
                 )
-            // Right source, wrong event type.
             accessService.save(
                 DtoGenerator.generateWaterStatisticDto(
                     externalUserId = DEFAULT_EXTERNAL_USER_ID,
@@ -368,7 +363,6 @@ class WaterStatisticAccessServiceTest
                     source = WaterEntrySourceType.NOTIFICATION,
                 ),
             )
-            // Right event type, wrong source.
             accessService.save(
                 DtoGenerator.generateWaterStatisticDto(
                     externalUserId = DEFAULT_EXTERNAL_USER_ID,
@@ -406,7 +400,6 @@ class WaterStatisticAccessServiceTest
                         source = WaterEntrySourceType.NOTIFICATION,
                     ),
                 )
-            // Same window, same source and event type, another owner: the journal must never show it.
             accessService.save(
                 DtoGenerator.generateWaterStatisticDto(
                     externalUserId = SECOND_EXTERNAL_USER_ID,
@@ -434,8 +427,6 @@ class WaterStatisticAccessServiceTest
         @DisplayName("findByIdAndUser(): returns the record of the requesting user, together with its owner")
         fun `findByIdAndUser returns own record`() {
             val eventTime = LocalDateTime.of(2025, 6, 15, 10, 0)
-            // The saved DTO deliberately carries another timezone: the owner of the record comes from the
-            // database, and the notification journal measures its edit window by exactly that value.
             val saved =
                 accessService.save(
                     DtoGenerator.generateWaterStatisticDto(
@@ -540,7 +531,6 @@ class WaterStatisticAccessServiceTest
                     eventTime = mine,
                 ),
             )
-            // Earlier event for a different user must NOT be returned for DEFAULT user.
             accessService.save(
                 DtoGenerator.generateWaterStatisticDto(
                     externalUserId = SECOND_EXTERNAL_USER_ID,
@@ -566,7 +556,6 @@ class WaterStatisticAccessServiceTest
             private const val SECOND_EXTERNAL_USER_ID = 2L
             private const val THIRD_EXTERNAL_USER_ID = 3L
 
-            // The timezone the seed script stores for the third user.
             private const val THIRD_USER_TIME_ZONE = "Asia/Kolkata"
             private const val NOT_EXISTED_USER_ID = 0L
             private const val NOT_EXISTED_ENTRY_ID = 0L

--- a/src/test/kotlin/ru/illine/drinking/ponies/mapper/StatisticsMapperTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/mapper/StatisticsMapperTest.kt
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import ru.illine.drinking.ponies.model.dto.BestDayDto
-import ru.illine.drinking.ponies.model.dto.StatisticsDto
-import ru.illine.drinking.ponies.model.dto.StatisticsPointDto
+import ru.illine.drinking.ponies.model.dto.internal.BestDayDto
+import ru.illine.drinking.ponies.model.dto.internal.StatisticsDto
+import ru.illine.drinking.ponies.model.dto.internal.StatisticsPointDto
 import ru.illine.drinking.ponies.model.dto.response.StatisticsResponse
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import java.time.DayOfWeek
@@ -76,11 +76,8 @@ class StatisticsMapperTest {
     }
 
     @Test
-    @DisplayName("DPTB-127 regression: StatisticsResponse and StatisticsDto no longer expose period/goalProgress")
+    @DisplayName("regression: StatisticsResponse and StatisticsDto no longer expose period/goalProgress")
     fun `removed fields are absent from response and dto`() {
-        // The MiniApp does not consume these fields - they were removed from the public contract.
-        // Restoring them silently (e.g. via a copy-paste from an older branch) would leak internal
-        // state into the API. This contract guard fails fast if either field returns.
         val responseFields = StatisticsResponse::class.memberProperties.map { it.name }.toSet()
         val dtoFields = StatisticsDto::class.memberProperties.map { it.name }.toSet()
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/scheduler/NotificationSchedulerIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/scheduler/NotificationSchedulerIntegrationTest.kt
@@ -36,7 +36,6 @@ class NotificationSchedulerIntegrationTest
         private val scheduler: NotificationScheduler,
         private val clock: Clock,
     ) {
-        // The real one would talk to Telegram; mocked, it also records who was about to be reminded.
         @MockitoBean
         private lateinit var notificationSenderService: NotificationSenderService
 
@@ -48,9 +47,6 @@ class NotificationSchedulerIntegrationTest
         @Test
         @DisplayName("sendDrinkingReminders(): a soft-deleted account no longer silences the reminders of everyone")
         fun `a deleted user does not stop the mailing`() {
-            // The scheduler swallows exceptions, so the old failure was invisible from the outside:
-            // loading the deleted user through the lazy association threw EntityNotFoundException
-            // before a single reminder went out, and the bot just went quiet for all users.
             scheduler.sendDrinkingReminders()
 
             val captor = argumentCaptor<List<NotificationSettingDto>>()

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/message/LocalMessageProviderTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/message/LocalMessageProviderTest.kt
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import ru.illine.drinking.ponies.exception.MessageTemplateException
-import ru.illine.drinking.ponies.model.dto.message.DefaultSettingsContext
-import ru.illine.drinking.ponies.model.dto.message.GreetingContext
-import ru.illine.drinking.ponies.model.dto.message.NoContext
-import ru.illine.drinking.ponies.model.dto.message.NotificationQuestionEditedContext
-import ru.illine.drinking.ponies.model.dto.message.NotificationSuspendContext
+import ru.illine.drinking.ponies.model.dto.internal.DefaultSettingsContext
+import ru.illine.drinking.ponies.model.dto.internal.GreetingContext
+import ru.illine.drinking.ponies.model.dto.internal.NoContext
+import ru.illine.drinking.ponies.model.dto.internal.NotificationQuestionEditedContext
+import ru.illine.drinking.ponies.model.dto.internal.NotificationSuspendContext
 import ru.illine.drinking.ponies.service.message.impl.LocalMessageProvider
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
@@ -34,8 +34,6 @@ class LocalMessageProviderTest {
     @Test
     @DisplayName("getMessage(): streak in 2..6 phrasing is reachable and includes 'подряд'")
     fun `streak small bucket contains number and word`() {
-        // All rules (specific + fallback) compete with equal priority, so specific phrasing
-        // is reachable but not guaranteed on every seed.
         val outcomes =
             (0L until 50L).map { seed ->
                 LocalMessageProvider(Random(seed))
@@ -72,7 +70,6 @@ class LocalMessageProviderTest {
                         DtoGenerator.generateInsightStatsContext(currentStreakDays = 7),
                     ).text
             }
-        // streak number must be present in at least one template; the other refers to it implicitly.
         assertTrue(
             outcomes.any { it.contains("7") || it.contains("привычка") },
             "expected medium streak phrasing, sample: ${outcomes.first()}",
@@ -99,7 +96,6 @@ class LocalMessageProviderTest {
     @Test
     @DisplayName("getMessage(): streak phrase includes correct russian plural form (1 -> день, 2 -> дня, 5 -> дней)")
     fun `streak pluralization`() {
-        // streak=2 -> "дня"
         val outcomes2 =
             (0L until 30L).map { seed ->
                 LocalMessageProvider(Random(seed))
@@ -110,7 +106,6 @@ class LocalMessageProviderTest {
             }
         assertTrue(outcomes2.any { it.contains("2 дня") }, "expected '2 дня' at least once, got: ${outcomes2.first()}")
 
-        // streak=5 -> "дней"
         val outcomes5 =
             (0L until 30L).map { seed ->
                 LocalMessageProvider(Random(seed))
@@ -136,7 +131,6 @@ class LocalMessageProviderTest {
                         DtoGenerator.generateInsightStatsContext(avgMlPerDay = 2200, dailyGoalMl = 2000),
                     ).text
             }
-        // AVG_GOOD competes with the fallback rule on equal footing - must be reachable, not exclusive.
         assertTrue(
             outcomes.any { it.contains("выше цели") || it.contains("перебирает") },
             "expected AVG_GOOD phrasing at least once across seeds",
@@ -146,9 +140,6 @@ class LocalMessageProviderTest {
     @Test
     @DisplayName("getMessage(): avg >= goal but goal <= 0 does NOT trigger AVG_GOOD (guards against bogus daily goal)")
     fun `avg above non-positive goal does not trigger specific bucket`() {
-        // Predicate is `avgMlPerDay >= dailyGoalMl && dailyGoalMl > 0`.
-        // With dailyGoalMl=0 the first part is true (0 >= 0) but the guard `> 0` must veto the AVG_GOOD rule,
-        // so only the fallback bucket may surface - never the "выше цели"/"перебирает" phrasing.
         val outcomes =
             (0L until 100L).map { seed ->
                 LocalMessageProvider(Random(seed))
@@ -190,15 +181,12 @@ class LocalMessageProviderTest {
                         ),
                     ).text
             }
-        // BEST_DAY competes with the fallback rule on equal footing - must surface, not dominate.
         assertTrue(outcomes.any { it.contains("2400") }, "expected bestDay value 2400 at least once")
     }
 
     @Test
     @DisplayName("getMessage(): specific and fallback rules both reachable when only streak rule matches")
     fun `specific and fallback mix when streak matches`() {
-        // streak=5 -> streak 2..6 rule matches; fallback `{ true }` also matches.
-        // All matching rules compete with equal priority, so both should be reachable across seeds.
         val outcomes =
             (0L until 100L).map { seed ->
                 LocalMessageProvider(Random(seed))
@@ -231,7 +219,6 @@ class LocalMessageProviderTest {
                         ),
                     ).text
             }
-        // None of the specific markers must surface
         val specificMarkers = listOf("подряд", "выше цели", "перебирает", "Лучший день", "размах")
         outcomes.forEach { text ->
             assertFalse(
@@ -247,8 +234,6 @@ class LocalMessageProviderTest {
         "getMessage(): bestDay with valueMl=0 still matches specific bucket (rule only checks non-null bestDay)",
     )
     fun `bestDay zero value still matches specific bucket`() {
-        // Predicate is `bestDay != null` (no valueMl check); ensure we land in the specific bucket.
-        // The template references bestDay!!.valueMl so it will render "0 мл".
         val text =
             provider
                 .getMessage(
@@ -263,7 +248,6 @@ class LocalMessageProviderTest {
                     ),
                 ).text
 
-        // Must be a BEST_DAY template (since it is the only matching specific rule):
         assertTrue(
             text.contains("0 мл") || text.contains("День с 0"),
             "expected BEST_DAY phrasing with 0 ml, got: $text",
@@ -286,10 +270,6 @@ class LocalMessageProviderTest {
     @Test
     @DisplayName("getMessage(): registered spec always produces non-blank text")
     fun `unregistered spec throws`() {
-        // We can't easily create a new MessageSpec subclass externally because the sealed class is closed
-        // to outside subclassing - skip this assertion. Coverage of the throwing path is exercised via
-        // the missing-fallback contract test below if it ever becomes reachable.
-        // Use the registered spec only.
         val text = provider.getMessage(MessageSpec.InsightStats, DtoGenerator.generateInsightStatsContext()).text
         assertTrue(text.isNotBlank())
     }
@@ -297,10 +277,6 @@ class LocalMessageProviderTest {
     @Test
     @DisplayName("getMessage(): no rule match falls back to fallback bucket and produces text")
     fun `no rule throws`() {
-        // Build a provider variant via subclass to inject a phrases map with no matching rule.
-        // Since LocalMessageProvider is sealed in private state, instead exercise the error path by
-        // verifying that the existing InsightStats spec ALWAYS produces output - the `{ true }` fallback
-        // bucket guarantees this. We assert on a context that would otherwise match nothing specific.
         val text =
             provider
                 .getMessage(
@@ -309,9 +285,7 @@ class LocalMessageProviderTest {
                 ).text
 
         assertTrue(text.isNotBlank(), "fallback bucket must always produce text")
-        // Sanity smoke: explicit type for the assertion below
         assertThrows(MessageTemplateException::class.java) {
-            // Reproduce the exception by directly constructing one
             throw MessageTemplateException("test")
         }
     }

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationHistoryServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationHistoryServiceTest.kt
@@ -74,7 +74,6 @@ class NotificationHistoryServiceTest {
         whenever(waterStatisticAccessService.findByIdAndUser(ENTRY_ID, EXTERNAL_USER_ID)).thenReturn(entry)
     }
 
-    // The access layer returns the record as it was persisted, so the stub echoes the merged DTO back.
     private fun stubSaveEcho() {
         whenever(waterStatisticAccessService.save(any())).thenAnswer { it.getArgument<WaterStatisticDto>(0) }
     }
@@ -111,7 +110,6 @@ class NotificationHistoryServiceTest {
 
         service.getHistory(EXTERNAL_USER_ID, LocalDate.of(2026, 5, 4), LocalDate.of(2026, 5, 4))
 
-        // Snoozed answers and manual entries are cut off by the query itself, not in memory.
         verify(waterStatisticAccessService).findByUserAndTypesAndEventTimeBetween(
             eq(EXTERNAL_USER_ID),
             argThat { toSet() == setOf(WaterEntrySourceType.NOTIFICATION) },
@@ -228,7 +226,6 @@ class NotificationHistoryServiceTest {
 
         val actual = service.getHistory(EXTERNAL_USER_ID, LocalDate.of(2026, 5, 2), LocalDate.of(2026, 5, 3))
 
-        // A day is indivisible: the client draws a single lock per day, so a day never mixes both flags.
         assertEquals(listOf(LocalDate.of(2026, 5, 2), LocalDate.of(2026, 5, 3)), actual.days.map { it.date })
         assertEquals(listOf(false, false), actual.days[0].events.map { it.editable })
         assertEquals(listOf(true, true), actual.days[1].events.map { it.editable })
@@ -273,8 +270,6 @@ class NotificationHistoryServiceTest {
     @Test
     @DisplayName("getHistory(): rejects a range before the supported year")
     fun `getHistory rejects a range before the supported year`() {
-        // The zone is stubbed on purpose: shifting the start of such a range into UTC underflows with a
-        // DateTimeException, which is a server error, so the range has to be turned down as an invalid one.
         stubZone("Europe/Moscow")
 
         assertThrows<IllegalArgumentException> {
@@ -330,11 +325,10 @@ class NotificationHistoryServiceTest {
 
         val actual = service.updateEntry(EXTERNAL_USER_ID, ENTRY_ID, NotificationHistoryStatus.CONFIRMED, 300)
 
-        // Only the status and the volume change, every other field of the stored record is kept as is.
         verify(waterStatisticAccessService)
             .save(stored.copy(eventType = AnswerNotificationType.YES, waterAmountMl = 300))
         assertEquals(
-            DtoGenerator.generateNotificationHistoryEvent(
+            DtoGenerator.generateNotificationHistoryEventDto(
                 id = ENTRY_ID,
                 eventTime = Instant.parse("2026-05-10T08:00:00Z"),
                 status = NotificationHistoryStatus.CONFIRMED,
@@ -342,7 +336,6 @@ class NotificationHistoryServiceTest {
             ),
             actual,
         )
-        // The record arrives with its owner, so the settings are never read on this path.
         verifyNoInteractions(notificationAccessService)
     }
 
@@ -391,8 +384,6 @@ class NotificationHistoryServiceTest {
         verify(waterStatisticAccessService, never()).save(any())
     }
 
-    // The service is the only place bounding the volume: the request DTO carries no constraint annotations,
-    // because a missed entry ignores the amount and clients send the whole form snapshot, zero included.
     @ParameterizedTest(name = "[{index}] amountMl={0}")
     @ValueSource(ints = [49, 1001])
     @DisplayName("updateEntry(): rejects a confirmed amount outside the allowed range")
@@ -417,8 +408,6 @@ class NotificationHistoryServiceTest {
         verify(waterStatisticAccessService, never()).save(any())
     }
 
-    // Same cases as the 'editable' flag of getHistory above: the flag and the refusal to update are one
-    // predicate, so an entry the journal shows as locked is exactly the entry the update refuses.
     @ParameterizedTest(name = "[{index}] {0}, eventTime={1} -> editable={2}")
     @MethodSource("provideEditWindowCases")
     @DisplayName("updateEntry(): refuses exactly the entries the journal marks read-only")
@@ -443,8 +432,6 @@ class NotificationHistoryServiceTest {
 
             verify(waterStatisticAccessService, never()).save(any())
         }
-        // The window is measured in the timezone carried by the entry itself, without a lookup of the settings:
-        // the last second of May 2nd in New York, for one, is already May 3rd in UTC.
         verifyNoInteractions(notificationAccessService)
     }
 
@@ -454,11 +441,9 @@ class NotificationHistoryServiceTest {
         private val NOW = Instant.parse("2026-05-10T12:00:00Z")
         private val DEFAULT_EVENT_TIME = LocalDateTime.of(2026, 5, 10, 8, 0, 0)
 
-        // Wide enough to cover every edit window case below; the access layer is stubbed, so it does not filter.
         private val WINDOW_CASE_FROM = LocalDate.of(2026, 5, 1)
         private val WINDOW_CASE_TO = LocalDate.of(2026, 5, 10)
 
-        // A persisted entry always arrives with its owner, so it carries the very timezone the settings hold.
         private fun entry(
             id: Long = ENTRY_ID,
             eventTime: LocalDateTime = DEFAULT_EVENT_TIME,
@@ -517,10 +502,6 @@ class NotificationHistoryServiceTest {
                 ),
             )
 
-        // With the clock fixed at 2026-05-10T12:00:00Z the local day is May 10th in every zone below,
-        // so the oldest editable local date is May 3rd and May 2nd is already locked.
-        // Event times are stored in UTC; the cases pair the last second of May 2nd with the first second
-        // of May 3rd of each zone, which is where the window flips.
         @JvmStatic
         fun provideEditWindowCases(): Stream<Arguments> =
             Stream.of(
@@ -576,8 +557,6 @@ class NotificationHistoryServiceTest {
                 ),
             )
 
-        // The first and the last second of May 2nd and of May 3rd, in UTC, per zone: two whole local days
-        // around the edge of the edit window.
         @JvmStatic
         fun provideLocalDayEdges(): Stream<Arguments> =
             Stream.of(

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceIntegrationTest.kt
@@ -42,7 +42,6 @@ class NotificationServiceIntegrationTest
         private val cacheManager: CacheManager,
         private val jdbcTemplate: JdbcTemplate,
     ) {
-        // The greeting would otherwise go out over the network on every /start.
         @MockitoBean
         private lateinit var sender: TelegramClient
 
@@ -57,9 +56,6 @@ class NotificationServiceIntegrationTest
             notificationService.start(messageContext())
             softDelete()
 
-            // Before the restore existed this threw DataIntegrityViolationException: the soft-deleted
-            // row is hidden from the existence check, so /start tried to insert a second row and the
-            // unique index on external_user_id refused it.
             assertDoesNotThrow { notificationService.start(messageContext()) }
 
             assertFalse(isDeleted(), "The account has to be usable again after /start")
@@ -132,7 +128,7 @@ class NotificationServiceIntegrationTest
 
         private fun softDelete() {
             val id = jdbcTemplate.queryForObject(SELECT_ID, Long::class.java, EXTERNAL_USER_ID)!!
-            telegramUserAccessService.updateDeleted(id, EXTERNAL_USER_ID, deleted = true)
+            telegramUserAccessService.updateState(id, EXTERNAL_USER_ID, deleted = true)
             assertTrue(isDeleted(), "Arrange step must really have soft deleted the user")
         }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceTest.kt
@@ -79,8 +79,6 @@ class NotificationServiceTest {
     @Test
     @DisplayName("start(): asks to undo a soft delete before deciding whether the user is new")
     fun `start restores a soft deleted user before the existence check`() {
-        // Order is the whole point: a soft-deleted row is invisible to the existence check, so
-        // asking afterwards would still take the user for a newcomer and hit the unique index.
         val dto = DtoGenerator.generateNotificationDto(externalUserId = externalUserId)
         doReturn(true).whenever(notificationAccessService).existsByExternalUserId(externalUserId)
         whenever(notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)).thenReturn(dto)

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationTimeServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationTimeServiceTest.kt
@@ -113,7 +113,6 @@ class NotificationTimeServiceTest
             @JvmStatic
             fun quietTimeScenarios(): Stream<Arguments> =
                 Stream.of(
-                    // FORMAT: CurrentTime | Zone | Start | End | Expected | Description
                     Arguments.of(
                         "2025-01-01T12:00:00Z",
                         "UTC",
@@ -279,7 +278,6 @@ class NotificationTimeServiceTest
             @JvmStatic
             fun nextNotificationAtScenarios(): Stream<Arguments> =
                 Stream.of(
-                    // FORMAT: LastNotificationTime | Interval | Zone | QuietStart | QuietEnd | Expected | Description
                     Arguments.of(
                         "2025-01-01T10:00:00Z",
                         IntervalNotificationType.HOUR,
@@ -379,10 +377,6 @@ class NotificationTimeServiceTest
                         "2025-01-01T08:00:00Z",
                         "rawNext 07:30 inside day quiet 02-08 -> Shift to 08:00 same day",
                     ),
-                    // Pause + quiet mode interaction:
-                    // simulates pauseUntil=23:30 (timeOfLastNotification = 23:30 - 60m = 22:30)
-                    // pauseUntil falls inside quiet zone 23:00-08:00, so /next is shifted to 08:00.
-                    // This documents UX nuance: getPauseState returns 23:30, but actual notification at 08:00.
                     Arguments.of(
                         "2025-01-01T22:30:00Z",
                         IntervalNotificationType.HOUR,
@@ -392,7 +386,6 @@ class NotificationTimeServiceTest
                         "2025-01-02T08:00:00Z",
                         "Pause ending in quiet mode: rawNext 23:30 inside 23-08 -> Shift to 08:00 next day",
                     ),
-                    // Covers (quietEnd == null) branch on line 69 of calculateNextNotificationAt.
                     Arguments.of(
                         "2025-01-01T10:00:00Z",
                         IntervalNotificationType.HOUR,
@@ -402,7 +395,6 @@ class NotificationTimeServiceTest
                         "2025-01-01T11:00:00Z",
                         "Partial null: Start set, End null -> Treat as no quiet mode, return rawNext",
                     ),
-                    // Covers (quietStart == null) branch on line 69 of calculateNextNotificationAt.
                     Arguments.of(
                         "2025-01-01T10:00:00Z",
                         IntervalNotificationType.HOUR,
@@ -412,8 +404,6 @@ class NotificationTimeServiceTest
                         "2025-01-01T11:00:00Z",
                         "Partial null: Start null, End set -> Treat as no quiet mode, return rawNext",
                     ),
-                    // Covers (isAtOrAfterStart=true && isAtOrBeforeEnd=false) on the day branch (line 82).
-                    // rawNext 17:00 is after end 16:00 -> NOT in quiet mode, return rawNext.
                     Arguments.of(
                         "2025-01-01T16:00:00Z",
                         IntervalNotificationType.HOUR,
@@ -423,8 +413,6 @@ class NotificationTimeServiceTest
                         "2025-01-01T17:00:00Z",
                         "Day quiet mode: rawNext 17:00 after end 16:00 -> Return rawNext",
                     ),
-                    // Covers (isAtOrAfterStart=false || isAtOrBeforeEnd=true) on the night branch (line 84).
-                    // rawNext 07:00 is before start 23:00 but at-or-before end 08:00 -> in quiet mode -> shift.
                     Arguments.of(
                         "2025-01-01T06:00:00Z",
                         IntervalNotificationType.HOUR,
@@ -439,7 +427,6 @@ class NotificationTimeServiceTest
             @JvmStatic
             fun notificationDueScenarios(): Stream<Arguments> =
                 Stream.of(
-                    // FORMAT: CurrentTime | LastNotificationTime | Delay | Expected | Description
                     Arguments.of(
                         "2025-01-01T12:00:00Z",
                         "2025-01-01T10:00:00Z",

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/statistic/StatisticsServiceTest.kt
@@ -21,9 +21,9 @@ import org.mockito.kotlin.whenever
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.dao.access.WaterStatisticAccessService
 import ru.illine.drinking.ponies.model.base.AnswerNotificationType
+import ru.illine.drinking.ponies.model.dto.internal.InsightStatsContext
+import ru.illine.drinking.ponies.model.dto.internal.MessageDto
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
-import ru.illine.drinking.ponies.model.dto.message.InsightStatsContext
-import ru.illine.drinking.ponies.model.dto.message.MessageDto
 import ru.illine.drinking.ponies.service.message.MessageProvider
 import ru.illine.drinking.ponies.service.statistic.impl.StatisticsServiceImpl
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
@@ -177,7 +177,6 @@ class StatisticsServiceTest {
     @Test
     @DisplayName("getStatistics(from < to): builds daily points, bestDay set with weekday")
     fun `getStatistics daily when range over multiple days`() {
-        // 2026-05-04 (Mon) .. 2026-05-10 (Sun) = 7 days
         buildService(clockAt("2026-05-10T12:00:00Z"))
         stubSettings()
         stubEvents(
@@ -237,7 +236,6 @@ class StatisticsServiceTest {
         assertEquals(24, result.points.size)
         assertEquals(400, result.points[9].valueMl)
         assertEquals(0, result.points[8].valueMl)
-        // sanity: today not used as the bucket day
         assertNotNull(today)
     }
 
@@ -283,9 +281,6 @@ class StatisticsServiceTest {
     @Test
     @DisplayName("getStatistics: streak counts back from today even when 'to' is far in the past")
     fun `getStatistics streak still anchored to today when to is before today`() {
-        // Critical regression target: streak must be computed from `today` back, not from `to` back.
-        // today=2026-05-20, range = [2026-04-01 .. 2026-04-30].
-        // Goal met for every day from 2026-05-14..2026-05-20 (7 days back through today).
         val today = LocalDate.of(2026, 5, 20)
         buildService(clockAt("2026-05-20T12:00:00Z"))
         stubSettings()
@@ -309,8 +304,6 @@ class StatisticsServiceTest {
     @Test
     @DisplayName("getStatistics: streak is bounded by STREAK_LIMIT_DAYS even for a very large past range")
     fun `getStatistics streak bounded by limit`() {
-        // Far-past range plus today met for every day for 500 days back.
-        // Streak loop iterates 366 days back from today-1 + today itself -> 367.
         val today = LocalDate.of(2026, 5, 20)
         buildService(clockAt("2026-05-20T12:00:00Z"))
         stubSettings()
@@ -339,20 +332,16 @@ class StatisticsServiceTest {
     @Test
     @DisplayName("getStatistics: bestDay only considers events in [from..to], not the streak window")
     fun `getStatistics bestDay scoped to range`() {
-        // Range is [05-15 .. 05-20] (today=05-20). The huge 9999 on 05-01 must NOT be bestDay
-        // even though it is fetched for the streak look-back window.
         val today = LocalDate.of(2026, 5, 20)
         buildService(clockAt("2026-05-20T12:00:00Z"))
         stubSettings()
         stubEvents(
             listOf(
-                // outside range, fetched only for streak
                 DtoGenerator.generateWaterStatisticDto(
                     externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 1, 10, 0),
                     waterAmountMl = 9999,
                 ),
-                // inside range
                 DtoGenerator.generateWaterStatisticDto(
                     externalUserId = externalUserId,
                     eventTime = LocalDateTime.of(2026, 5, 17, 10, 0),
@@ -380,7 +369,6 @@ class StatisticsServiceTest {
     @DisplayName("getStatistics: from > to -> IllegalArgumentException")
     fun `getStatistics rejects from after to`() {
         buildService(clockAt("2026-05-20T12:00:00Z"))
-        // settings stub not needed: validation runs before user context fetch
         stubSettings()
 
         val ex =
@@ -504,7 +492,6 @@ class StatisticsServiceTest {
                     LocalDateTime.of(2026, 5, 8, 18, 30),
                     "UTC+5:30, fractional offset",
                 ),
-                // DST spring-forward (23h day)
                 Arguments.of(
                     "America/New_York",
                     "2026-03-08T07:30:00Z",

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/user/UserAdminServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/user/UserAdminServiceTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.params.provider.NullSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -20,10 +19,11 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageRequest
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
-import ru.illine.drinking.ponies.dao.repository.AdminUserProjection
-import ru.illine.drinking.ponies.dao.repository.UserCountsProjection
 import ru.illine.drinking.ponies.exception.TelegramUserNotFoundException
 import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
+import ru.illine.drinking.ponies.model.dto.internal.AdminUserDto
+import ru.illine.drinking.ponies.model.dto.internal.UserCountsDto
+import ru.illine.drinking.ponies.model.dto.internal.UserStateDto
 import ru.illine.drinking.ponies.service.user.impl.UserAdminServiceImpl
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import java.time.LocalDateTime
@@ -50,7 +50,6 @@ class UserAdminServiceTest {
         userAdminService.getUsers(search, AdminUserStatusFilter.BANNED, page = 1, size = 5)
 
         verify(telegramUserAccessService).findAllForAdmin(null, AdminUserStatusFilter.BANNED, PageRequest.of(1, 5))
-        // The counters cover every chip of the admin page, so the status must not narrow them down.
         verify(telegramUserAccessService).countForAdmin(null)
     }
 
@@ -58,10 +57,8 @@ class UserAdminServiceTest {
     @CsvSource(
         "alice,    %alice%",
         "' alice ', '% alice %'",
-        // LIKE wildcards a user may legitimately type - a Telegram username often carries "_".
         """alice_p,  '%alice\_p%'""",
         """50%,      '%50\%%'""",
-        // The escape character itself has to be escaped first, or it would swallow the next one.
         """'a\b',    '%a\\b%'""",
     )
     @DisplayName("getUsers(): wraps a real search in wildcards and escapes the ones the user typed")
@@ -89,27 +86,21 @@ class UserAdminServiceTest {
         status: AdminUserStatusFilter,
         expectedTotal: Long,
     ) {
-        val counts =
-            mock<UserCountsProjection> {
-                on { all } doReturn 11L
-                on { active } doReturn 8L
-                on { inactive } doReturn 1L
-                on { banned } doReturn 2L
-            }
+        val counts = UserCountsDto(all = 11L, active = 8L, inactive = 1L, banned = 2L)
         whenever(telegramUserAccessService.findAllForAdmin(anyOrNull(), any(), any())).thenReturn(emptyList())
         whenever(telegramUserAccessService.countForAdmin(anyOrNull())).thenReturn(counts)
 
-        val response = userAdminService.getUsers(null, status, page = 0, size = 20)
+        val result = userAdminService.getUsers(null, status, page = 0, size = 20)
 
-        assertEquals(expectedTotal, response.total)
-        assertEquals(11L, response.counts.all)
+        assertEquals(expectedTotal, result.total)
+        assertEquals(11L, result.counts.all)
     }
 
     @Test
     @DisplayName("updateState(): an empty payload is rejected before the DAO is touched at all")
     fun `updateState rejects an empty payload`() {
         assertThrows<IllegalArgumentException> {
-            userAdminService.updateState(USER_ID, isActive = null)
+            userAdminService.updateState(USER_ID, UserStateDto(isActive = null))
         }
 
         verifyNoInteractions(telegramUserAccessService)
@@ -121,35 +112,35 @@ class UserAdminServiceTest {
         whenever(telegramUserAccessService.findByIdForAdmin(USER_ID)).thenReturn(null)
 
         assertThrows<TelegramUserNotFoundException> {
-            userAdminService.updateState(USER_ID, isActive = false)
+            userAdminService.updateState(USER_ID, UserStateDto(isActive = false))
         }
 
         verify(telegramUserAccessService).findByIdForAdmin(USER_ID)
-        verify(telegramUserAccessService, never()).updateDeleted(any(), any(), any())
+        verify(telegramUserAccessService, never()).updateState(any(), any(), anyOrNull())
     }
 
     @ParameterizedTest(name = "[{index}] isActive={0}")
     @CsvSource("true", "false")
     @DisplayName("updateState(): writes the flag, answers with it and reads the row only once")
     fun `updateState answers with the freshly written flag`(isActive: Boolean) {
-        val user =
-            mock<AdminUserProjection> {
-                on { id } doReturn USER_ID
-                on { externalUserId } doReturn EXTERNAL_USER_ID
-                // Stale on purpose - the row still holds the state from before the update,
-                // so an answer built from it alone would report the opposite of the truth.
-                on { deleted } doReturn isActive
-                on { timeZone } doReturn "Europe/Moscow"
-                on { created } doReturn LocalDateTime.of(2026, 1, 1, 10, 0)
-            }
+        val user = adminUser(deleted = isActive)
         whenever(telegramUserAccessService.findByIdForAdmin(USER_ID)).thenReturn(user)
 
-        val response = userAdminService.updateState(USER_ID, isActive)
+        val result = userAdminService.updateState(USER_ID, UserStateDto(isActive = isActive))
 
-        assertEquals(isActive, response.isActive)
-        verify(telegramUserAccessService).updateDeleted(USER_ID, EXTERNAL_USER_ID, !isActive)
-        // The card comes from the row already read, so the update must not trigger a second read.
+        assertEquals(!isActive, result.deleted)
+        verify(telegramUserAccessService).updateState(USER_ID, EXTERNAL_USER_ID, !isActive)
         verify(telegramUserAccessService, times(1)).findByIdForAdmin(USER_ID)
+    }
+
+    @Test
+    @DisplayName("updateState(): the rest of the row comes back untouched")
+    fun `updateState keeps the rest of the row`() {
+        whenever(telegramUserAccessService.findByIdForAdmin(USER_ID)).thenReturn(adminUser(deleted = true))
+
+        val result = userAdminService.updateState(USER_ID, UserStateDto(isActive = true))
+
+        assertEquals(adminUser(deleted = false), result)
     }
 
     @Test
@@ -166,11 +157,28 @@ class UserAdminServiceTest {
 
     private fun stubEmptyPage() {
         whenever(telegramUserAccessService.findAllForAdmin(anyOrNull(), any(), any())).thenReturn(emptyList())
-        whenever(telegramUserAccessService.countForAdmin(anyOrNull())).thenReturn(mock<UserCountsProjection>())
+        whenever(telegramUserAccessService.countForAdmin(anyOrNull())).thenReturn(EMPTY_COUNTS)
     }
+
+    private fun adminUser(deleted: Boolean): AdminUserDto =
+        AdminUserDto(
+            id = USER_ID,
+            externalUserId = EXTERNAL_USER_ID,
+            firstName = "Alisa",
+            lastName = "Petrova",
+            username = "alisaadmin",
+            isAdmin = false,
+            isBanned = false,
+            deleted = deleted,
+            timeZone = "Europe/Moscow",
+            created = LocalDateTime.of(2026, 1, 1, 10, 0),
+            lastActivity = null,
+        )
 
     companion object {
         private const val USER_ID = 1042L
         private const val EXTERNAL_USER_ID = 482719301L
+
+        private val EMPTY_COUNTS = UserCountsDto(all = 0L, active = 0L, inactive = 0L, banned = 0L)
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
@@ -4,19 +4,20 @@ import ru.illine.drinking.ponies.model.base.AnswerNotificationType
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
 import ru.illine.drinking.ponies.model.base.NotificationHistoryStatus
 import ru.illine.drinking.ponies.model.base.WaterEntrySourceType
-import ru.illine.drinking.ponies.model.dto.BestDayDto
-import ru.illine.drinking.ponies.model.dto.SettingDto
-import ru.illine.drinking.ponies.model.dto.StatisticsDto
-import ru.illine.drinking.ponies.model.dto.StatisticsPointDto
-import ru.illine.drinking.ponies.model.dto.TelegramUserDto
+import ru.illine.drinking.ponies.model.dto.internal.BestDayDto
+import ru.illine.drinking.ponies.model.dto.internal.InsightStatsContext
+import ru.illine.drinking.ponies.model.dto.internal.NotificationHistoryEventDto
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
+import ru.illine.drinking.ponies.model.dto.internal.PauseStateDto
+import ru.illine.drinking.ponies.model.dto.internal.SettingDto
+import ru.illine.drinking.ponies.model.dto.internal.StatisticsDto
+import ru.illine.drinking.ponies.model.dto.internal.StatisticsPointDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfile
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
-import ru.illine.drinking.ponies.model.dto.message.InsightStatsContext
+import ru.illine.drinking.ponies.model.dto.request.TelegramInitDataUser
 import ru.illine.drinking.ponies.model.dto.request.WaterEntryRequest
 import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryEvent
-import ru.illine.drinking.ponies.model.dto.response.PauseStateResponse
 import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
@@ -135,8 +136,8 @@ class DtoGenerator {
             firstName: String? = "First Name",
             lastName: String? = null,
             username: String? = "username",
-        ): TelegramUserDto =
-            TelegramUserDto(
+        ): TelegramInitDataUser =
+            TelegramInitDataUser(
                 externalUserId = externalUserId,
                 firstName = firstName,
                 lastName = lastName,
@@ -203,6 +204,23 @@ class DtoGenerator {
                 firstEntryAt = firstEntryAt,
             )
 
+        fun generateNotificationHistoryEventDto(
+            id: Long = 1042L,
+            eventTime: Instant = Instant.parse("2026-05-10T09:30:00Z"),
+            status: NotificationHistoryStatus = NotificationHistoryStatus.CONFIRMED,
+            amountMl: Int = 300,
+            source: WaterEntrySourceType = WaterEntrySourceType.NOTIFICATION,
+            editable: Boolean = true,
+        ): NotificationHistoryEventDto =
+            NotificationHistoryEventDto(
+                id = id,
+                eventTime = eventTime,
+                status = status,
+                amountMl = amountMl,
+                source = source,
+                editable = editable,
+            )
+
         fun generateNotificationHistoryEvent(
             id: Long = 1042L,
             eventTime: Instant = Instant.parse("2026-05-10T09:30:00Z"),
@@ -220,11 +238,11 @@ class DtoGenerator {
                 editable = editable,
             )
 
-        fun generatePauseStateResponse(
+        fun generatePauseStateDto(
             paused: Boolean = true,
             pauseUntil: Instant? = Instant.parse("2025-01-01T18:00:00Z"),
-        ): PauseStateResponse =
-            PauseStateResponse(
+        ): PauseStateDto =
+            PauseStateDto(
                 paused = paused,
                 pauseUntil = pauseUntil,
             )

--- a/src/test/kotlin/ru/illine/drinking/ponies/test/tag/SpringIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/test/tag/SpringIntegrationTest.kt
@@ -21,8 +21,6 @@ import ru.illine.drinking.ponies.test.config.TestTimeConfig
         TestTimeConfig::class,
     ],
 )
-// These library beans must be mocked via @MockitoBean (not @Bean @Primary)
-// to prevent real instantiation and network connections
 @MockitoBean(types = [TelegramBotsLongPollingApplication::class, BaseAbilityBot::class])
 @ActiveProfiles("integration-test")
 annotation class SpringIntegrationTest

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/PluralizationHelperTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/PluralizationHelperTest.kt
@@ -11,13 +11,11 @@ import ru.illine.drinking.ponies.test.tag.UnitTest
 class PluralizationHelperTest {
     @ParameterizedTest(name = "[{index}] n={0} -> {1}")
     @CsvSource(
-        // singular form (1, 21, 31, 101, ..., excluding 11)
         "1,         день",
         "21,        день",
         "31,        день",
         "101,       день",
         "1001,      день",
-        // few form (2-4, 22-24, 32-34, ..., excluding 12-14)
         "2,         дня",
         "3,         дня",
         "4,         дня",
@@ -25,7 +23,6 @@ class PluralizationHelperTest {
         "24,        дня",
         "33,        дня",
         "104,       дня",
-        // many form (5-20, 25-30, ..., 11-14 special)
         "0,         дней",
         "5,         дней",
         "10,        дней",
@@ -42,7 +39,6 @@ class PluralizationHelperTest {
         "113,       дней",
         "114,       дней",
         "366,       дней",
-        // negative numbers - use absolute value
         "-1,        день",
         "-2,        дня",
         "-5,        дней",

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/message/TemplateRuleTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/message/TemplateRuleTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import ru.illine.drinking.ponies.model.dto.message.InsightStatsContext
+import ru.illine.drinking.ponies.model.dto.internal.InsightStatsContext
 import ru.illine.drinking.ponies.test.tag.UnitTest
 
 @UnitTest

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/sql/CustomP6SpyLoggerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/sql/CustomP6SpyLoggerTest.kt
@@ -21,8 +21,6 @@ class CustomP6SpyLoggerTest {
     @Test
     @DisplayName("init(): does nothing when field is not found")
     fun `init skips when field not found`() {
-        // Exception to the mockito-kotlin style: mockito-kotlin 5.2.1 has no mockStatic wrapper,
-        // so static mocking uses the raw Mockito API (mockStatic + MockedStatic.`when`).
         mockStatic(ReflectionUtils::class.java).use { mocked: MockedStatic<ReflectionUtils> ->
             mocked.`when`<Any?> { ReflectionUtils.findField(any(), anyString()) }.thenReturn(null)
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsAggregatorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsAggregatorTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import ru.illine.drinking.ponies.model.dto.StatisticsPointDto
+import ru.illine.drinking.ponies.model.dto.internal.StatisticsPointDto
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import java.time.DayOfWeek
@@ -44,7 +44,6 @@ class StatisticsAggregatorTest {
     @Test
     @DisplayName("sumByLocalDate(): event near midnight UTC shifts to next local date for +5 zone")
     fun `sumByLocalDate shifts day for positive offset zone`() {
-        // 2026-05-11T19:30Z -> 2026-05-12T00:30 in +5
         val events = listOf(DtoGenerator.generateWaterEvent(LocalDateTime.of(2026, 5, 11, 19, 30), 250))
 
         val result = StatisticsAggregator.sumByLocalDate(events, yekZone)
@@ -105,7 +104,6 @@ class StatisticsAggregatorTest {
     @Test
     @DisplayName("aggregateByHour(): TZ shift moves event into local hour, not UTC hour")
     fun `aggregateByHour respects user zone`() {
-        // 03:30 UTC -> 08:30 in +5 -> hour 08
         val events = listOf(DtoGenerator.generateWaterEvent(LocalDateTime.of(2026, 5, 12, 3, 30), 250))
 
         val result = StatisticsAggregator.aggregateByHour(events, yekZone)
@@ -202,7 +200,6 @@ class StatisticsAggregatorTest {
     @Test
     @DisplayName("bestDay(): picks max value with weekday")
     fun `bestDay picks max with weekday`() {
-        // 2026-05-06 is Wednesday
         val byDate =
             mapOf(
                 LocalDate.of(2026, 5, 4) to 1800,
@@ -255,14 +252,12 @@ class StatisticsAggregatorTest {
         @JvmStatic
         fun provideAverageCases(): Stream<Arguments> =
             Stream.of(
-                // days=1, total=750
                 Arguments.of(
                     1,
                     listOf(StatisticsPointDto("08:00", 250), StatisticsPointDto("13:00", 500)),
                     750,
                     "days=1 returns total",
                 ),
-                // days=7, floor division
                 Arguments.of(
                     7,
                     listOf(
@@ -277,14 +272,12 @@ class StatisticsAggregatorTest {
                     (1800 + 2100 + 2400 + 1500) / 7,
                     "days=7 with partial fill (floor division)",
                 ),
-                // days=28, all zeros
                 Arguments.of(
                     28,
                     (1..28).map { StatisticsPointDto("2025-02-%02d".format(it), 0) },
                     0,
                     "all zeros",
                 ),
-                // days=2, total=999 -> 999/2 = 499 (floor)
                 Arguments.of(
                     2,
                     listOf(

--- a/src/test/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsPeriodHelperTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/util/statistics/StatisticsPeriodHelperTest.kt
@@ -19,7 +19,6 @@ class StatisticsPeriodHelperTest {
     @Test
     @DisplayName("toLocal(): converts UTC LocalDateTime to user zone LocalDateTime")
     fun `toLocal converts utc to user zone`() {
-        // 03:30 UTC -> +5 zone = 08:30 local
         val utc = LocalDateTime.of(2026, 5, 12, 3, 30)
         val zone = ZoneId.of("Asia/Yekaterinburg") // +5
 
@@ -31,7 +30,6 @@ class StatisticsPeriodHelperTest {
     @Test
     @DisplayName("toLocal(): crosses day boundary in positive zone")
     fun `toLocal crosses day boundary`() {
-        // 19:30 UTC -> +5 zone = next day 00:30 local
         val utc = LocalDateTime.of(2026, 5, 11, 19, 30)
         val zone = ZoneId.of("Asia/Yekaterinburg") // +5
 
@@ -95,7 +93,6 @@ class StatisticsPeriodHelperTest {
         @JvmStatic
         fun provideLocalDayBoundsCases(): Stream<Arguments> =
             Stream.of(
-                // UTC
                 Arguments.of(
                     "UTC",
                     LocalDate.of(2026, 5, 12),
@@ -103,7 +100,6 @@ class StatisticsPeriodHelperTest {
                     LocalDateTime.of(2026, 5, 13, 0, 0),
                     "UTC",
                 ),
-                // Asia/Yekaterinburg (+5)
                 Arguments.of(
                     "Asia/Yekaterinburg",
                     LocalDate.of(2026, 5, 12),
@@ -111,7 +107,6 @@ class StatisticsPeriodHelperTest {
                     LocalDateTime.of(2026, 5, 12, 19, 0),
                     "UTC+5",
                 ),
-                // Pacific/Kiritimati (+14)
                 Arguments.of(
                     "Pacific/Kiritimati",
                     LocalDate.of(2026, 5, 12),
@@ -119,7 +114,6 @@ class StatisticsPeriodHelperTest {
                     LocalDateTime.of(2026, 5, 12, 10, 0),
                     "UTC+14 extreme",
                 ),
-                // Etc/GMT+12 is UTC-12 (POSIX sign-flip).
                 Arguments.of(
                     "Etc/GMT+12",
                     LocalDate.of(2026, 5, 12),
@@ -127,7 +121,6 @@ class StatisticsPeriodHelperTest {
                     LocalDateTime.of(2026, 5, 13, 12, 0),
                     "UTC-12 extreme",
                 ),
-                // Asia/Kolkata (+5:30) fractional
                 Arguments.of(
                     "Asia/Kolkata",
                     LocalDate.of(2026, 5, 12),
@@ -135,7 +128,6 @@ class StatisticsPeriodHelperTest {
                     LocalDateTime.of(2026, 5, 12, 18, 30),
                     "UTC+5:30 fractional",
                 ),
-                // DST spring-forward NY: 2026-03-08 is a 23-hour day in NY.
                 Arguments.of(
                     "America/New_York",
                     LocalDate.of(2026, 3, 8),
@@ -143,7 +135,6 @@ class StatisticsPeriodHelperTest {
                     LocalDateTime.of(2026, 3, 9, 4, 0),
                     "DST spring-forward (23-hour day)",
                 ),
-                // DST fall-back NY: 2026-11-01 is a 25-hour day in NY.
                 Arguments.of(
                     "America/New_York",
                     LocalDate.of(2026, 11, 1),


### PR DESCRIPTION
## Summary
- dao no longer leaks its own types: native query projections moved to `dao/repository/projection/`, the access layer hands out internal DTOs
- services no longer return HTTP response types - `getPauseState`, the notification journal and the admin user endpoints return DTOs, the response is assembled in the controller
- response assembly goes through Konvert mappers (`AdminUserMapper`, `AdminUserResponseMapper`, `NotificationHistoryResponseMapper`, `PauseStateResponseMapper`); the hand-written mapping functions are gone from the services
- `PATCH /users/{id}` state update takes a DTO with named nullable fields, and the access layer writes them with a single statement, so the next toggle joins as a field instead of a new method
- DTO packages flattened to `request` / `response` / `internal`, no nesting and nothing in the root
- page size limit inlined as `@Max(100)`, native SQL fragments moved to `dao/repository/query/`, `MagicNumber` now ignores annotations instead of being baselined
- comments cut down to the few that a failing test would not catch; `DEVELOPMENT.md` gained a Code layout section describing the packages and the DTO rule

## Test plan
- [x] `./gradlew check` green: 813 tests, 0 failures, lint + detekt + coverage
- [x] HTTP contract untouched: no file under `model/dto/response` changed behaviour, controller tests assert the same JSON
- [x] no service returns a response type, no dao type is referenced outside `dao` except the boundary mapper
- [x] GitLab CI pipeline 338 green on edf2cdc
