### PR TITLE
DPTB-128: ban a user, turn them away everywhere and audit the state change

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -144,12 +144,18 @@ The rules above are not left to review attention - most of them fail the build.
 | Internal carriers end with `*Dto` or `*Context` | `architecture/CodeLayoutTest` |
 | `@Konverter`, `@Entity` and `@RestController` each stay in one package | `architecture/CodeLayoutTest` |
 | Tests stay out of `impl` packages, each carries one tag | `architecture/CodeLayoutTest` |
+| Account state flags are written in one place only | `architecture/CodeLayoutTest` |
 | One Liquibase version for tests and for the CI runner | `architecture/ToolingConsistencyTest` |
 | One Gradle version for the wrapper and the CI images | `architecture/ToolingConsistencyTest` |
 | Every declared test tag is executed by the `test` task | `architecture/ToolingConsistencyTest` |
 | Every CI job running gradle is pinned to the shared image | `architecture/ToolingConsistencyTest` |
 | `package` matches the directory | detekt `InvalidPackageDeclaration` |
 | Naming, formatting, import order | ktlint |
+
+`deleted` and `is_banned` are written through `TelegramUserAccessServiceImpl` and nowhere else: every write there
+records an audit event in `user_state_events` and drops the cached access flags. A second writer would produce a state
+change that the history never saw, so the rule matches both spellings of an assignment and any update statement over
+the users table.
 
 Silencing a boundary is caught by the architecture test rather than by detekt's
 own `ForbiddenSuppress`: detekt matches suppression ids as literals while

--- a/src/main/kotlin/ru/illine/drinking/ponies/bot/DrinkingPoniesTelegramBot.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/bot/DrinkingPoniesTelegramBot.kt
@@ -1,5 +1,6 @@
 package ru.illine.drinking.ponies.bot
 
+import org.slf4j.LoggerFactory
 import org.telegram.telegrambots.abilitybots.api.bot.AbilityBot
 import org.telegram.telegrambots.abilitybots.api.bot.BaseAbilityBot
 import org.telegram.telegrambots.abilitybots.api.objects.Ability
@@ -8,9 +9,11 @@ import org.telegram.telegrambots.abilitybots.api.objects.Locality
 import org.telegram.telegrambots.abilitybots.api.objects.Privacy
 import org.telegram.telegrambots.abilitybots.api.objects.Reply
 import org.telegram.telegrambots.abilitybots.api.toggle.BareboneToggle
+import org.telegram.telegrambots.abilitybots.api.util.AbilityUtils
 import org.telegram.telegrambots.meta.api.objects.Update
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.config.property.TelegramBotProperties
+import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
 import ru.illine.drinking.ponies.model.base.TelegramCommandType
 import ru.illine.drinking.ponies.service.button.ReplyButtonFactory
 import ru.illine.drinking.ponies.service.command.CommandService
@@ -19,17 +22,38 @@ import java.util.function.BiConsumer
 
 class DrinkingPoniesTelegramBot(
     telegramClient: TelegramClient,
-    private val telegramBotProperties: TelegramBotProperties,
+    telegramBotProperties: TelegramBotProperties,
     private val notificationService: NotificationService,
     private val replyButtonFactory: ReplyButtonFactory,
     private val commandService: CommandService,
+    private val telegramUserAccessService: TelegramUserAccessService,
 ) : AbilityBot(
         telegramClient,
         telegramBotProperties.username,
         InMemoryDBContext(),
         BareboneToggle(),
     ) {
+    private val logger = LoggerFactory.getLogger("BOT")
+
     override fun creatorId(): Long = 0L
+
+    // The single gate every update passes through, commands and callback queries alike.
+    public override fun checkGlobalFlags(update: Update): Boolean {
+        val externalUserId =
+            try {
+                AbilityUtils.getUser(update).id
+            } catch (e: IllegalStateException) {
+                logger.debug("An update without an originating user is left to the filters downstream: {}", e.message)
+                return true
+            }
+
+        val banned = telegramUserAccessService.resolveAccessFlags(externalUserId).isBanned
+        if (banned) {
+            logger.warn("Banned externalUserId [{}] gets no answer", externalUserId)
+        }
+
+        return !banned
+    }
 
     override fun onRegister() {
         super.onRegister()

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/TelegramBotConfig.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/TelegramBotConfig.kt
@@ -12,6 +12,7 @@ import org.zalando.logbook.Logbook
 import org.zalando.logbook.okhttp.LogbookInterceptor
 import ru.illine.drinking.ponies.bot.DrinkingPoniesTelegramBot
 import ru.illine.drinking.ponies.config.property.TelegramBotProperties
+import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
 import ru.illine.drinking.ponies.service.button.ReplyButtonFactory
 import ru.illine.drinking.ponies.service.command.CommandService
 import ru.illine.drinking.ponies.service.notification.NotificationService
@@ -36,6 +37,7 @@ class TelegramBotConfig {
         notificationService: NotificationService,
         replyButtonFactory: ReplyButtonFactory,
         commandService: CommandService,
+        telegramUserAccessService: TelegramUserAccessService,
     ): BaseAbilityBot =
         DrinkingPoniesTelegramBot(
             telegramClient,
@@ -43,6 +45,7 @@ class TelegramBotConfig {
             notificationService,
             replyButtonFactory,
             commandService,
+            telegramUserAccessService,
         )
 
     @Bean

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/cache/CacheConfig.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/cache/CacheConfig.kt
@@ -16,9 +16,10 @@ class CacheConfig(
 ) {
     companion object {
         const val USER_ACCESS_FLAGS = "user-access-flags"
+        const val USER_PROFILE_SYNC = "user-profile-sync"
         const val WATER_FIRST_ENTRY = "water-first-entry"
 
-        private val ALL_CACHES = listOf(USER_ACCESS_FLAGS, WATER_FIRST_ENTRY)
+        private val ALL_CACHES = listOf(USER_ACCESS_FLAGS, USER_PROFILE_SYNC, WATER_FIRST_ENTRY)
     }
 
     @Bean

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/DefaultExceptionHandler.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/DefaultExceptionHandler.kt
@@ -12,8 +12,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import ru.illine.drinking.ponies.exception.ConflictException
 import ru.illine.drinking.ponies.exception.NotFoundException
-import ru.illine.drinking.ponies.exception.NotificationHistoryEntryNotEditableException
 import ru.illine.drinking.ponies.model.dto.response.ErrorResponse
 
 @RestControllerAdvice
@@ -76,12 +76,10 @@ class DefaultExceptionHandler {
             .body(response)
     }
 
-    @ExceptionHandler(NotificationHistoryEntryNotEditableException::class)
-    fun handleNotificationHistoryEntryNotEditable(
-        e: NotificationHistoryEntryNotEditableException,
-    ): ResponseEntity<ErrorResponse> {
-        logger.warn("Notification history entry is not editable: ${e.message}")
-        val response = ErrorResponse("notification history entry is not editable")
+    @ExceptionHandler(ConflictException::class)
+    fun handleConflict(e: ConflictException): ResponseEntity<ErrorResponse> {
+        logger.warn("${e.clientMessage}: ${e.message}")
+        val response = ErrorResponse(e.clientMessage)
         return ResponseEntity
             .status(HttpStatus.CONFLICT)
             .contentType(MediaType.APPLICATION_JSON)

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptor.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptor.kt
@@ -9,7 +9,9 @@ import org.springframework.web.servlet.HandlerInterceptor
 import ru.illine.drinking.ponies.config.web.security.AuthErrorType
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
 import ru.illine.drinking.ponies.exception.InvalidAuthSignatureException
+import ru.illine.drinking.ponies.model.dto.internal.TelegramAuthUserDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfileDto
+import ru.illine.drinking.ponies.model.dto.internal.UserAccessDto
 import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
 import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
 
@@ -31,49 +33,90 @@ class TelegramAuthInterceptor(
             return true
         }
 
+        val initData = readInitData(request, response) ?: return false
+        val telegramUser = authenticate(initData, response) ?: return false
+        val access = telegramUserAccessService.resolveAccessFlags(telegramUser.externalUserId)
+        if (!admit(access, response)) {
+            return false
+        }
+
+        syncProfile(telegramUser)
+        request.setAttribute(
+            TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE,
+            telegramUser.copy(id = access.id, isAdmin = access.isAdmin),
+        )
+
+        return true
+    }
+
+    private fun readInitData(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+    ): String? {
         val initData = request.getHeader(defaultHeaderName)
         if (initData.isNullOrBlank()) {
             logger.error("Not found required header '$defaultHeaderName', return false")
             rejectResponse(response, HttpServletResponse.SC_UNAUTHORIZED, AuthErrorType.INVALID_AUTH_SIGNATURE)
-            return false
+            return null
         }
 
-        val validSignature =
-            try {
-                telegramValidatorService.verifySignature(initData)
-            } catch (e: InvalidAuthSignatureException) {
-                logger.warn("Invalid signature: ${e.message}")
-                rejectResponse(response, HttpServletResponse.SC_UNAUTHORIZED, AuthErrorType.INVALID_AUTH_SIGNATURE)
-                return false
-            } catch (e: Exception) {
-                logger.error("Unexpected error", e)
-                rejectResponse(response, HttpServletResponse.SC_UNAUTHORIZED)
-                return false
+        return initData
+    }
+
+    private fun authenticate(
+        initData: String,
+        response: HttpServletResponse,
+    ): TelegramAuthUserDto? {
+        val rejection = verifySignature(initData)
+        if (rejection != null) {
+            rejectResponse(response, rejection.status, rejection.errorCode)
+            return null
+        }
+
+        return telegramValidatorService.map(initData)
+    }
+
+    private fun verifySignature(initData: String): Rejection? =
+        try {
+            if (telegramValidatorService.verifySignature(initData)) {
+                null
+            } else {
+                Rejection(HttpServletResponse.SC_FORBIDDEN, AuthErrorType.SESSION_EXPIRED)
+            }
+        } catch (e: InvalidAuthSignatureException) {
+            logger.warn("Invalid signature: ${e.message}")
+            Rejection(HttpServletResponse.SC_UNAUTHORIZED, AuthErrorType.INVALID_AUTH_SIGNATURE)
+        } catch (e: Exception) {
+            logger.error("Unexpected error", e)
+            Rejection(HttpServletResponse.SC_UNAUTHORIZED, AuthErrorType.UNKNOWN)
+        }
+
+    private fun admit(
+        access: UserAccessDto,
+        response: HttpServletResponse,
+    ): Boolean {
+        val rejection =
+            when {
+                access.isBanned -> AuthErrorType.BANNED
+                access.isDeleted -> AuthErrorType.DELETED
+                else -> return true
             }
 
-        if (validSignature) {
-            val telegramUser = telegramValidatorService.map(initData)
-            val access =
-                telegramUserAccessService.resolveAccessFlags(
-                    telegramUser.externalUserId,
-                    TelegramUserProfileDto(
-                        firstName = telegramUser.firstName,
-                        lastName = telegramUser.lastName,
-                        username = telegramUser.username,
-                    ),
-                )
-            val enriched =
-                telegramUser.copy(
-                    isAdmin = access.isAdmin,
-                    isBanned = access.isBanned,
-                    isActive = !access.isDeleted,
-                )
-            request.setAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE, enriched)
-            return true
-        }
+        logger.info("Rejecting externalUserId [{}] as {}", access.externalUserId, rejection.value)
+        rejectResponse(response, HttpServletResponse.SC_FORBIDDEN, rejection)
 
-        rejectResponse(response, HttpServletResponse.SC_FORBIDDEN, AuthErrorType.SESSION_EXPIRED)
         return false
+    }
+
+    private fun syncProfile(telegramUser: TelegramAuthUserDto) {
+        telegramUserAccessService.syncProfile(
+            telegramUser.externalUserId,
+            TelegramUserProfileDto(
+                firstName = telegramUser.firstName,
+                lastName = telegramUser.lastName,
+                username = telegramUser.username,
+            ),
+        )
     }
 
     private fun rejectResponse(
@@ -84,4 +127,9 @@ class TelegramAuthInterceptor(
         response.status = status
         response.setHeader(AuthErrorType.HEADER_NAME, errorCode.value)
     }
+
+    private data class Rejection(
+        val status: Int,
+        val errorCode: AuthErrorType,
+    )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/config/web/security/AuthErrorType.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/config/web/security/AuthErrorType.kt
@@ -7,6 +7,8 @@ enum class AuthErrorType(
     INVALID_AUTH_SIGNATURE("invalid_auth_signature"),
     SESSION_EXPIRED("session_expired"),
     FORBIDDEN_ADMIN("forbidden_admin"),
+    BANNED("banned"),
+    DELETED("deleted"),
     ;
 
     companion object {

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/UserAdminController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/UserAdminController.kt
@@ -10,6 +10,7 @@ import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -17,11 +18,13 @@ import org.springframework.web.bind.annotation.RestController
 import ru.illine.drinking.ponies.config.web.security.AdminOnly
 import ru.illine.drinking.ponies.mapper.AdminUserResponseMapper
 import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
+import ru.illine.drinking.ponies.model.dto.internal.TelegramAuthUserDto
 import ru.illine.drinking.ponies.model.dto.internal.UserStateDto
 import ru.illine.drinking.ponies.model.dto.request.UserStateRequest
 import ru.illine.drinking.ponies.model.dto.response.UserDetailsResponse
 import ru.illine.drinking.ponies.model.dto.response.UsersResponse
 import ru.illine.drinking.ponies.service.user.UserAdminService
+import ru.illine.drinking.ponies.util.telegram.TelegramGeneralConstants
 
 @RestController
 @RequestMapping("/users")
@@ -56,14 +59,17 @@ class UserAdminController(
     ): UserDetailsResponse = AdminUserResponseMapper.toDetails(userAdminService.getUser(id))
 
     @PatchMapping("/{id}")
-    @Operation(summary = "Update user state: soft delete or restore")
+    @Operation(summary = "Update user state: soft delete, restore, ban or unban")
     fun updateUserState(
         @Parameter(description = "Internal user id", example = "1042")
         @PathVariable(name = "id") id: Long,
+        @Parameter(hidden = true)
+        @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) actor: TelegramAuthUserDto,
         @Valid @RequestBody request: UserStateRequest,
     ): UserDetailsResponse {
-        val state = UserStateDto(isActive = request.isActive)
+        val state = UserStateDto(isActive = request.isActive, isBanned = request.isBanned)
+        val actorId = requireNotNull(actor.id) { "An admin without a stored account cannot reach this endpoint" }
 
-        return AdminUserResponseMapper.toDetails(userAdminService.updateState(id, state))
+        return AdminUserResponseMapper.toDetails(userAdminService.updateState(id, actorId, state))
     }
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/UserController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/UserController.kt
@@ -24,7 +24,5 @@ class UserController {
         MeResponse(
             externalUserId = telegramUser.externalUserId,
             isAdmin = telegramUser.isAdmin,
-            isBanned = telegramUser.isBanned,
-            isActive = telegramUser.isActive,
         )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessService.kt
@@ -30,7 +30,7 @@ interface NotificationAccessService {
         time: LocalDateTime,
     ): NotificationSettingDto
 
-    fun updateNotificationSettings(settings: Collection<NotificationSettingDto>): Set<NotificationSettingDto>
+    fun recordMailingResults(settings: Collection<NotificationSettingDto>)
 
     fun findIsEnabledNotificationsByExternalUserId(externalUserId: Long): Boolean
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessService.kt
@@ -6,12 +6,16 @@ import ru.illine.drinking.ponies.model.dto.internal.AdminUserDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfileDto
 import ru.illine.drinking.ponies.model.dto.internal.UserAccessDto
 import ru.illine.drinking.ponies.model.dto.internal.UserCountsDto
+import ru.illine.drinking.ponies.model.dto.internal.UserStateChangeDto
 
 interface TelegramUserAccessService {
-    fun resolveAccessFlags(
+    fun resolveAccessFlags(externalUserId: Long): UserAccessDto
+
+    /** Returns null when the caller carries no profile, true when the stored one was refreshed. */
+    fun syncProfile(
         externalUserId: Long,
         profile: TelegramUserProfileDto,
-    ): UserAccessDto
+    ): Boolean?
 
     fun findAllForAdmin(
         search: String?,
@@ -25,9 +29,9 @@ interface TelegramUserAccessService {
 
     fun updateState(
         id: Long,
-        externalUserId: Long,
-        deleted: Boolean?,
-    )
+        actorId: Long,
+        change: UserStateChangeDto,
+    ): UserAccessDto
 
     fun restoreIfDeleted(externalUserId: Long): Boolean
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/NotificationAccessServiceImpl.kt
@@ -34,7 +34,7 @@ class NotificationAccessServiceImpl(
         logger.debug("Finding all notification setting records")
 
         return settingRepository
-            .findAllWithUserAndChat()
+            .findAllNotBannedWithUserAndChat()
             .map {
                 val user = TelegramUserMapper.toDto(it.telegramUser)
                 val chat = TelegramChatMapper.toDto(it.telegramChat, user)
@@ -73,15 +73,15 @@ class NotificationAccessServiceImpl(
         val userEntity =
             userRepository.findByExternalUserId(
                 externalUserId,
-            ) ?: TelegramUserMapper.toEntity(user)
+            ) ?: TelegramUserMapper.toNewEntity(user)
 
         val chatEntity =
-            chatRepository.findByExternalChatId(externalChatId) ?: TelegramChatMapper.toEntity(chat, userEntity)
+            chatRepository.findByExternalChatId(externalChatId) ?: TelegramChatMapper.toNewEntity(chat, userEntity)
 
         val settingEntity =
             settingRepository.findByTelegramUser_ExternalUserId(
                 externalUserId,
-            ) ?: NotificationSettingMapper.toEntity(setting, userEntity, chatEntity)
+            ) ?: NotificationSettingMapper.toNewEntity(setting, userEntity, chatEntity)
 
         userEntity.addTelegramChat(chatEntity)
         userEntity.notificationSettings = settingEntity
@@ -118,34 +118,39 @@ class NotificationAccessServiceImpl(
     @Transactional
     override fun updateNotificationsEnabled(externalUserId: Long) {
         logger.debug("A notification settings will be enabled (enabled = true) by externalUserId [$externalUserId]")
+        settingRepository.clearPause(externalUserId, LocalDateTime.now(clock))
         settingRepository.switchEnabled(externalUserId, true)
     }
 
     @Transactional
     override fun updateNotificationsDisabled(externalUserId: Long) {
         logger.debug("A notification settings will be disabled (enabled = false) by externalUserId [$externalUserId]")
-        settingRepository.clearPause(externalUserId)
+        settingRepository.clearPause(externalUserId, LocalDateTime.now(clock))
         settingRepository.switchEnabled(externalUserId, false)
     }
 
     @Transactional
-    override fun updateNotificationSettings(settings: Collection<NotificationSettingDto>): Set<NotificationSettingDto> {
-        logger.debug("Updating of notification settings...")
+    override fun recordMailingResults(settings: Collection<NotificationSettingDto>) {
+        if (settings.isEmpty()) return
 
-        return settings
-            .map {
-                val user = TelegramUserMapper.toEntity(it.telegramUser)
-                val chat = TelegramChatMapper.toEntity(it.telegramChat, user)
-                NotificationSettingMapper.toEntity(it, user, chat).also { setting ->
-                    user.notificationSettings = setting
-                    user.telegramChats += chat
-                }
-            }.apply { settingRepository.saveAll(this) }
-            .map {
-                val user = TelegramUserMapper.toDto(it.telegramUser)
-                val chat = TelegramChatMapper.toDto(it.telegramChat, user)
-                NotificationSettingMapper.toDto(it, user, chat)
-            }.toSet()
+        logger.debug("Recording the results of a mailing round for [{}] users", settings.size)
+
+        val byExternalUserId =
+            settingRepository
+                .findAllWithUserAndChatByExternalUserIdIn(settings.map { it.telegramUser.externalUserId })
+                .associateBy { it.telegramUser.externalUserId }
+
+        settings.forEach { dto ->
+            val stored = byExternalUserId[dto.telegramUser.externalUserId]
+            if (stored == null) {
+                logger.warn("Nothing to record: settings of [{}] are gone", dto.telegramUser.externalUserId)
+                return@forEach
+            }
+
+            stored.timeOfLastNotification = dto.timeOfLastNotification
+            stored.notificationAttempts = dto.notificationAttempts
+            stored.telegramChat.previousNotificationMessageId = dto.telegramChat.previousNotificationMessageId
+        }
     }
 
     @Transactional
@@ -188,14 +193,14 @@ class NotificationAccessServiceImpl(
             start,
             end,
         )
-        settingRepository.clearPause(externalUserId)
+        settingRepository.clearPause(externalUserId, LocalDateTime.now(clock))
         settingRepository.updateQuietMode(externalUserId, start, end)
     }
 
     @Transactional
     override fun updateQuietModeDisabled(externalUserId: Long) {
         logger.debug("The quiet mod will be disabled for a user [$externalUserId]")
-        settingRepository.clearPause(externalUserId)
+        settingRepository.clearPause(externalUserId, LocalDateTime.now(clock))
         settingRepository.updateQuietMode(externalUserId)
     }
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/TelegramUserAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/TelegramUserAccessServiceImpl.kt
@@ -9,33 +9,67 @@ import org.springframework.transaction.annotation.Transactional
 import ru.illine.drinking.ponies.config.cache.CacheConfig
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
 import ru.illine.drinking.ponies.dao.repository.TelegramUserRepository
+import ru.illine.drinking.ponies.dao.repository.UserStateEventRepository
+import ru.illine.drinking.ponies.exception.TelegramUserNotFoundException
 import ru.illine.drinking.ponies.mapper.AdminUserMapper
 import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
+import ru.illine.drinking.ponies.model.base.UserStateEventType
 import ru.illine.drinking.ponies.model.dto.internal.AdminUserDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfileDto
 import ru.illine.drinking.ponies.model.dto.internal.UserAccessDto
 import ru.illine.drinking.ponies.model.dto.internal.UserCountsDto
+import ru.illine.drinking.ponies.model.dto.internal.UserStateChangeDto
 import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
+import ru.illine.drinking.ponies.model.entity.UserStateEventEntity
+import java.time.Clock
+import java.time.LocalDateTime
 
 @Service
 class TelegramUserAccessServiceImpl(
     private val telegramUserRepository: TelegramUserRepository,
+    private val userStateEventRepository: UserStateEventRepository,
+    private val clock: Clock,
 ) : TelegramUserAccessService {
     private val logger = LoggerFactory.getLogger("ACCESS-SERVICE")
 
-    @Transactional
     @Cacheable(CacheConfig.USER_ACCESS_FLAGS, key = "#externalUserId")
-    override fun resolveAccessFlags(
-        externalUserId: Long,
-        profile: TelegramUserProfileDto,
-    ): UserAccessDto {
+    override fun resolveAccessFlags(externalUserId: Long): UserAccessDto {
         logger.debug("Resolving access flags for externalUserId={}", externalUserId)
 
         val user =
-            telegramUserRepository.findByExternalUserIdIncludingDeleted(externalUserId) ?: return UserAccessDto()
-        refreshProfile(user, profile)
+            telegramUserRepository.findByExternalUserIdIncludingDeleted(externalUserId)
+                ?: return UserAccessDto(externalUserId = externalUserId)
 
-        return UserAccessDto(isAdmin = user.isAdmin, isBanned = user.isBanned, isDeleted = user.deleted)
+        return user.toAccessDto()
+    }
+
+    // The cache is a throttle rather than a store: a miss means the profile is due for a re-read, once per its TTL.
+    // A call without a profile returns null and is not cached, so it does not eat the window of a real rename.
+    @Transactional
+    @Cacheable(CacheConfig.USER_PROFILE_SYNC, key = "#externalUserId", unless = "#result == null")
+    override fun syncProfile(
+        externalUserId: Long,
+        profile: TelegramUserProfileDto,
+    ): Boolean? {
+        // Telegram guarantees a first name and nothing else, so its absence means no profile was handed over at all.
+        if (profile.firstName == null) {
+            logger.info("Nothing to sync for externalUserId={}: the caller carries no profile", externalUserId)
+            return null
+        }
+
+        val user =
+            telegramUserRepository
+                .findByExternalUserIdIncludingDeleted(externalUserId)
+                ?.takeUnless { it.matches(profile) }
+
+        user?.apply {
+            logger.debug("Refreshing profile for externalUserId={}", externalUserId)
+            firstName = profile.firstName
+            lastName = profile.lastName
+            username = profile.username
+        }
+
+        return user != null
     }
 
     @Transactional(readOnly = true)
@@ -66,41 +100,80 @@ class TelegramUserAccessServiceImpl(
     }
 
     @Transactional
-    @CacheEvict(CacheConfig.USER_ACCESS_FLAGS, key = "#externalUserId")
+    @CacheEvict(CacheConfig.USER_ACCESS_FLAGS, key = "#result.externalUserId")
     override fun updateState(
         id: Long,
-        externalUserId: Long,
-        deleted: Boolean?,
-    ) {
-        logger.debug("Setting deleted={} for user [{}]", deleted, id)
+        actorId: Long,
+        change: UserStateChangeDto,
+    ): UserAccessDto {
+        val user =
+            telegramUserRepository.findByIdIncludingDeleted(id)
+                ?: throw TelegramUserNotFoundException("No user with id: [$id]")
 
-        telegramUserRepository.updateState(id, deleted)
+        val events =
+            buildList {
+                change.deleted?.takeIf { it != user.deleted }?.let {
+                    user.deleted = it
+                    add(if (it) UserStateEventType.DEACTIVATED else UserStateEventType.RESTORED)
+                }
+                change.banned?.takeIf { it != user.isBanned }?.let {
+                    user.isBanned = it
+                    add(if (it) UserStateEventType.BANNED else UserStateEventType.UNBANNED)
+                }
+            }
+
+        if (events.isNotEmpty()) {
+            logger.info("Applying {} to user [{}]", events, id)
+            recordEvents(id, actorId, events)
+        }
+
+        return user.toAccessDto()
     }
 
     @Transactional
-    @CacheEvict(CacheConfig.USER_ACCESS_FLAGS, key = "#externalUserId")
+    @CacheEvict(CacheConfig.USER_ACCESS_FLAGS, key = "#externalUserId", condition = "#result")
     override fun restoreIfDeleted(externalUserId: Long): Boolean {
-        val restored = telegramUserRepository.restoreByExternalUserId(externalUserId) > 0
-        if (restored) {
-            logger.info("Restoring soft deleted user [{}]", externalUserId)
-        }
+        val user =
+            telegramUserRepository
+                .findByExternalUserIdIncludingDeleted(externalUserId)
+                ?.takeIf { it.deleted }
+                ?: return false
 
-        return restored
+        val id = requireNotNull(user.id)
+        logger.info("Restoring soft deleted user [{}]", externalUserId)
+        user.deleted = false
+        recordEvents(id, id, listOf(UserStateEventType.RESTORED))
+
+        return true
     }
 
-    private fun refreshProfile(
-        user: TelegramUserEntity,
-        profile: TelegramUserProfileDto,
+    private fun recordEvents(
+        userId: Long,
+        actorId: Long,
+        types: List<UserStateEventType>,
     ) {
-        if (profile.firstName == null) return
+        val eventTime = LocalDateTime.now(clock)
 
-        if (user.matches(profile)) return
-
-        logger.debug("Refreshing profile for externalUserId={}", user.externalUserId)
-        user.firstName = profile.firstName
-        user.lastName = profile.lastName
-        user.username = profile.username
+        userStateEventRepository.saveAll(
+            types.map {
+                UserStateEventEntity(
+                    userId = userId,
+                    actorUserId = actorId,
+                    eventType = it,
+                    eventTime = eventTime,
+                )
+            },
+        )
     }
+
+    private fun TelegramUserEntity.toAccessDto(): UserAccessDto =
+        UserAccessDto(
+            id = id,
+            externalUserId = externalUserId,
+            isAdmin = isAdmin,
+            isBanned = isBanned,
+            isDeleted = deleted,
+        )
 
     private fun TelegramUserEntity.matches(profile: TelegramUserProfileDto): Boolean =
         firstName == profile.firstName &&

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/NotificationSettingRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/NotificationSettingRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import ru.illine.drinking.ponies.model.entity.NotificationSettingEntity
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 interface NotificationSettingRepository : JpaRepository<NotificationSettingEntity, Long> {
@@ -15,11 +16,24 @@ interface NotificationSettingRepository : JpaRepository<NotificationSettingEntit
     @Query(
         value = """
             select ns from NotificationSettingEntity ns
-            join fetch ns.telegramUser
+            join fetch ns.telegramUser u
             join fetch ns.telegramChat
+            where u.isBanned = false
         """,
     )
-    fun findAllWithUserAndChat(): List<NotificationSettingEntity>
+    fun findAllNotBannedWithUserAndChat(): List<NotificationSettingEntity>
+
+    @Query(
+        value = """
+            select ns from NotificationSettingEntity ns
+            join fetch ns.telegramUser u
+            join fetch ns.telegramChat
+            where u.externalUserId in :externalUserIds
+        """,
+    )
+    fun findAllWithUserAndChatByExternalUserIdIn(
+        @Param("externalUserIds") externalUserIds: Collection<Long>,
+    ): List<NotificationSettingEntity>
 
     @Query(
         value = """
@@ -67,11 +81,14 @@ interface NotificationSettingRepository : JpaRepository<NotificationSettingEntit
         @Param("end") end: LocalTime? = null,
     )
 
+    // A pause is a forward shift of time_of_last_notification, so dropping the mark alone would leave
+    // the user silent until the shift runs out.
     @Modifying
     @Query(
         value = """
         update notification_settings ns
-        set pause_until = null
+        set pause_until = null,
+            time_of_last_notification = least(ns.time_of_last_notification, :now)
         from telegram_users u
         where ns.telegram_user_id = u.id
           and u.external_user_id = :externalUserId
@@ -80,6 +97,7 @@ interface NotificationSettingRepository : JpaRepository<NotificationSettingEntit
     )
     fun clearPause(
         @Param("externalUserId") externalUserId: Long,
+        @Param("now") now: LocalDateTime,
     )
 
     @Modifying

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/TelegramUserRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/TelegramUserRepository.kt
@@ -2,7 +2,6 @@ package ru.illine.drinking.ponies.dao.repository
 
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import ru.illine.drinking.ponies.dao.repository.projection.AdminUserProjection
@@ -21,6 +20,11 @@ interface TelegramUserRepository : JpaRepository<TelegramUserEntity, Long> {
     @Query(value = "select * from telegram_users u where u.external_user_id = :externalUserId", nativeQuery = true)
     fun findByExternalUserIdIncludingDeleted(
         @Param("externalUserId") externalUserId: Long,
+    ): TelegramUserEntity?
+
+    @Query(value = "select * from telegram_users u where u.id = :id", nativeQuery = true)
+    fun findByIdIncludingDeleted(
+        @Param("id") id: Long,
     ): TelegramUserEntity?
 
     @Query(
@@ -61,32 +65,4 @@ interface TelegramUserRepository : JpaRepository<TelegramUserEntity, Long> {
     fun countForAdmin(
         @Param("search") search: String?,
     ): UserCountsProjection
-
-    @Modifying(clearAutomatically = true)
-    @Query(
-        value = """
-            update telegram_users
-            set deleted = coalesce(cast(:deleted as boolean), deleted)
-            where id = :id
-        """,
-        nativeQuery = true,
-    )
-    fun updateState(
-        @Param("id") id: Long,
-        @Param("deleted") deleted: Boolean?,
-    )
-
-    @Modifying(clearAutomatically = true)
-    @Query(
-        value = """
-            update telegram_users
-            set deleted = false
-            where external_user_id = :externalUserId
-              and deleted = true
-        """,
-        nativeQuery = true,
-    )
-    fun restoreByExternalUserId(
-        @Param("externalUserId") externalUserId: Long,
-    ): Int
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/UserStateEventRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/UserStateEventRepository.kt
@@ -1,0 +1,6 @@
+package ru.illine.drinking.ponies.dao.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import ru.illine.drinking.ponies.model.entity.UserStateEventEntity
+
+interface UserStateEventRepository : JpaRepository<UserStateEventEntity, Long>

--- a/src/main/kotlin/ru/illine/drinking/ponies/exception/ConflictException.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/exception/ConflictException.kt
@@ -1,0 +1,6 @@
+package ru.illine.drinking.ponies.exception
+
+abstract class ConflictException(
+    val clientMessage: String,
+    message: String,
+) : RuntimeException(message)

--- a/src/main/kotlin/ru/illine/drinking/ponies/exception/NotificationHistoryEntryNotEditableException.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/exception/NotificationHistoryEntryNotEditableException.kt
@@ -2,4 +2,4 @@ package ru.illine.drinking.ponies.exception
 
 class NotificationHistoryEntryNotEditableException(
     message: String,
-) : RuntimeException(message)
+) : ConflictException("notification history entry is not editable", message)

--- a/src/main/kotlin/ru/illine/drinking/ponies/exception/SelfStateChangeException.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/exception/SelfStateChangeException.kt
@@ -1,0 +1,5 @@
+package ru.illine.drinking.ponies.exception
+
+class SelfStateChangeException(
+    message: String,
+) : ConflictException("you cannot change the state of your own account", message)

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/NotificationSettingMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/NotificationSettingMapper.kt
@@ -1,6 +1,8 @@
 package ru.illine.drinking.ponies.mapper
 
+import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Mapping
 import ru.illine.drinking.ponies.model.dto.internal.NotificationSettingDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
@@ -16,7 +18,8 @@ interface NotificationSettingMapper {
         telegramChat: TelegramChatDto,
     ): NotificationSettingDto
 
-    fun toEntity(
+    @Konvert(mappings = [Mapping(target = "id", ignore = true)])
+    fun toNewEntity(
         @Konverter.Source setting: NotificationSettingDto,
         telegramUser: TelegramUserEntity,
         telegramChat: TelegramChatEntity,

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/TelegramChatMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/TelegramChatMapper.kt
@@ -1,6 +1,8 @@
 package ru.illine.drinking.ponies.mapper
 
+import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Mapping
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
 import ru.illine.drinking.ponies.model.entity.TelegramChatEntity
@@ -13,7 +15,8 @@ interface TelegramChatMapper {
         telegramUser: TelegramUserDto,
     ): TelegramChatDto
 
-    fun toEntity(
+    @Konvert(mappings = [Mapping(target = "id", ignore = true)])
+    fun toNewEntity(
         @Konverter.Source chat: TelegramChatDto,
         telegramUser: TelegramUserEntity,
     ): TelegramChatEntity

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/TelegramUserMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/TelegramUserMapper.kt
@@ -1,6 +1,8 @@
 package ru.illine.drinking.ponies.mapper
 
+import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Mapping
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserDto
 import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 
@@ -8,7 +10,8 @@ import ru.illine.drinking.ponies.model.entity.TelegramUserEntity
 interface TelegramUserMapper {
     fun toDto(entity: TelegramUserEntity): TelegramUserDto
 
-    fun toEntity(dto: TelegramUserDto): TelegramUserEntity
+    @Konvert(mappings = [Mapping(target = "id", ignore = true)])
+    fun toNewEntity(dto: TelegramUserDto): TelegramUserEntity
 
     companion object : TelegramUserMapper by Konverter.get<TelegramUserMapper>()
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/base/UserStateEventType.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/base/UserStateEventType.kt
@@ -1,0 +1,8 @@
+package ru.illine.drinking.ponies.model.base
+
+enum class UserStateEventType {
+    BANNED,
+    UNBANNED,
+    DEACTIVATED,
+    RESTORED,
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/TelegramAuthUserDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/TelegramAuthUserDto.kt
@@ -1,11 +1,10 @@
 package ru.illine.drinking.ponies.model.dto.internal
 
 data class TelegramAuthUserDto(
+    val id: Long? = null,
     val externalUserId: Long,
     val firstName: String? = null,
     val lastName: String? = null,
     val username: String? = null,
     val isAdmin: Boolean = false,
-    val isBanned: Boolean = false,
-    val isActive: Boolean = false,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserAccessDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserAccessDto.kt
@@ -1,6 +1,8 @@
 package ru.illine.drinking.ponies.model.dto.internal
 
 data class UserAccessDto(
+    val id: Long? = null,
+    val externalUserId: Long,
     val isAdmin: Boolean = false,
     val isBanned: Boolean = false,
     val isDeleted: Boolean = false,

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserStateChangeDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserStateChangeDto.kt
@@ -1,0 +1,6 @@
+package ru.illine.drinking.ponies.model.dto.internal
+
+data class UserStateChangeDto(
+    val deleted: Boolean? = null,
+    val banned: Boolean? = null,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserStateDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserStateDto.kt
@@ -2,4 +2,5 @@ package ru.illine.drinking.ponies.model.dto.internal
 
 data class UserStateDto(
     val isActive: Boolean? = null,
+    val isBanned: Boolean? = null,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/UserStateRequest.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/UserStateRequest.kt
@@ -13,4 +13,11 @@ data class UserStateRequest(
         requiredMode = Schema.RequiredMode.NOT_REQUIRED,
     )
     val isActive: Boolean?,
+    @Schema(
+        description = "True bans the user, false lifts the ban",
+        example = "false",
+        nullable = true,
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val isBanned: Boolean?,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/MeResponse.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/MeResponse.kt
@@ -10,11 +10,4 @@ data class MeResponse(
     val externalUserId: Long,
     @Schema(description = "Whether the user has admin privileges", example = "false")
     val isAdmin: Boolean,
-    @Schema(description = "Whether the user has been banned", example = "false")
-    val isBanned: Boolean,
-    @Schema(
-        description = "Whether the account is active; false means it was deleted and a /start brings it back",
-        example = "true",
-    )
-    val isActive: Boolean,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/entity/TelegramUserEntity.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/entity/TelegramUserEntity.kt
@@ -11,10 +11,8 @@ import jakarta.persistence.Id
 import jakarta.persistence.Index
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
-import jakarta.persistence.PreRemove
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
-import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -30,7 +28,6 @@ import java.time.ZoneOffset
         ),
     ],
 )
-@SQLDelete(sql = "update telegram_users set deleted = true where id = ?")
 @SQLRestriction(value = "deleted = false")
 class TelegramUserEntity(
     @Id
@@ -75,11 +72,6 @@ class TelegramUserEntity(
     )
     var notificationSettings: NotificationSettingEntity? = null,
 ) {
-    @PreRemove
-    private fun onDelete() {
-        deleted = true
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/entity/UserStateEventEntity.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/entity/UserStateEventEntity.kt
@@ -1,0 +1,37 @@
+package ru.illine.drinking.ponies.model.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
+import ru.illine.drinking.ponies.model.base.UserStateEventType
+import java.time.LocalDateTime
+
+// Users are referenced by raw ids: @SQLRestriction hides a deleted user, and every event is about state changes
+// that a deleted or banned user goes through.
+@Entity
+@Table(name = "user_state_events")
+class UserStateEventEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "userStateEventSeqGenerator")
+    @SequenceGenerator(
+        name = "userStateEventSeqGenerator",
+        sequenceName = "user_state_event_seq",
+        allocationSize = 1,
+    )
+    var id: Long? = null,
+    @Column(name = "user_id", nullable = false)
+    var userId: Long,
+    @Column(name = "actor_user_id", nullable = false)
+    var actorUserId: Long,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false)
+    var eventType: UserStateEventType,
+    @Column(name = "event_time", nullable = false)
+    var eventTime: LocalDateTime,
+)

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSenderServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationSenderServiceImpl.kt
@@ -63,7 +63,7 @@ class NotificationSenderServiceImpl(
                 }
             }
 
-        notificationAccessService.updateNotificationSettings(sent)
+        notificationAccessService.recordMailingResults(sent)
     }
 
     override fun suspendNotifications(notifications: Collection<NotificationSettingDto>) {
@@ -94,7 +94,7 @@ class NotificationSenderServiceImpl(
                 }
             }
 
-        notificationAccessService.updateNotificationSettings(sent)
+        notificationAccessService.recordMailingResults(sent)
         waterStatisticService.recordEvents(
             sent.map { it.telegramUser },
             AnswerNotificationType.CANCEL,

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/notification/impl/NotificationServiceImpl.kt
@@ -42,6 +42,7 @@ class NotificationServiceImpl(
         val setting =
             notificationAccessService.existsByExternalUserId(externalUserId).check(
                 ifTrue = {
+                    notificationAccessService.updateNotificationsEnabled(externalUserId)
                     notificationAccessService.findNotificationSettingByExternalUserId(externalUserId)
                 },
                 ifFalse = {

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/user/UserAdminService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/user/UserAdminService.kt
@@ -17,6 +17,7 @@ interface UserAdminService {
 
     fun updateState(
         id: Long,
+        actorId: Long,
         state: UserStateDto,
     ): AdminUserDto
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/user/impl/UserAdminServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/user/impl/UserAdminServiceImpl.kt
@@ -6,11 +6,13 @@ import org.springframework.data.jpa.repository.query.EscapeCharacter
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
+import ru.illine.drinking.ponies.exception.SelfStateChangeException
 import ru.illine.drinking.ponies.exception.TelegramUserNotFoundException
 import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
 import ru.illine.drinking.ponies.model.dto.internal.AdminUserDto
 import ru.illine.drinking.ponies.model.dto.internal.AdminUserPageDto
 import ru.illine.drinking.ponies.model.dto.internal.UserCountsDto
+import ru.illine.drinking.ponies.model.dto.internal.UserStateChangeDto
 import ru.illine.drinking.ponies.model.dto.internal.UserStateDto
 import ru.illine.drinking.ponies.service.user.UserAdminService
 
@@ -45,16 +47,27 @@ class UserAdminServiceImpl(
     @Transactional
     override fun updateState(
         id: Long,
+        actorId: Long,
         state: UserStateDto,
     ): AdminUserDto {
-        val isActive = requireNotNull(state.isActive) { "At least one state field is required, got an empty payload" }
+        require(state.isActive != null || state.isBanned != null) {
+            "At least one state field is required, got an empty payload"
+        }
+        if (id == actorId) {
+            throw SelfStateChangeException("Admin [$actorId] tried to change their own state")
+        }
 
         val user = requireUser(id)
 
-        logger.info("Setting isActive={} for user [{}]", isActive, id)
-        telegramUserAccessService.updateState(id, user.externalUserId, deleted = !isActive)
+        logger.info("Setting isActive={}, isBanned={} for user [{}]", state.isActive, state.isBanned, id)
+        val applied =
+            telegramUserAccessService.updateState(
+                id = id,
+                actorId = actorId,
+                change = UserStateChangeDto(deleted = state.isActive?.not(), banned = state.isBanned),
+            )
 
-        return user.copy(deleted = !isActive)
+        return user.copy(deleted = applied.isDeleted, isBanned = applied.isBanned)
     }
 
     private fun String.toSearchPattern(): String = "%${EscapeCharacter.DEFAULT.escape(this)}%"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -86,10 +86,13 @@ cache:
   default:
     ttl: ${CACHE_DEFAULT_TTL:5m}
     maximum-size: ${CACHE_DEFAULT_MAXIMUM_SIZE:100}
-  # Per-cache overrides (optional). Example:
-  # overrides:
-  #   user-access-flags:
-  #     ttl: 10m
+  overrides:
+    # How stale an access decision may be: a ban has to take effect quickly.
+    user-access-flags:
+      ttl: ${CACHE_USER_ACCESS_FLAGS_TTL:1m}
+    # How often the Telegram profile is re-read: a name changes rarely, the write is pure overhead.
+    user-profile-sync:
+      ttl: ${CACHE_USER_PROFILE_SYNC_TTL:1h}
 
 springdoc:
   api-docs:

--- a/src/main/resources/liquibase/8.8.0/changes.yaml
+++ b/src/main/resources/liquibase/8.8.0/changes.yaml
@@ -17,3 +17,9 @@ databaseChangeLog:
   - include:
       file: ddl/03_telegram_users_created_without_time_zone.sql
       relativeToChangelogFile: true
+  - include:
+      file: ddl/04_user_state_events.sql
+      relativeToChangelogFile: true
+  - include:
+      file: ddl/05_grants.sql
+      relativeToChangelogFile: true

--- a/src/main/resources/liquibase/8.8.0/ddl/04_user_state_events.sql
+++ b/src/main/resources/liquibase/8.8.0/ddl/04_user_state_events.sql
@@ -1,0 +1,29 @@
+--liquibase formatted sql
+
+--changeset illine:8.8.0/ddl/user_state_events
+
+/* liquibase rollback
+ drop table user_state_events;
+ drop sequence user_state_event_seq;
+*/
+
+create sequence user_state_event_seq;
+
+create table user_state_events
+(
+    id            bigint default nextval('user_state_event_seq') not null
+        primary key,
+    user_id       bigint                                         not null
+        references telegram_users (id),
+    actor_user_id bigint                                         not null
+        references telegram_users (id),
+    event_type    text                                           not null,
+    event_time    timestamp(0)                                   not null
+);
+
+comment on table user_state_events is 'History of account state changes; the current state itself lives in telegram_users';
+comment on column user_state_events.id is 'Primary key of the table';
+comment on column user_state_events.user_id is 'Whose state has changed';
+comment on column user_state_events.actor_user_id is 'Who changed it: an admin or the user themselves';
+comment on column user_state_events.event_type is 'Type of the event: BANNED, UNBANNED, DEACTIVATED, RESTORED';
+comment on column user_state_events.event_time is 'Time when the change was applied, stored in UTC';

--- a/src/main/resources/liquibase/8.8.0/ddl/05_grants.sql
+++ b/src/main/resources/liquibase/8.8.0/ddl/05_grants.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+
+--changeset illine:8.8.0/ddl/grants
+--rollback revoke all on table user_state_events from dptb;
+
+grant all on table user_state_events to dptb;
+
+grant usage, select, update on sequence user_state_event_seq to dptb;

--- a/src/test/kotlin/ru/illine/drinking/ponies/architecture/CodeLayoutTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/architecture/CodeLayoutTest.kt
@@ -1,11 +1,13 @@
 package ru.illine.drinking.ponies.architecture
 
 import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.declaration.KoFileDeclaration
 import com.lemonappdev.konsist.api.ext.list.withPackage
 import com.lemonappdev.konsist.api.verify.assertFalse
 import com.lemonappdev.konsist.api.verify.assertTrue
 import com.lemonappdev.konsist.core.exception.KoAssertionFailedException
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -25,6 +27,21 @@ private val TEST_TAGS = listOf("UnitTest", "SpringIntegrationTest", "Architectur
 private val SUPPRESS_CALL = Regex("""@(?:file:)?Suppress\(([^)]*)\)""")
 
 private val STRING_LITERAL = Regex(""""([^"]*)"""")
+
+private const val STATE_DOOR = "TelegramUserAccessServiceImpl"
+
+private val STATE_FLAGS = listOf("deleted", "isBanned")
+
+// Both spellings of a write: qualified (user.deleted = ...) and bare inside an apply/with block. The
+// lookbehind drops a named argument, which reads exactly like a bare write once the call wraps over lines.
+private fun stateFlagWrite(flag: String) =
+    Regex("""(?<![(,]\s{0,64})(?:^|\.)\s*$flag\s*=(?!=)""", RegexOption.MULTILINE)
+
+private val STATE_UPDATE_STATEMENT =
+    Regex("""update\s+(telegram_users|TelegramUserEntity)""", RegexOption.IGNORE_CASE)
+
+// Queries live in string literals, where `u.deleted = false` is a condition and not a write.
+private val STRING_LITERAL_CONTENT = Regex(""""{3}[\s\S]*?"{3}|"(?:\\.|[^"\\])*"""")
 
 // detekt accepts its own prefix in any case and honours the ruleset id, so the forms that switch a
 // boundary off are matched by shape instead of being listed one by one.
@@ -183,6 +200,53 @@ class CodeLayoutTest {
             "A boundary is fixed in the code, not silenced with @Suppress",
         )
     }
+
+    @Test
+    @DisplayName("the account state flags are written through a single door")
+    fun `account state has a single door`() {
+        val (door, rest) = Konsist.scopeFromProduction().files.partition { it.name == STATE_DOOR }
+
+        STATE_FLAGS.forEach { flag ->
+            val write = stateFlagWrite(flag)
+
+            assertEquals(
+                emptyList<String>(),
+                rest.filter { write.containsMatchIn(it.code()) }.map { it.name },
+                "'$flag' is written in $STATE_DOOR only, so no write escapes its audit record and cache eviction",
+            )
+            // Per flag, because the rule would otherwise stay green on a rename as long as one flag still matches.
+            assertTrue(
+                write.containsMatchIn(door.single().code()),
+                "$STATE_DOOR must still hold the '$flag' write this rule guards",
+            )
+        }
+        assertEquals(
+            emptyList<String>(),
+            rest.filter { STATE_UPDATE_STATEMENT.containsMatchIn(it.text) }.map { it.name },
+            "An update statement over the users table bypasses the same door",
+        )
+    }
+
+    @Test
+    @DisplayName("guard: the single door rule tells a write from a named argument")
+    fun `a named argument is no state flag write`() {
+        val write = stateFlagWrite("isBanned")
+        val samples =
+            mapOf(
+                "entity.isBanned = true" to true,
+                "entity.apply {\n    isBanned = true\n}" to true,
+                "user.copy(isBanned = applied.isBanned)" to false,
+                "user.copy(\n    deleted = applied.isDeleted,\n    isBanned = applied.isBanned,\n)" to false,
+            )
+
+        assertEquals(
+            samples,
+            samples.mapValues { (code, _) -> write.containsMatchIn(code) },
+            "a named argument stays a read however the call is wrapped, or the rule guards formatting",
+        )
+    }
+
+    private fun KoFileDeclaration.code(): String = text.replace(STRING_LITERAL_CONTENT, "")
 
     @Test
     @DisplayName("guard: a rule broken on purpose still fails")

--- a/src/test/kotlin/ru/illine/drinking/ponies/bot/DrinkingPoniesTelegramBotTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/bot/DrinkingPoniesTelegramBotTest.kt
@@ -1,0 +1,123 @@
+package ru.illine.drinking.ponies.bot
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery
+import org.telegram.telegrambots.meta.api.objects.Update
+import org.telegram.telegrambots.meta.api.objects.User
+import org.telegram.telegrambots.meta.api.objects.message.Message
+import org.telegram.telegrambots.meta.generics.TelegramClient
+import ru.illine.drinking.ponies.config.property.TelegramBotProperties
+import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
+import ru.illine.drinking.ponies.service.button.ReplyButtonFactory
+import ru.illine.drinking.ponies.service.command.CommandService
+import ru.illine.drinking.ponies.service.notification.NotificationService
+import ru.illine.drinking.ponies.test.generator.DtoGenerator
+import ru.illine.drinking.ponies.test.tag.UnitTest
+import java.util.stream.Stream
+
+@UnitTest
+@DisplayName("DrinkingPoniesTelegramBot Unit Test")
+class DrinkingPoniesTelegramBotTest {
+    private lateinit var telegramUserAccessService: TelegramUserAccessService
+    private lateinit var notificationService: NotificationService
+    private lateinit var replyButtonFactory: ReplyButtonFactory
+    private lateinit var bot: DrinkingPoniesTelegramBot
+
+    @BeforeEach
+    fun setUp() {
+        telegramUserAccessService = mock<TelegramUserAccessService>()
+        notificationService = mock<NotificationService>()
+        replyButtonFactory = mock<ReplyButtonFactory>()
+        bot =
+            DrinkingPoniesTelegramBot(
+                mock<TelegramClient>(),
+                properties(),
+                notificationService,
+                replyButtonFactory,
+                mock<CommandService>(),
+                telegramUserAccessService,
+            )
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("provideUpdatesCarryingAUser")
+    @DisplayName("checkGlobalFlags(): a banned user is dropped before any ability or button runs")
+    fun `checkGlobalFlags drops a banned user`(update: Update) {
+        whenever(telegramUserAccessService.resolveAccessFlags(EXTERNAL_USER_ID))
+            .thenReturn(DtoGenerator.generateUserAccessDto(externalUserId = EXTERNAL_USER_ID, isBanned = true))
+
+        assertFalse(bot.checkGlobalFlags(update))
+
+        verify(telegramUserAccessService).resolveAccessFlags(EXTERNAL_USER_ID)
+        verifyNoInteractions(notificationService, replyButtonFactory)
+    }
+
+    @ParameterizedTest(name = "[{index}] isDeleted={0}")
+    @CsvSource("false", "true")
+    @DisplayName("checkGlobalFlags(): anyone who is not banned is let through, a soft-deleted user included")
+    fun `checkGlobalFlags lets a user who is not banned through`(isDeleted: Boolean) {
+        whenever(telegramUserAccessService.resolveAccessFlags(EXTERNAL_USER_ID))
+            .thenReturn(DtoGenerator.generateUserAccessDto(externalUserId = EXTERNAL_USER_ID, isDeleted = isDeleted))
+
+        assertTrue(bot.checkGlobalFlags(messageUpdate()), "A start has to be able to bring a deleted user back")
+
+        verify(telegramUserAccessService).resolveAccessFlags(EXTERNAL_USER_ID)
+    }
+
+    @Test
+    @DisplayName("checkGlobalFlags(): an update without a user is let through without asking for any flags")
+    fun `checkGlobalFlags lets an update without a user through`() {
+        assertTrue(bot.checkGlobalFlags(Update()))
+
+        verifyNoInteractions(telegramUserAccessService, notificationService, replyButtonFactory)
+    }
+
+    private fun properties(): TelegramBotProperties =
+        TelegramBotProperties(
+            token = "token",
+            username = "DrinkingPoniesBot",
+            miniAppUrl = "https://example.test",
+            autoUpdateTelegramConfig = false,
+            http = TelegramBotProperties.Http(connectionTimeToLiveInSec = 60, maxConnectionTotal = 100),
+        )
+
+    companion object {
+        private const val EXTERNAL_USER_ID = 777003L
+
+        @JvmStatic
+        fun provideUpdatesCarryingAUser(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of(Named.of("a command", messageUpdate())),
+                Arguments.of(Named.of("a button press", callbackUpdate())),
+            )
+
+        private fun messageUpdate(): Update =
+            Update().apply {
+                message =
+                    Message().apply {
+                        from = User(EXTERNAL_USER_ID, "Alisa", false)
+                    }
+            }
+
+        private fun callbackUpdate(): Update =
+            Update().apply {
+                callbackQuery =
+                    CallbackQuery().apply {
+                        from = User(EXTERNAL_USER_ID, "Alisa", false)
+                    }
+            }
+    }
+}

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/cache/CacheConfigTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/cache/CacheConfigTest.kt
@@ -27,10 +27,12 @@ class CacheConfigTest {
         val manager = CacheConfig(properties).cacheManager()
 
         assertTrue(manager.cacheNames.contains(CacheConfig.USER_ACCESS_FLAGS))
+        assertTrue(manager.cacheNames.contains(CacheConfig.USER_PROFILE_SYNC))
         assertTrue(manager.cacheNames.contains(CacheConfig.WATER_FIRST_ENTRY))
         assertNotNull(manager.getCache(CacheConfig.USER_ACCESS_FLAGS))
+        assertNotNull(manager.getCache(CacheConfig.USER_PROFILE_SYNC))
         assertNotNull(manager.getCache(CacheConfig.WATER_FIRST_ENTRY))
-        assertEquals(2, manager.cacheNames.size)
+        assertEquals(3, manager.cacheNames.size)
     }
 
     @Test
@@ -69,8 +71,9 @@ class CacheConfigTest {
         val manager = CacheConfig(properties).cacheManager()
 
         assertNotNull(manager.getCache(CacheConfig.USER_ACCESS_FLAGS))
+        assertNotNull(manager.getCache(CacheConfig.USER_PROFILE_SYNC))
         assertNotNull(manager.getCache(CacheConfig.WATER_FIRST_ENTRY))
-        assertEquals(2, manager.cacheNames.size)
+        assertEquals(3, manager.cacheNames.size)
     }
 
     @Test
@@ -92,7 +95,8 @@ class CacheConfigTest {
         val manager = CacheConfig(properties).cacheManager()
 
         assertNotNull(manager.getCache(CacheConfig.USER_ACCESS_FLAGS))
+        assertNotNull(manager.getCache(CacheConfig.USER_PROFILE_SYNC))
         assertNotNull(manager.getCache(CacheConfig.WATER_FIRST_ENTRY))
-        assertEquals(2, manager.cacheNames.size)
+        assertEquals(3, manager.cacheNames.size)
     }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigAuthInterceptorIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/WebConfigAuthInterceptorIntegrationTest.kt
@@ -6,29 +6,38 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.cache.CacheManager
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlConfig
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping
+import ru.illine.drinking.ponies.config.cache.CacheConfig
 import ru.illine.drinking.ponies.config.web.WebConfigAuthInterceptorIntegrationTest.DefaultSecureTestConfig
 import ru.illine.drinking.ponies.config.web.security.AuthErrorType
 import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
+import java.util.stream.Stream
 
 @SpringIntegrationTest
 @DisplayName("WebConfig default-secure interceptor Spring Integration Test")
@@ -47,6 +56,9 @@ class WebConfigAuthInterceptorIntegrationTest
     @Autowired
     constructor(
         private val restTemplate: TestRestTemplate,
+        private val cacheManager: CacheManager,
+        @Qualifier("requestMappingHandlerMapping")
+        private val handlerMapping: RequestMappingHandlerMapping,
     ) {
         @MockitoBean
         private lateinit var telegramValidatorService: TelegramValidatorService
@@ -55,6 +67,7 @@ class WebConfigAuthInterceptorIntegrationTest
 
         @BeforeEach
         fun setUp() {
+            cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)?.clear()
             whenever(telegramValidatorService.verifySignature(any())).thenReturn(true)
             whenever(telegramValidatorService.map(any())).thenReturn(telegramUser)
         }
@@ -129,6 +142,59 @@ class WebConfigAuthInterceptorIntegrationTest
             }
         }
 
+        @Nested
+        @DisplayName("a banned or deleted caller is turned away on every route of the application")
+        inner class RejectedCaller {
+            @ParameterizedTest(name = "[{index}] {1} - {0}")
+            @MethodSource(
+                "ru.illine.drinking.ponies.config.web.WebConfigAuthInterceptorIntegrationTest#provideRoutesAndStates",
+            )
+            @DisplayName("returns 403 with the state code, the admin check never getting a say")
+            fun `turns a rejected caller away`(
+                route: Route,
+                expected: AuthErrorType,
+                externalUserId: Long,
+            ) {
+                whenever(telegramValidatorService.map(any()))
+                    .thenReturn(telegramUser.copy(externalUserId = externalUserId))
+
+                val response =
+                    restTemplate.exchange(
+                        route.path,
+                        route.method,
+                        HttpEntity(route.body, buildHeaders().apply { contentType = MediaType.APPLICATION_JSON }),
+                        String::class.java,
+                    )
+
+                assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
+                assertEquals(expected.value, response.headers.getFirst(AuthErrorType.HEADER_NAME))
+            }
+
+            // An unmapped path answers 403 as well - the barrier sits in front of the resource handler too - so a
+            // typo above would read as a guarantee while walking nothing, and a route added later would go
+            // unwalked. Both are caught by comparing the list to what the application really publishes.
+            @Test
+            @DisplayName("guard: the walked routes are exactly the routes the application publishes")
+            fun `the walked routes are the published ones`() {
+                val published =
+                    handlerMapping.handlerMethods
+                        .filterValues { it.beanType.packageName.startsWith(APPLICATION_PACKAGE) }
+                        .keys
+                        .flatMap { info ->
+                            val patterns = info.pathPatternsCondition?.patternValues.orEmpty()
+                            info.methodsCondition.methods.flatMap { method ->
+                                patterns.map { "${method.name} $it" }
+                            }
+                        }.toSet()
+
+                assertEquals(
+                    EVERY_ROUTE.map { it.toString() }.toSet(),
+                    published,
+                    "A route nobody walks here is a route nobody knows the barrier covers",
+                )
+            }
+        }
+
         @TestConfiguration
         class DefaultSecureTestConfig {
             @RestController
@@ -137,5 +203,55 @@ class WebConfigAuthInterceptorIntegrationTest
                 @GetMapping
                 fun defaultSecure(): String = "ok"
             }
+        }
+
+        data class Route(
+            val method: HttpMethod,
+            val pattern: String,
+            val path: String = pattern,
+            val body: String? = null,
+        ) {
+            override fun toString(): String = "$method $pattern"
+        }
+
+        companion object {
+            private const val APPLICATION_PACKAGE = "ru.illine.drinking.ponies"
+            private const val BANNED_EXTERNAL_ID = 777002L
+            private const val DELETED_EXTERNAL_ID = 777001L
+            private const val EMPTY_BODY = "{}"
+
+            private val EVERY_ROUTE =
+                listOf(
+                    Route(HttpMethod.GET, "/test-default-secure"),
+                    Route(HttpMethod.GET, "/systems/version"),
+                    Route(HttpMethod.GET, "/users/me"),
+                    Route(HttpMethod.GET, "/users"),
+                    Route(HttpMethod.GET, "/users/{id}", "/users/1"),
+                    Route(HttpMethod.PATCH, "/users/{id}", "/users/1", EMPTY_BODY),
+                    Route(HttpMethod.GET, "/settings"),
+                    Route(HttpMethod.PUT, "/settings/quiet-mode", body = EMPTY_BODY),
+                    Route(HttpMethod.PUT, "/settings/timezone", body = EMPTY_BODY),
+                    Route(HttpMethod.PUT, "/settings/interval", body = EMPTY_BODY),
+                    Route(HttpMethod.PUT, "/settings/notification-status", body = EMPTY_BODY),
+                    Route(HttpMethod.PUT, "/settings/goal", body = EMPTY_BODY),
+                    Route(HttpMethod.GET, "/statistics"),
+                    Route(HttpMethod.GET, "/statistics/today"),
+                    Route(HttpMethod.POST, "/statistics/water", body = EMPTY_BODY),
+                    Route(HttpMethod.GET, "/notifications/next"),
+                    Route(HttpMethod.GET, "/notifications/pause"),
+                    Route(HttpMethod.PUT, "/notifications/pause", body = EMPTY_BODY),
+                    Route(HttpMethod.GET, "/notifications/history"),
+                    Route(HttpMethod.PATCH, "/notifications/history/{id}", "/notifications/history/1", EMPTY_BODY),
+                )
+
+            @JvmStatic
+            fun provideRoutesAndStates(): Stream<Arguments> =
+                EVERY_ROUTE
+                    .flatMap {
+                        listOf(
+                            Arguments.of(it, AuthErrorType.BANNED, BANNED_EXTERNAL_ID),
+                            Arguments.of(it, AuthErrorType.DELETED, DELETED_EXTERNAL_ID),
+                        )
+                    }.stream()
         }
     }

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptorTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/interceptor/TelegramAuthInterceptorTest.kt
@@ -2,7 +2,6 @@ package ru.illine.drinking.ponies.config.web.interceptor
 
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -13,9 +12,9 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -117,23 +116,14 @@ class TelegramAuthInterceptorTest {
         verifyNoInteractions(telegramUserAccessService)
     }
 
-    @ParameterizedTest(name = "[{index}] isAdmin={0}, isBanned={1}, isDeleted={2}")
-    @CsvSource(
-        "true,  false, false",
-        "false, true,  false",
-        "false, false, true",
-        "true,  true,  true",
-    )
-    @DisplayName("preHandle(): valid signature - enriches the access flags and sets telegramUser attribute")
-    fun `preHandle valid signature enriches access flags`(
-        isAdmin: Boolean,
-        isBanned: Boolean,
-        isDeleted: Boolean,
-    ) {
+    @ParameterizedTest(name = "[{index}] isAdmin={0}")
+    @CsvSource("true", "false")
+    @DisplayName("preHandle(): valid signature - enriches the admin flag and sets telegramUser attribute")
+    fun `preHandle valid signature enriches access flags`(isAdmin: Boolean) {
         val initData =
             stubValidRequest(
                 user = DtoGenerator.generateTelegramAuthUserDto(lastName = "Petrova"),
-                access = UserAccessDto(isAdmin = isAdmin, isBanned = isBanned, isDeleted = isDeleted),
+                access = DtoGenerator.generateUserAccessDto(isAdmin = isAdmin),
             )
 
         val result = interceptor.preHandle(request, response, Any())
@@ -142,49 +132,82 @@ class TelegramAuthInterceptorTest {
         verify(validatorService).map(initData)
         verify(request).setAttribute(
             TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE,
-            DtoGenerator.generateTelegramAuthUserDto(
-                lastName = "Petrova",
-                isAdmin = isAdmin,
-                isBanned = isBanned,
-                isActive = !isDeleted,
-            ),
+            DtoGenerator.generateTelegramAuthUserDto(lastName = "Petrova", isAdmin = isAdmin),
         )
         verifyNoMoreInteractions(response)
     }
 
     @Test
-    @DisplayName("preHandle(): the access flags come from the access service, never from initData")
+    @DisplayName("preHandle(): the admin flag comes from the access service, never from initData")
     fun `preHandle overrides the access flags carried by initData`() {
         stubValidRequest(
-            user = DtoGenerator.generateTelegramAuthUserDto(isAdmin = true, isBanned = true, isActive = true),
-            access = UserAccessDto(isAdmin = false, isBanned = false, isDeleted = true),
+            user = DtoGenerator.generateTelegramAuthUserDto(isAdmin = true),
+            access = DtoGenerator.generateUserAccessDto(isAdmin = false),
         )
 
         interceptor.preHandle(request, response, Any())
 
         verify(request).setAttribute(
             TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE,
-            DtoGenerator.generateTelegramAuthUserDto(isAdmin = false, isBanned = false, isActive = false),
+            DtoGenerator.generateTelegramAuthUserDto(isAdmin = false),
         )
     }
 
-    @ParameterizedTest(name = "[{index}] isDeleted={0} - isActive={1}")
-    @CsvSource("true, false", "false, true")
-    @DisplayName("preHandle(): valid signature - a deleted account is reported as inactive, not the other way round")
-    fun `preHandle inverts isDeleted into isActive`(
+    @ParameterizedTest(name = "[{index}] isBanned={0}, isDeleted={1} - {2}")
+    @CsvSource(
+        "true,  false, BANNED",
+        "false, true,  DELETED",
+        "true,  true,  BANNED",
+    )
+    @DisplayName("preHandle(): a banned or deleted caller - returns false, 403 and the code the mini app reads")
+    fun `preHandle rejects a banned or deleted caller`(
+        isBanned: Boolean,
         isDeleted: Boolean,
-        expectedIsActive: Boolean,
+        expected: AuthErrorType,
     ) {
         stubValidRequest(
             user = DtoGenerator.generateTelegramAuthUserDto(),
-            access = UserAccessDto(isDeleted = isDeleted),
+            access = DtoGenerator.generateUserAccessDto(isBanned = isBanned, isDeleted = isDeleted),
+        )
+
+        val result = interceptor.preHandle(request, response, Any())
+
+        assertFalse(result)
+        verify(response).status = HttpServletResponse.SC_FORBIDDEN
+        verify(response).setHeader(AuthErrorType.HEADER_NAME, expected.value)
+        verify(request, never()).setAttribute(eq(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE), any())
+    }
+
+    @Test
+    @DisplayName("preHandle(): the internal id of the stored account rides along, the admin endpoints need it")
+    fun `preHandle carries the internal id into the request attribute`() {
+        stubValidRequest(
+            user = DtoGenerator.generateTelegramAuthUserDto(externalUserId = 42L),
+            access = DtoGenerator.generateUserAccessDto(id = 1042L, externalUserId = 42L),
         )
 
         interceptor.preHandle(request, response, Any())
 
-        val captor = argumentCaptor<TelegramAuthUserDto>()
-        verify(request).setAttribute(eq(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE), captor.capture())
-        assertEquals(expectedIsActive, captor.firstValue.isActive)
+        verify(request).setAttribute(
+            TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE,
+            DtoGenerator.generateTelegramAuthUserDto(id = 1042L, externalUserId = 42L),
+        )
+    }
+
+    @Test
+    @DisplayName("preHandle(): a caller with no stored account keeps a null internal id")
+    fun `preHandle leaves the internal id null for an unknown caller`() {
+        stubValidRequest(
+            user = DtoGenerator.generateTelegramAuthUserDto(externalUserId = 42L),
+            access = DtoGenerator.generateUserAccessDto(externalUserId = 42L),
+        )
+
+        assertTrue(interceptor.preHandle(request, response, Any()))
+
+        verify(request).setAttribute(
+            TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE,
+            DtoGenerator.generateTelegramAuthUserDto(externalUserId = 42L),
+        )
     }
 
     @Test
@@ -202,7 +225,7 @@ class TelegramAuthInterceptorTest {
 
         interceptor.preHandle(request, response, Any())
 
-        verify(telegramUserAccessService).resolveAccessFlags(
+        verify(telegramUserAccessService).syncProfile(
             eq(42L),
             eq(
                 DtoGenerator.generateTelegramUserProfileDto(
@@ -212,6 +235,23 @@ class TelegramAuthInterceptorTest {
                 ),
             ),
         )
+    }
+
+    @ParameterizedTest(name = "[{index}] isBanned={0}, isDeleted={1}")
+    @CsvSource("true, false", "false, true")
+    @DisplayName("preHandle(): a rejected caller does not get their profile refreshed either")
+    fun `preHandle skips the profile sync of a rejected caller`(
+        isBanned: Boolean,
+        isDeleted: Boolean,
+    ) {
+        stubValidRequest(
+            user = DtoGenerator.generateTelegramAuthUserDto(firstName = "Alisa"),
+            access = DtoGenerator.generateUserAccessDto(isBanned = isBanned, isDeleted = isDeleted),
+        )
+
+        interceptor.preHandle(request, response, Any())
+
+        verify(telegramUserAccessService, never()).syncProfile(any(), any())
     }
 
     @Test
@@ -233,7 +273,7 @@ class TelegramAuthInterceptorTest {
 
     private fun stubValidRequest(
         user: TelegramAuthUserDto,
-        access: UserAccessDto = UserAccessDto(),
+        access: UserAccessDto = DtoGenerator.generateUserAccessDto(),
     ): String {
         val initData = "valid-init-data"
 
@@ -241,7 +281,7 @@ class TelegramAuthInterceptorTest {
         whenever(request.getHeader(headerName)).thenReturn(initData)
         whenever(validatorService.verifySignature(any())).thenReturn(true)
         whenever(validatorService.map(initData)).thenReturn(user)
-        whenever(telegramUserAccessService.resolveAccessFlags(any(), any())).thenReturn(access)
+        whenever(telegramUserAccessService.resolveAccessFlags(any())).thenReturn(access)
 
         return initData
     }

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/UserAdminControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/UserAdminControllerTest.kt
@@ -31,7 +31,6 @@ import org.springframework.test.context.jdbc.SqlConfig
 import ru.illine.drinking.ponies.config.cache.CacheConfig
 import ru.illine.drinking.ponies.config.web.security.AuthErrorType
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
-import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfileDto
 import ru.illine.drinking.ponies.model.dto.response.UserDetailsResponse
 import ru.illine.drinking.ponies.model.dto.response.UsersResponse
 import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
@@ -428,6 +427,51 @@ class UserAdminControllerTest
             }
 
             @Test
+            @DisplayName("isBanned=true - returns 200 with the banned card and moves the user to BANNED")
+            fun `bans the user`() {
+                val response = patchState(ACTIVE_USER_ID, """{"isBanned": true}""")
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertTrue(objectMapper.readTree(response.body).path("isBanned").asBoolean())
+                assertTrue(getUser(ACTIVE_USER_ID).isBanned)
+                assertEquals(3L, getUsers("?status=BANNED").total)
+            }
+
+            @Test
+            @DisplayName("isBanned=false - lifts the ban and the user leaves the BANNED chip")
+            fun `unbans the user`() {
+                val response = patchState(BANNED_DELETED_USER_ID, """{"isBanned": false}""")
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertFalse(objectMapper.readTree(response.body).path("isBanned").asBoolean())
+                assertFalse(getUser(BANNED_DELETED_USER_ID).isBanned)
+            }
+
+            @Test
+            @DisplayName("both toggles at once - activity and ban are applied in a single call")
+            fun `applies both toggles at once`() {
+                val response = patchState(ACTIVE_USER_ID, """{"isActive": false, "isBanned": true}""")
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                val card = getUser(ACTIVE_USER_ID)
+                assertFalse(card.isActive)
+                assertTrue(card.isBanned)
+            }
+
+            @Test
+            @DisplayName("own account - returns 409 with a readable message and leaves the account alone")
+            fun `refuses to change own state`() {
+                val response = patchState(ADMIN_USER_ID, """{"isBanned": true}""")
+
+                assertEquals(HttpStatus.CONFLICT, response.statusCode)
+                assertEquals(
+                    "you cannot change the state of your own account",
+                    objectMapper.readTree(response.body).path("message").asText(),
+                )
+                assertFalse(getUser(ADMIN_USER_ID).isBanned)
+            }
+
+            @Test
             @DisplayName("empty payload - returns 400 and leaves the user alone")
             fun `returns 400 for an empty payload`() {
                 val response = patchState(ACTIVE_USER_ID, "{}")
@@ -448,7 +492,7 @@ class UserAdminControllerTest
             @DisplayName("evicts the cached access flags, so the next request of that user is resolved afresh")
             fun `evicts the cached access flags of the updated user`() {
                 val cache = cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)!!
-                telegramUserAccessService.resolveAccessFlags(ACTIVE_EXTERNAL_ID, TelegramUserProfileDto())
+                telegramUserAccessService.resolveAccessFlags(ACTIVE_EXTERNAL_ID)
                 assertNotNull(cache.get(ACTIVE_EXTERNAL_ID))
 
                 patchState(ACTIVE_USER_ID, """{"isActive": false}""")

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/UserControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/UserControllerTest.kt
@@ -65,21 +65,16 @@ class UserControllerTest
                 set("X-Authorization-Telegram-Data", "test-init-data")
             }
 
-        @ParameterizedTest(name = "[{index}] externalUserId={0} - isAdmin={1}, isBanned={2}, isActive={3}")
+        @ParameterizedTest(name = "[{index}] externalUserId={0} - isAdmin={1}")
         @CsvSource(
-            "1,      true,  false, true",
-            "2,      false, false, true",
-            "777002, false, true,  true",
-            "777001, false, false, false",
-            "777004, false, true,  false",
-            "0,      false, false, true",
+            "1, true",
+            "2, false",
+            "0, false",
         )
-        @DisplayName("getMe(): returns 200 with the access flags of the caller, unknown callers included")
+        @DisplayName("getMe(): returns 200 with the identity of the caller, unknown callers included")
         fun `returns 200 with access flags`(
             externalUserId: Long,
             isAdmin: Boolean,
-            isBanned: Boolean,
-            isActive: Boolean,
         ) {
             whenever(telegramValidatorService.map(any()))
                 .thenReturn(telegramUser.copy(externalUserId = externalUserId))
@@ -96,26 +91,32 @@ class UserControllerTest
             assertNotNull(response.body)
             assertEquals(externalUserId, response.body!!.externalUserId)
             assertEquals(isAdmin, response.body!!.isAdmin)
-            assertEquals(isBanned, response.body!!.isBanned)
-            assertEquals(isActive, response.body!!.isActive)
         }
 
-        @Test
-        @DisplayName("getMe(): a soft-deleted caller still reaches the endpoint and learns they are inactive")
-        fun `stays open for a soft deleted caller`() {
+        @ParameterizedTest(name = "[{index}] externalUserId={0} - {1}")
+        @CsvSource(
+            "777002, BANNED",
+            "777004, BANNED",
+            "777001, DELETED",
+        )
+        @DisplayName("getMe(): a banned or deleted caller - returns 403 with the code the mini app reads")
+        fun `rejects a banned or deleted caller`(
+            externalUserId: Long,
+            expected: AuthErrorType,
+        ) {
             whenever(telegramValidatorService.map(any()))
-                .thenReturn(telegramUser.copy(externalUserId = DELETED_EXTERNAL_ID))
+                .thenReturn(telegramUser.copy(externalUserId = externalUserId))
 
             val response =
                 restTemplate.exchange(
                     "/users/me",
                     HttpMethod.GET,
                     HttpEntity<Void>(buildHeaders()),
-                    MeResponse::class.java,
+                    Void::class.java,
                 )
 
-            assertEquals(HttpStatus.OK, response.statusCode)
-            assertFalse(response.body!!.isActive)
+            assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
+            assertEquals(expected.value, response.headers.getFirst(AuthErrorType.HEADER_NAME))
         }
 
         @Test
@@ -150,9 +151,6 @@ class UserControllerTest
             val body = objectMapper.readTree(response.body)
             assertEquals(ADMIN_EXTERNAL_ID, body.path("telegramUserId").asLong())
             assertTrue(body.path("isAdmin").asBoolean())
-            assertFalse(body.path("isBanned").asBoolean())
-            assertTrue(body.path("isActive").asBoolean())
-            assertFalse(body.path("isActive").isMissingNode, "The MiniApp reads the flag under this exact key")
         }
 
         @Test
@@ -196,6 +194,5 @@ class UserControllerTest
         companion object {
             private const val ADMIN_EXTERNAL_ID = 1L
             private const val PLAIN_EXTERNAL_ID = 2L
-            private const val DELETED_EXTERNAL_ID = 777001L
         }
     }

--- a/src/test/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/dao/access/NotificationAccessServiceTest.kt
@@ -12,11 +12,14 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.function.ThrowingSupplier
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlConfig
 import ru.illine.drinking.ponies.exception.NotificationSettingsNotFoundException
 import ru.illine.drinking.ponies.model.base.IntervalNotificationType
+import ru.illine.drinking.ponies.model.dto.internal.UserStateChangeDto
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
 import ru.illine.drinking.ponies.test.util.TestClockHelper
@@ -40,6 +43,7 @@ class NotificationAccessServiceTest
     @Autowired
     constructor(
         private val accessService: NotificationAccessService,
+        private val telegramUserAccessService: TelegramUserAccessService,
         private val clock: Clock,
     ) {
         private fun getMutableClock() = clock as TestClockHelper.MutableClock
@@ -170,19 +174,65 @@ class NotificationAccessServiceTest
         }
 
         @Test
-        @DisplayName("updateNotificationSettings(): returns an updated set of records")
-        fun `successful updateNotificationSettings`() {
+        @DisplayName("recordMailingResults(): an untouched snapshot goes back in without complaint")
+        fun `successful recordMailingResults`() {
             val existed = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
 
-            val actual =
-                assertDoesNotThrow(
-                    ThrowingSupplier {
-                        accessService.updateNotificationSettings(setOf(existed))
-                    },
-                )
+            assertDoesNotThrow {
+                accessService.recordMailingResults(setOf(existed))
+            }
+        }
 
-            assertFalse(actual.isEmpty())
-            assertEquals(existed.id, actual.first().id)
+        @Test
+        @DisplayName("recordMailingResults(): writes back what a mailing round produces")
+        fun `recordMailingResults writes the mailing result`() {
+            val snapshot =
+                accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID).apply {
+                    notificationAttempts = 3
+                    timeOfLastNotification = LocalDateTime.of(2025, 1, 1, 9, 0)
+                    telegramChat.previousNotificationMessageId = 4242
+                }
+
+            accessService.recordMailingResults(setOf(snapshot))
+
+            val stored = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+            assertEquals(3, stored.notificationAttempts)
+            assertEquals(LocalDateTime.of(2025, 1, 1, 9, 0), stored.timeOfLastNotification)
+            assertEquals(4242, stored.telegramChat.previousNotificationMessageId)
+        }
+
+        @Test
+        @DisplayName("recordMailingResults(): a ban applied mid-round is not reverted by the stale snapshot")
+        fun `recordMailingResults does not revert a ban`() {
+            val snapshot = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+            telegramUserAccessService.updateState(
+                id = DEFAULT_USER_ID,
+                actorId = DISABLED_USER_ID,
+                change = UserStateChangeDto(banned = true),
+            )
+
+            accessService.recordMailingResults(setOf(snapshot))
+
+            assertTrue(telegramUserAccessService.resolveAccessFlags(DEFAULT_EXTERNAL_USER_ID).isBanned)
+        }
+
+        @ParameterizedTest(name = "[{index}] externalUserId={0}")
+        @ValueSource(longs = [NOT_EXISTED_USER_ID, DELETED_EXTERNAL_USER_ID])
+        @DisplayName("recordMailingResults(): a user whose settings are gone is skipped, the rest of the round lands")
+        fun `recordMailingResults survives a vanished user`(vanished: Long) {
+            val alive =
+                accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID).apply {
+                    notificationAttempts = 7
+                }
+            val gone = DtoGenerator.generateNotificationDto(externalUserId = vanished)
+
+            assertDoesNotThrow { accessService.recordMailingResults(listOf(gone, alive)) }
+
+            assertEquals(
+                7,
+                accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID).notificationAttempts,
+                "One missing row must not cost the whole round",
+            )
         }
 
         @Test
@@ -532,6 +582,7 @@ class NotificationAccessServiceTest
 
             val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
             assertNull(actual.pauseUntil)
+            assertFalse(actual.timeOfLastNotification.isAfter(LocalDateTime.now(clock)))
             assertEquals(LocalTime.of(22, 0), actual.quietModeStart)
             assertEquals(LocalTime.of(8, 0), actual.quietModeEnd)
         }
@@ -551,6 +602,7 @@ class NotificationAccessServiceTest
 
             val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
             assertNull(actual.pauseUntil)
+            assertFalse(actual.timeOfLastNotification.isAfter(LocalDateTime.now(clock)))
             assertNull(actual.quietModeStart)
             assertNull(actual.quietModeEnd)
         }
@@ -570,6 +622,38 @@ class NotificationAccessServiceTest
 
             val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
             assertNull(actual.pauseUntil)
+        }
+
+        @Test
+        @DisplayName("updateNotificationsEnabled(): clears an active pause so the countdown starts over")
+        fun `updateNotificationsEnabled clears active pause`() {
+            val now = LocalDateTime.now(clock)
+            accessService.updatePause(DEFAULT_EXTERNAL_USER_ID, now.plusHours(8))
+
+            accessService.updateNotificationsEnabled(DEFAULT_EXTERNAL_USER_ID)
+
+            val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+            assertNull(actual.pauseUntil)
+            assertFalse(
+                actual.timeOfLastNotification.isAfter(now),
+                "a pause shifts timeOfLastNotification forward, and the shift outlives the pause mark",
+            )
+        }
+
+        @Test
+        @DisplayName("updateNotificationsEnabled(): a countdown that is not shifted stays where it was")
+        fun `updateNotificationsEnabled keeps an unshifted countdown`() {
+            val lastNotification = LocalDateTime.now(clock).minusMinutes(30)
+            accessService.updateTimeOfLastNotification(DEFAULT_EXTERNAL_USER_ID, lastNotification)
+
+            accessService.updateNotificationsEnabled(DEFAULT_EXTERNAL_USER_ID)
+
+            val actual = accessService.findNotificationSettingByExternalUserId(DEFAULT_EXTERNAL_USER_ID)
+            assertEquals(
+                lastNotification,
+                actual.timeOfLastNotification,
+                "Without a pause to undo there is nothing to move, and moving it would delay the reminder",
+            )
         }
 
         @Test
@@ -640,6 +724,8 @@ class NotificationAccessServiceTest
         companion object {
             private const val DEFAULT_ID = 1L
             private const val NOT_EXISTED_USER_ID = 0L
+            private const val DEFAULT_USER_ID = 1L
+            private const val DISABLED_USER_ID = 2L
             private const val DEFAULT_EXTERNAL_USER_ID = 1L
             private const val DISABLED_EXTERNAL_USER_ID = 2L
             private const val DELETED_EXTERNAL_USER_ID = 3L

--- a/src/test/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessServiceTest.kt
@@ -9,20 +9,28 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.CacheManager
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.domain.PageRequest
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlConfig
 import ru.illine.drinking.ponies.config.cache.CacheConfig
 import ru.illine.drinking.ponies.dao.repository.TelegramUserRepository
+import ru.illine.drinking.ponies.dao.repository.UserStateEventRepository
+import ru.illine.drinking.ponies.exception.TelegramUserNotFoundException
 import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
+import ru.illine.drinking.ponies.model.base.UserStateEventType
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfileDto
 import ru.illine.drinking.ponies.model.dto.internal.UserAccessDto
+import ru.illine.drinking.ponies.model.dto.internal.UserStateChangeDto
 import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
+import java.time.Clock
 import java.time.LocalDateTime
 
 @SpringIntegrationTest
@@ -42,35 +50,46 @@ class TelegramUserAccessServiceTest
     constructor(
         private val accessService: TelegramUserAccessService,
         private val telegramUserRepository: TelegramUserRepository,
+        private val userStateEventRepository: UserStateEventRepository,
         private val cacheManager: CacheManager,
+        private val clock: Clock,
     ) {
         @BeforeEach
         fun clearCache() {
             cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)?.clear()
+            cacheManager.getCache(CacheConfig.USER_PROFILE_SYNC)?.clear()
         }
 
         @Nested
         @DisplayName("resolveAccessFlags()")
         inner class ResolveAccessFlags {
-            @ParameterizedTest(name = "[{index}] externalUserId={0} - admin={1}, banned={2}, deleted={3}")
+            @ParameterizedTest(name = "[{index}] externalUserId={1} - admin={2}, banned={3}, deleted={4}")
             @CsvSource(
-                "1,      true,  false, false",
-                "2,      false, false, false",
-                "777001, false, false, true",
-                "777002, false, true,  false",
-                "777004, false, true,  true",
-                "0,      false, false, false",
+                "1, 1,      true,  false, false",
+                "2, 2,      false, false, false",
+                "3, 777001, false, false, true",
+                "4, 777002, false, true,  false",
+                "6, 777004, false, true,  true",
             )
-            @DisplayName("returns the stored flags, a soft-deleted user resolves as well")
+            @DisplayName("returns the stored flags with the internal id, a soft-deleted user resolves as well")
             fun `returns stored flags`(
+                id: Long,
                 externalUserId: Long,
                 isAdmin: Boolean,
                 isBanned: Boolean,
                 isDeleted: Boolean,
             ) {
-                val access = accessService.resolveAccessFlags(externalUserId, TelegramUserProfileDto())
+                val access = accessService.resolveAccessFlags(externalUserId)
 
-                assertEquals(UserAccessDto(isAdmin, isBanned, isDeleted), access)
+                assertEquals(UserAccessDto(id, externalUserId, isAdmin, isBanned, isDeleted), access)
+            }
+
+            @Test
+            @DisplayName("an unknown caller resolves to the default flags without an internal id")
+            fun `returns default flags for an unknown caller`() {
+                val access = accessService.resolveAccessFlags(MISSING_EXTERNAL_ID)
+
+                assertEquals(UserAccessDto(externalUserId = MISSING_EXTERNAL_ID), access)
             }
 
             @Test
@@ -79,9 +98,12 @@ class TelegramUserAccessServiceTest
                 val cache = cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)!!
                 assertNull(cache.get(ADMIN_EXTERNAL_ID))
 
-                accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID, TelegramUserProfileDto())
+                accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID)
 
-                assertEquals(UserAccessDto(isAdmin = true), cache.get(ADMIN_EXTERNAL_ID)?.get())
+                assertEquals(
+                    UserAccessDto(ADMIN_USER_ID, ADMIN_EXTERNAL_ID, isAdmin = true),
+                    cache.get(ADMIN_EXTERNAL_ID)?.get(),
+                )
             }
 
             @Test
@@ -89,30 +111,48 @@ class TelegramUserAccessServiceTest
             fun `caches default flags for missing user`() {
                 val cache = cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)!!
 
-                accessService.resolveAccessFlags(MISSING_EXTERNAL_ID, TelegramUserProfileDto())
+                accessService.resolveAccessFlags(MISSING_EXTERNAL_ID)
 
-                assertEquals(UserAccessDto(), cache.get(MISSING_EXTERNAL_ID)?.get())
+                assertEquals(
+                    UserAccessDto(externalUserId = MISSING_EXTERNAL_ID),
+                    cache.get(MISSING_EXTERNAL_ID)?.get(),
+                )
             }
 
             @Test
             @DisplayName("keeps serving the cached flags after a DB change until the entry is evicted")
             fun `returns stale value from cache after db change`() {
-                assertTrue(accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID, TelegramUserProfileDto()).isAdmin)
+                assertTrue(accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID).isAdmin)
 
                 val entity = telegramUserRepository.findByExternalUserId(ADMIN_EXTERNAL_ID)!!
                 entity.isAdmin = false
                 telegramUserRepository.saveAndFlush(entity)
 
                 assertTrue(
-                    accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID, TelegramUserProfileDto()).isAdmin,
+                    accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID).isAdmin,
                     "Expected stale cached value (true) before eviction",
                 )
 
                 cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)?.clear()
 
-                assertFalse(accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID, TelegramUserProfileDto()).isAdmin)
+                assertFalse(accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID).isAdmin)
             }
 
+            @Test
+            @DisplayName("resolving the flags leaves the stored profile alone, that is what syncProfile is for")
+            fun `resolving the flags never touches the profile`() {
+                accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID)
+
+                val stored = telegramUserRepository.findByExternalUserIdIncludingDeleted(ADMIN_EXTERNAL_ID)!!
+                assertEquals("Alisa", stored.firstName)
+                assertEquals("Petrova", stored.lastName)
+                assertEquals("alisaadmin", stored.username)
+            }
+        }
+
+        @Nested
+        @DisplayName("syncProfile()")
+        inner class SyncProfile {
             @Test
             @DisplayName("stores the profile from initData when it differs from the stored one")
             fun `refreshes profile on mismatch`() {
@@ -123,7 +163,7 @@ class TelegramUserAccessServiceTest
                         username = "alisamoved",
                     )
 
-                accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID, profile)
+                assertEquals(true, accessService.syncProfile(ADMIN_EXTERNAL_ID, profile))
 
                 val stored = telegramUserRepository.findByExternalUserIdIncludingDeleted(ADMIN_EXTERNAL_ID)!!
                 assertEquals("Alisa", stored.firstName)
@@ -134,7 +174,7 @@ class TelegramUserAccessServiceTest
             @Test
             @DisplayName("leaves the stored profile alone when the caller has no first name to offer")
             fun `keeps profile when caller sends nothing`() {
-                accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID, TelegramUserProfileDto())
+                assertNull(accessService.syncProfile(ADMIN_EXTERNAL_ID, TelegramUserProfileDto()))
 
                 val stored = telegramUserRepository.findByExternalUserIdIncludingDeleted(ADMIN_EXTERNAL_ID)!!
                 assertEquals("Alisa", stored.firstName)
@@ -152,7 +192,7 @@ class TelegramUserAccessServiceTest
                         username = null,
                     )
 
-                accessService.resolveAccessFlags(ADMIN_EXTERNAL_ID, profile)
+                accessService.syncProfile(ADMIN_EXTERNAL_ID, profile)
 
                 val stored = telegramUserRepository.findByExternalUserIdIncludingDeleted(ADMIN_EXTERNAL_ID)!!
                 assertEquals("Alisa", stored.firstName)
@@ -170,12 +210,57 @@ class TelegramUserAccessServiceTest
                         username = "carolback",
                     )
 
-                accessService.resolveAccessFlags(DELETED_EXTERNAL_ID, profile)
+                accessService.syncProfile(DELETED_EXTERNAL_ID, profile)
 
                 val stored = telegramUserRepository.findByExternalUserIdIncludingDeleted(DELETED_EXTERNAL_ID)!!
                 assertEquals("Carol", stored.firstName)
                 assertEquals("Renamed", stored.lastName)
                 assertEquals("carolback", stored.username)
+            }
+
+            @Test
+            @DisplayName("reports no refresh when the stored profile already matches the one from initData")
+            fun `reports no refresh when the profile already matches`() {
+                val profile =
+                    DtoGenerator.generateTelegramUserProfileDto(
+                        firstName = "Alisa",
+                        lastName = "Petrova",
+                        username = "alisaadmin",
+                    )
+
+                assertEquals(false, accessService.syncProfile(ADMIN_EXTERNAL_ID, profile))
+
+                val cache = cacheManager.getCache(CacheConfig.USER_PROFILE_SYNC)!!
+                assertEquals(false, cache.get(ADMIN_EXTERNAL_ID)?.get(), "An answer of its own fills the window")
+            }
+
+            @Test
+            @DisplayName("a call without a profile leaves the throttle window free for the next real one")
+            fun `a call without a profile does not take the throttle window`() {
+                assertNull(accessService.syncProfile(ADMIN_EXTERNAL_ID, TelegramUserProfileDto()))
+
+                val cache = cacheManager.getCache(CacheConfig.USER_PROFILE_SYNC)!!
+                assertNull(cache.get(ADMIN_EXTERNAL_ID), "Nothing was answered, so nothing may be throttled")
+
+                val renamed = DtoGenerator.generateTelegramUserProfileDto(firstName = "Renamed")
+                assertEquals(true, accessService.syncProfile(ADMIN_EXTERNAL_ID, renamed))
+                assertEquals(
+                    "Renamed",
+                    telegramUserRepository.findByExternalUserIdIncludingDeleted(ADMIN_EXTERNAL_ID)!!.firstName,
+                )
+            }
+
+            @Test
+            @DisplayName("throttles by its own cache: a second call within the TTL does not read the profile again")
+            fun `throttles the refresh by its own cache`() {
+                val profile = DtoGenerator.generateTelegramUserProfileDto(firstName = "Alisa", username = "alisamoved")
+                accessService.syncProfile(ADMIN_EXTERNAL_ID, profile)
+
+                val renamedAgain = DtoGenerator.generateTelegramUserProfileDto(firstName = "Renamed")
+                accessService.syncProfile(ADMIN_EXTERNAL_ID, renamedAgain)
+
+                val stored = telegramUserRepository.findByExternalUserIdIncludingDeleted(ADMIN_EXTERNAL_ID)!!
+                assertEquals("Alisa", stored.firstName, "The throttled call must not have reached the database")
             }
         }
 
@@ -404,67 +489,155 @@ class TelegramUserAccessServiceTest
         @Nested
         @DisplayName("updateState()")
         inner class UpdateState {
-            @ParameterizedTest(name = "[{index}] id={0} - deleted={2}")
+            @ParameterizedTest(name = "[{index}] id={0} - deleted={1}")
             @CsvSource(
-                "5, 777003, true",
-                "3, 777001, false",
+                "5, true",
+                "3, false",
             )
             @DisplayName("writes the flag and the admin card reflects it")
             fun `updates the deleted flag`(
                 id: Long,
-                externalUserId: Long,
                 deleted: Boolean,
             ) {
-                accessService.updateState(id, externalUserId, deleted)
+                accessService.updateState(id, ADMIN_USER_ID, UserStateChangeDto(deleted = deleted))
 
                 assertEquals(deleted, accessService.findByIdForAdmin(id)!!.deleted)
             }
 
-            @ParameterizedTest(name = "[{index}] id={0}")
+            @ParameterizedTest(name = "[{index}] id={0} - banned={1}")
             @CsvSource(
-                "5, 777003",
-                "3, 777001",
+                "5, true",
+                "4, false",
             )
-            @DisplayName("a null field leaves its column as it is, so an untouched toggle keeps its value")
-            fun `a null field changes nothing`(
+            @DisplayName("writes the ban flag and the admin card reflects it")
+            fun `updates the ban flag`(
                 id: Long,
-                externalUserId: Long,
+                banned: Boolean,
             ) {
-                val before = accessService.findByIdForAdmin(id)!!.deleted
+                accessService.updateState(id, ADMIN_USER_ID, UserStateChangeDto(banned = banned))
 
-                accessService.updateState(id, externalUserId, deleted = null)
+                assertEquals(banned, accessService.findByIdForAdmin(id)!!.isBanned)
+            }
 
-                assertEquals(before, accessService.findByIdForAdmin(id)!!.deleted)
+            @ParameterizedTest(name = "[{index}] id={0}")
+            @ValueSource(longs = [5L, 3L])
+            @DisplayName("a null field leaves its column as it is, so an untouched toggle keeps its value")
+            fun `a null field changes nothing`(id: Long) {
+                val before = accessService.findByIdForAdmin(id)!!
+
+                accessService.updateState(id, ADMIN_USER_ID, UserStateChangeDto())
+
+                val after = accessService.findByIdForAdmin(id)!!
+                assertEquals(before.deleted, after.deleted)
+                assertEquals(before.isBanned, after.isBanned)
+                assertTrue(userStateEventRepository.findAll().isEmpty(), "Nothing changed, nothing to record")
             }
 
             @Test
-            @DisplayName("repeating the same update leaves the flag as it is")
+            @DisplayName("answers with the flags it has just applied, the eviction key riding along with them")
+            fun `answers with the applied flags`() {
+                val applied =
+                    accessService.updateState(
+                        ACTIVE_USER_ID,
+                        ADMIN_USER_ID,
+                        UserStateChangeDto(deleted = true, banned = true),
+                    )
+
+                assertEquals(
+                    UserAccessDto(ACTIVE_USER_ID, ACTIVE_EXTERNAL_ID, isBanned = true, isDeleted = true),
+                    applied,
+                )
+            }
+
+            @Test
+            @DisplayName("both fields at once are applied and recorded as two separate events")
+            fun `applies both fields at once`() {
+                accessService.updateState(
+                    ACTIVE_USER_ID,
+                    ADMIN_USER_ID,
+                    UserStateChangeDto(deleted = true, banned = true),
+                )
+
+                val user = accessService.findByIdForAdmin(ACTIVE_USER_ID)!!
+                assertTrue(user.deleted)
+                assertTrue(user.isBanned)
+                assertEquals(
+                    listOf(UserStateEventType.DEACTIVATED, UserStateEventType.BANNED),
+                    userStateEventRepository.findAll().sortedBy { it.id }.map { it.eventType },
+                )
+            }
+
+            // Each row picks a user for whom the transition really is a change: the active one for
+            // DEACTIVATED and BANNED, the already deleted and banned one for RESTORED and UNBANNED.
+            @ParameterizedTest(name = "[{index}] id={0} - deleted={1}, banned={2} - {3}")
+            @CsvSource(
+                "5, true,  ,      DEACTIVATED",
+                "6, false, ,      RESTORED",
+                "5, ,      true,  BANNED",
+                "6, ,      false, UNBANNED",
+            )
+            @DisplayName("records who changed whose state and how")
+            fun `records the event`(
+                id: Long,
+                deleted: Boolean?,
+                banned: Boolean?,
+                expected: UserStateEventType,
+            ) {
+                accessService.updateState(id, ADMIN_USER_ID, UserStateChangeDto(deleted = deleted, banned = banned))
+
+                val event = userStateEventRepository.findAll().single()
+                assertEquals(id, event.userId)
+                assertEquals(ADMIN_USER_ID, event.actorUserId)
+                assertEquals(expected, event.eventType)
+                assertEquals(LocalDateTime.now(clock), event.eventTime)
+            }
+
+            @Test
+            @DisplayName("repeating the same update leaves the flag as it is and records a single event")
             fun `repeating the same update is idempotent`() {
-                accessService.updateState(ACTIVE_USER_ID, ACTIVE_EXTERNAL_ID, deleted = true)
-                accessService.updateState(ACTIVE_USER_ID, ACTIVE_EXTERNAL_ID, deleted = true)
+                accessService.updateState(ACTIVE_USER_ID, ADMIN_USER_ID, UserStateChangeDto(deleted = true))
+                accessService.updateState(ACTIVE_USER_ID, ADMIN_USER_ID, UserStateChangeDto(deleted = true))
 
                 assertTrue(accessService.findByIdForAdmin(ACTIVE_USER_ID)!!.deleted)
                 assertEquals(2L, accessService.countForAdmin(null).inactive)
+                assertEquals(1, userStateEventRepository.findAll().size, "The second call changed nothing")
             }
 
             @Test
-            @DisplayName("an unknown id changes nothing")
+            @DisplayName("an unknown id is reported as not found and changes nothing")
             fun `unknown id changes nothing`() {
-                accessService.updateState(MISSING_USER_ID, MISSING_EXTERNAL_ID, deleted = true)
+                assertThrows<TelegramUserNotFoundException> {
+                    accessService.updateState(MISSING_USER_ID, ADMIN_USER_ID, UserStateChangeDto(deleted = true))
+                }
 
                 val counts = accessService.countForAdmin(null)
                 assertEquals(8L, counts.all)
                 assertEquals(1L, counts.inactive)
+                assertTrue(userStateEventRepository.findAll().isEmpty())
+            }
+
+            @Test
+            @DisplayName("an audit record that cannot be written takes the flag change down with it")
+            fun `a failed event write rolls the flag back`() {
+                assertThrows<DataIntegrityViolationException> {
+                    accessService.updateState(ACTIVE_USER_ID, MISSING_USER_ID, UserStateChangeDto(banned = true))
+                }
+
+                assertFalse(
+                    accessService.findByIdForAdmin(ACTIVE_USER_ID)!!.isBanned,
+                    "A state that outlives its audit record is exactly what the single door is for",
+                )
+                assertTrue(userStateEventRepository.findAll().isEmpty())
             }
 
             @Test
             @DisplayName("evicts the cached access flags of the user it touches")
             fun `evicts the cached access flags`() {
                 val cache = cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)!!
-                accessService.resolveAccessFlags(ACTIVE_EXTERNAL_ID, TelegramUserProfileDto())
+                accessService.resolveAccessFlags(ACTIVE_EXTERNAL_ID)
                 assertNotNull(cache.get(ACTIVE_EXTERNAL_ID))
 
-                accessService.updateState(ACTIVE_USER_ID, ACTIVE_EXTERNAL_ID, deleted = true)
+                accessService.updateState(ACTIVE_USER_ID, ADMIN_USER_ID, UserStateChangeDto(deleted = true))
 
                 assertNull(cache.get(ACTIVE_EXTERNAL_ID))
             }
@@ -473,10 +646,10 @@ class TelegramUserAccessServiceTest
             @DisplayName("evicts the flags even when every field is null and nothing is written")
             fun `evicts the cached access flags on a no-op update`() {
                 val cache = cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)!!
-                accessService.resolveAccessFlags(ACTIVE_EXTERNAL_ID, TelegramUserProfileDto())
+                accessService.resolveAccessFlags(ACTIVE_EXTERNAL_ID)
                 assertNotNull(cache.get(ACTIVE_EXTERNAL_ID))
 
-                accessService.updateState(ACTIVE_USER_ID, ACTIVE_EXTERNAL_ID, deleted = null)
+                accessService.updateState(ACTIVE_USER_ID, ADMIN_USER_ID, UserStateChangeDto(deleted = null))
 
                 assertNull(cache.get(ACTIVE_EXTERNAL_ID))
             }
@@ -494,6 +667,18 @@ class TelegramUserAccessServiceTest
                 assertFalse(accessService.findByIdForAdmin(DELETED_USER_ID)!!.deleted)
             }
 
+            @Test
+            @DisplayName("records the restore with the user as their own actor, no admin behind it")
+            fun `records the restore as the deed of the user themselves`() {
+                accessService.restoreIfDeleted(DELETED_EXTERNAL_ID)
+
+                val event = userStateEventRepository.findAll().single()
+                assertEquals(DELETED_USER_ID, event.userId)
+                assertEquals(DELETED_USER_ID, event.actorUserId, "A start is the user's own doing")
+                assertEquals(UserStateEventType.RESTORED, event.eventType)
+                assertEquals(LocalDateTime.now(clock), event.eventTime)
+            }
+
             @ParameterizedTest(name = "[{index}] externalUserId={0}")
             @CsvSource(
                 "1",
@@ -506,6 +691,7 @@ class TelegramUserAccessServiceTest
 
                 assertFalse(restored)
                 assertEquals(1L, accessService.countForAdmin(null).inactive, "No one else may be revived")
+                assertTrue(userStateEventRepository.findAll().isEmpty(), "Nothing happened, nothing to record")
             }
 
             @Test
@@ -521,12 +707,24 @@ class TelegramUserAccessServiceTest
             @DisplayName("evicts the cached access flags, so the stale isDeleted is not served on")
             fun `evicts the cached access flags`() {
                 val cache = cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)!!
-                accessService.resolveAccessFlags(DELETED_EXTERNAL_ID, TelegramUserProfileDto())
+                accessService.resolveAccessFlags(DELETED_EXTERNAL_ID)
                 assertNotNull(cache.get(DELETED_EXTERNAL_ID))
 
                 accessService.restoreIfDeleted(DELETED_EXTERNAL_ID)
 
                 assertNull(cache.get(DELETED_EXTERNAL_ID))
+            }
+
+            @Test
+            @DisplayName("keeps the cached flags of a live user, a call that restores nothing evicts nothing")
+            fun `keeps the cached access flags when nothing was restored`() {
+                val cache = cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)!!
+                accessService.resolveAccessFlags(ACTIVE_EXTERNAL_ID)
+                assertNotNull(cache.get(ACTIVE_EXTERNAL_ID))
+
+                accessService.restoreIfDeleted(ACTIVE_EXTERNAL_ID)
+
+                assertNotNull(cache.get(ACTIVE_EXTERNAL_ID), "A no-op must not cost the cached flags")
             }
         }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationSenderServiceTest.kt
@@ -115,7 +115,7 @@ class NotificationSenderServiceTest {
 
         verify(messageEditorService).deleteMessages(any())
         verify(sender).execute(any<SendMessage>())
-        verify(notificationAccessService).updateNotificationSettings(any())
+        verify(notificationAccessService).recordMailingResults(any())
         assertEquals(1, dto.notificationAttempts)
         assertEquals(2, dto.telegramChat.previousNotificationMessageId)
         assertEquals(expectedTimeOfLastNotification, dto.timeOfLastNotification)
@@ -132,7 +132,7 @@ class NotificationSenderServiceTest {
         service.sendNotifications(listOf(dto))
 
         verify(notificationAccessService).updateNotificationsDisabled(externalUserId)
-        verify(notificationAccessService).updateNotificationSettings(any())
+        verify(notificationAccessService).recordMailingResults(any())
     }
 
     @Test
@@ -147,7 +147,7 @@ class NotificationSenderServiceTest {
 
         val captor = argumentCaptor<Collection<NotificationSettingDto>>()
         verify(notificationAccessService, never()).updateNotificationsDisabled(any())
-        verify(notificationAccessService).updateNotificationSettings(captor.capture())
+        verify(notificationAccessService).recordMailingResults(captor.capture())
         assertEquals(emptyList<NotificationSettingDto>(), captor.firstValue.toList())
     }
 
@@ -182,7 +182,7 @@ class NotificationSenderServiceTest {
         val captor = argumentCaptor<Collection<NotificationSettingDto>>()
         verify(sender, times(3)).execute(any<SendMessage>())
         verify(notificationAccessService, never()).updateNotificationsDisabled(any())
-        verify(notificationAccessService).updateNotificationSettings(captor.capture())
+        verify(notificationAccessService).recordMailingResults(captor.capture())
         assertEquals(listOf(first, last), captor.firstValue.toList())
     }
 
@@ -211,7 +211,7 @@ class NotificationSenderServiceTest {
 
         verify(messageEditorService).deleteMessages(any())
         verify(sender).execute(any<SendMessage>())
-        verify(notificationAccessService).updateNotificationSettings(any())
+        verify(notificationAccessService).recordMailingResults(any())
         assertEquals(0, dto.notificationAttempts)
         assertNull(dto.telegramChat.previousNotificationMessageId)
     }
@@ -237,7 +237,7 @@ class NotificationSenderServiceTest {
         service.suspendNotifications(listOf(dto))
 
         verify(notificationAccessService).updateNotificationsDisabled(externalUserId)
-        verify(notificationAccessService).updateNotificationSettings(any())
+        verify(notificationAccessService).recordMailingResults(any())
     }
 
     @Test
@@ -252,7 +252,7 @@ class NotificationSenderServiceTest {
 
         val captor = argumentCaptor<Collection<NotificationSettingDto>>()
         verify(notificationAccessService, never()).updateNotificationsDisabled(any())
-        verify(notificationAccessService).updateNotificationSettings(captor.capture())
+        verify(notificationAccessService).recordMailingResults(captor.capture())
         assertEquals(emptyList<NotificationSettingDto>(), captor.firstValue.toList())
     }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceIntegrationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/notification/NotificationServiceIntegrationTest.kt
@@ -23,8 +23,10 @@ import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.illine.drinking.ponies.config.cache.CacheConfig
 import ru.illine.drinking.ponies.dao.access.NotificationAccessService
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
-import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfileDto
+import ru.illine.drinking.ponies.model.dto.internal.UserStateChangeDto
 import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
+import java.time.Clock
+import java.time.LocalDateTime
 
 @SpringIntegrationTest
 @DisplayName("NotificationService Spring Integration Test")
@@ -41,6 +43,7 @@ class NotificationServiceIntegrationTest
         private val telegramUserAccessService: TelegramUserAccessService,
         private val cacheManager: CacheManager,
         private val jdbcTemplate: JdbcTemplate,
+        private val clock: Clock,
     ) {
         @MockitoBean
         private lateinit var sender: TelegramClient
@@ -80,7 +83,7 @@ class NotificationServiceIntegrationTest
             notificationService.start(messageContext())
             softDelete()
             val cache = cacheManager.getCache(CacheConfig.USER_ACCESS_FLAGS)!!
-            telegramUserAccessService.resolveAccessFlags(EXTERNAL_USER_ID, TelegramUserProfileDto())
+            telegramUserAccessService.resolveAccessFlags(EXTERNAL_USER_ID)
             assertNotNull(cache.get(EXTERNAL_USER_ID))
 
             notificationService.start(messageContext())
@@ -123,13 +126,99 @@ class NotificationServiceIntegrationTest
             assertFalse(isDeleted())
         }
 
+        @Test
+        @DisplayName("start(): a user who switched notifications off says /start - it works and turns them back on")
+        fun `start revives a user with notifications switched off`() {
+            notificationService.start(messageContext())
+            notificationAccessService.updateNotificationsDisabled(EXTERNAL_USER_ID)
+
+            assertDoesNotThrow { notificationService.start(messageContext()) }
+
+            assertTrue(notificationAccessService.findIsEnabledNotificationsByExternalUserId(EXTERNAL_USER_ID))
+        }
+
+        @Test
+        @DisplayName("start(): an active pause does not outlive the /start that turns notifications back on")
+        fun `start clears an active pause`() {
+            notificationService.start(messageContext())
+            val now = LocalDateTime.now(clock)
+            notificationAccessService.updatePause(EXTERNAL_USER_ID, now.plusHours(8))
+
+            notificationService.start(messageContext())
+
+            val settings = notificationAccessService.findNotificationSettingByExternalUserId(EXTERNAL_USER_ID)
+            assertNull(settings.pauseUntil)
+            assertFalse(
+                settings.timeOfLastNotification.isAfter(now),
+                "the bot answers that notifications are on, so they have to actually arrive",
+            )
+        }
+
+        @Test
+        @DisplayName("start(): the ban survives a /start, unlike a deletion")
+        fun `start does not lift a ban`() {
+            notificationService.start(messageContext())
+            ban()
+
+            notificationService.start(messageContext())
+
+            assertTrue(telegramUserAccessService.resolveAccessFlags(EXTERNAL_USER_ID).isBanned)
+        }
+
+        @Test
+        @DisplayName("a banned user is dropped from the mailing selection")
+        fun `a banned user is not reminded to drink`() {
+            notificationService.start(messageContext())
+            assertEquals(listOf(EXTERNAL_USER_ID), mailingRecipients())
+
+            ban()
+
+            assertTrue(mailingRecipients().isEmpty(), "A banned user gets no notifications")
+        }
+
+        @Test
+        @DisplayName("start(): the restore is recorded with the returning user as their own actor")
+        fun `start records the restore as the deed of the user themselves`() {
+            notificationService.start(messageContext())
+            softDelete()
+
+            notificationService.start(messageContext())
+
+            val id = userId()
+            assertEquals(listOf("RESTORED by $id on $id"), stateEvents().filter { it.startsWith("RESTORED") })
+        }
+
+        @Test
+        @DisplayName("start(): a live user says /start - the audit history stays empty, nothing changed")
+        fun `start records nothing for a live user`() {
+            notificationService.start(messageContext())
+
+            notificationService.start(messageContext())
+
+            assertTrue(stateEvents().isEmpty(), "An unchanged state is not a state event")
+        }
+
         private fun mailingRecipients(): List<Long> =
             notificationAccessService.findAllNotificationSettings().map { it.telegramUser.externalUserId }
 
+        private fun stateEvents(): List<String> =
+            jdbcTemplate.query(SELECT_EVENTS) { rs, _ ->
+                "${rs.getString("event_type")} by ${rs.getLong("actor_user_id")} on ${rs.getLong("user_id")}"
+            }
+
+        private fun userId(): Long = jdbcTemplate.queryForObject(SELECT_ID, Long::class.java, EXTERNAL_USER_ID)!!
+
+        // The admin API refuses to change one's own state, so an arrange step doing it describes a world
+        // that cannot happen - both fixtures act as somebody else.
+        private fun adminId(): Long = jdbcTemplate.queryForObject(UPSERT_ADMIN, Long::class.java, ADMIN_EXTERNAL_ID)!!
+
         private fun softDelete() {
-            val id = jdbcTemplate.queryForObject(SELECT_ID, Long::class.java, EXTERNAL_USER_ID)!!
-            telegramUserAccessService.updateState(id, EXTERNAL_USER_ID, deleted = true)
+            telegramUserAccessService.updateState(userId(), adminId(), UserStateChangeDto(deleted = true))
             assertTrue(isDeleted(), "Arrange step must really have soft deleted the user")
+        }
+
+        private fun ban() {
+            telegramUserAccessService.updateState(userId(), adminId(), UserStateChangeDto(banned = true))
         }
 
         private fun isDeleted(): Boolean =
@@ -157,9 +246,19 @@ class NotificationServiceIntegrationTest
 
         companion object {
             private const val EXTERNAL_USER_ID = 777001L
+            private const val ADMIN_EXTERNAL_ID = 777099L
             private const val CHAT_ID = 424242L
 
+            private const val UPSERT_ADMIN = """
+                insert into telegram_users (external_user_id, user_time_zone, is_admin)
+                values (?, 'Europe/Moscow', true)
+                on conflict (external_user_id) do update set is_admin = true
+                returning id
+            """
+
             private const val SELECT_ID = "select id from telegram_users where external_user_id = ?"
+            private const val SELECT_EVENTS =
+                "select event_type, user_id, actor_user_id from user_state_events order by id"
             private const val SELECT_DELETED = "select deleted from telegram_users where external_user_id = ?"
             private const val COUNT_USERS = "select count(*) from telegram_users where external_user_id = ?"
             private const val COUNT_CHATS = """

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/user/UserAdminServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/user/UserAdminServiceTest.kt
@@ -1,6 +1,7 @@
 package ru.illine.drinking.ponies.service.user
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -19,10 +20,13 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageRequest
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
+import ru.illine.drinking.ponies.exception.SelfStateChangeException
 import ru.illine.drinking.ponies.exception.TelegramUserNotFoundException
 import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
 import ru.illine.drinking.ponies.model.dto.internal.AdminUserDto
+import ru.illine.drinking.ponies.model.dto.internal.UserAccessDto
 import ru.illine.drinking.ponies.model.dto.internal.UserCountsDto
+import ru.illine.drinking.ponies.model.dto.internal.UserStateChangeDto
 import ru.illine.drinking.ponies.model.dto.internal.UserStateDto
 import ru.illine.drinking.ponies.service.user.impl.UserAdminServiceImpl
 import ru.illine.drinking.ponies.test.tag.UnitTest
@@ -100,7 +104,7 @@ class UserAdminServiceTest {
     @DisplayName("updateState(): an empty payload is rejected before the DAO is touched at all")
     fun `updateState rejects an empty payload`() {
         assertThrows<IllegalArgumentException> {
-            userAdminService.updateState(USER_ID, UserStateDto(isActive = null))
+            userAdminService.updateState(USER_ID, ACTOR_ID, UserStateDto())
         }
 
         verifyNoInteractions(telegramUserAccessService)
@@ -112,35 +116,76 @@ class UserAdminServiceTest {
         whenever(telegramUserAccessService.findByIdForAdmin(USER_ID)).thenReturn(null)
 
         assertThrows<TelegramUserNotFoundException> {
-            userAdminService.updateState(USER_ID, UserStateDto(isActive = false))
+            userAdminService.updateState(USER_ID, ACTOR_ID, UserStateDto(isActive = false))
         }
 
         verify(telegramUserAccessService).findByIdForAdmin(USER_ID)
-        verify(telegramUserAccessService, never()).updateState(any(), any(), anyOrNull())
+        verify(telegramUserAccessService, never()).updateState(any(), any(), any())
+    }
+
+    @Test
+    @DisplayName("updateState(): an admin changing their own state is rejected before the row is even read")
+    fun `updateState rejects a self change`() {
+        assertThrows<SelfStateChangeException> {
+            userAdminService.updateState(USER_ID, USER_ID, UserStateDto(isBanned = true))
+        }
+
+        verifyNoInteractions(telegramUserAccessService)
     }
 
     @ParameterizedTest(name = "[{index}] isActive={0}")
     @CsvSource("true", "false")
-    @DisplayName("updateState(): writes the flag, answers with it and reads the row only once")
+    @DisplayName("updateState(): writes the flag, answers with what the DAO applied and reads the row only once")
     fun `updateState answers with the freshly written flag`(isActive: Boolean) {
-        val user = adminUser(deleted = isActive)
-        whenever(telegramUserAccessService.findByIdForAdmin(USER_ID)).thenReturn(user)
+        whenever(telegramUserAccessService.findByIdForAdmin(USER_ID)).thenReturn(adminUser(deleted = isActive))
+        stubApplied(deleted = !isActive)
 
-        val result = userAdminService.updateState(USER_ID, UserStateDto(isActive = isActive))
+        val result = userAdminService.updateState(USER_ID, ACTOR_ID, UserStateDto(isActive = isActive))
 
         assertEquals(!isActive, result.deleted)
-        verify(telegramUserAccessService).updateState(USER_ID, EXTERNAL_USER_ID, !isActive)
+        verify(telegramUserAccessService).updateState(
+            USER_ID,
+            ACTOR_ID,
+            UserStateChangeDto(deleted = !isActive),
+        )
         verify(telegramUserAccessService, times(1)).findByIdForAdmin(USER_ID)
+    }
+
+    @ParameterizedTest(name = "[{index}] isBanned={0}")
+    @CsvSource("true", "false")
+    @DisplayName("updateState(): writes the ban flag and answers with it, leaving activity alone")
+    fun `updateState answers with the freshly written ban flag`(isBanned: Boolean) {
+        whenever(telegramUserAccessService.findByIdForAdmin(USER_ID)).thenReturn(adminUser(deleted = true))
+        stubApplied(deleted = true, banned = isBanned)
+
+        val result = userAdminService.updateState(USER_ID, ACTOR_ID, UserStateDto(isBanned = isBanned))
+
+        assertEquals(isBanned, result.isBanned)
+        assertTrue(result.deleted, "An untouched field keeps its value")
+        verify(telegramUserAccessService).updateState(
+            USER_ID,
+            ACTOR_ID,
+            UserStateChangeDto(banned = isBanned),
+        )
     }
 
     @Test
     @DisplayName("updateState(): the rest of the row comes back untouched")
     fun `updateState keeps the rest of the row`() {
         whenever(telegramUserAccessService.findByIdForAdmin(USER_ID)).thenReturn(adminUser(deleted = true))
+        stubApplied(deleted = false)
 
-        val result = userAdminService.updateState(USER_ID, UserStateDto(isActive = true))
+        val result = userAdminService.updateState(USER_ID, ACTOR_ID, UserStateDto(isActive = true))
 
         assertEquals(adminUser(deleted = false), result)
+    }
+
+    private fun stubApplied(
+        deleted: Boolean,
+        banned: Boolean = false,
+    ) {
+        whenever(telegramUserAccessService.updateState(any(), any(), any()))
+            .thenReturn(UserAccessDto(USER_ID, EXTERNAL_USER_ID, isBanned = banned, isDeleted = deleted))
     }
 
     @Test
@@ -178,6 +223,7 @@ class UserAdminServiceTest {
     companion object {
         private const val USER_ID = 1042L
         private const val EXTERNAL_USER_ID = 482719301L
+        private const val ACTOR_ID = 1L
 
         private val EMPTY_COUNTS = UserCountsDto(all = 0L, active = 0L, inactive = 0L, banned = 0L)
     }

--- a/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/test/generator/DtoGenerator.kt
@@ -15,6 +15,7 @@ import ru.illine.drinking.ponies.model.dto.internal.StatisticsPointDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramAuthUserDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramChatDto
 import ru.illine.drinking.ponies.model.dto.internal.TelegramUserProfileDto
+import ru.illine.drinking.ponies.model.dto.internal.UserAccessDto
 import ru.illine.drinking.ponies.model.dto.internal.WaterStatisticDto
 import ru.illine.drinking.ponies.model.dto.request.WaterEntryRequest
 import ru.illine.drinking.ponies.model.dto.response.NotificationHistoryEvent
@@ -132,22 +133,35 @@ class DtoGenerator {
             )
 
         fun generateTelegramAuthUserDto(
+            id: Long? = null,
             externalUserId: Long = 1L,
             firstName: String? = "First Name",
             lastName: String? = null,
             username: String? = "username",
             isAdmin: Boolean = false,
-            isBanned: Boolean = false,
-            isActive: Boolean = false,
         ): TelegramAuthUserDto =
             TelegramAuthUserDto(
+                id = id,
                 externalUserId = externalUserId,
                 firstName = firstName,
                 lastName = lastName,
                 username = username,
                 isAdmin = isAdmin,
+            )
+
+        fun generateUserAccessDto(
+            id: Long? = null,
+            externalUserId: Long = 1L,
+            isAdmin: Boolean = false,
+            isBanned: Boolean = false,
+            isDeleted: Boolean = false,
+        ): UserAccessDto =
+            UserAccessDto(
+                id = id,
+                externalUserId = externalUserId,
+                isAdmin = isAdmin,
                 isBanned = isBanned,
-                isActive = isActive,
+                isDeleted = isDeleted,
             )
 
         fun generateTelegramUserProfileDto(

--- a/src/test/resources/sql/clear.sql
+++ b/src/test/resources/sql/clear.sql
@@ -1,8 +1,10 @@
+delete from user_state_events where id is not null;
 delete from water_statistics where id is not null;
 delete from notification_settings where id is not null;
 delete from telegram_chats where id is not null;
 delete from telegram_users where id is not null;
 
+alter sequence user_state_event_seq restart with 1;
 alter sequence water_statistics_seq restart with 1;
 alter sequence notification_setting_seq restart with 1;
 alter sequence telegram_chat_seq restart with 1;


### PR DESCRIPTION
## Summary
- A new `user_state_events` table records every account state change - whose, by whom, which type, UTC time; the state itself stays in `telegram_users`.
- Every write of `deleted` / `is_banned` goes through `TelegramUserAccessServiceImpl`: the audit record and the cache eviction share the transaction with the flag, and an architecture rule keeps that the only door.
- `PATCH /users/{id}` carries the ban flag; changing one's own state is refused with 409 through a new `ConflictException` family.
- A banned or deleted caller is stopped in `TelegramAuthInterceptor` on every route: 403 plus `X-Auth-Error-Code` (`banned` / `deleted`), which the mini app reads to show a block screen or ask for a `/start`. `isBanned` / `isActive` left `MeResponse` - the barrier answers instead.
- The bot drops a banned user in `checkGlobalFlags`, ahead of every ability and reply handler, and banned users fall out of the mailing selection in SQL.
- Access flags and profile refresh no longer share one cache: `user-access-flags` (1 minute) against `user-profile-sync` (1 hour).
- A mailing round writes its results onto managed entities instead of merging a stale snapshot, so a ban applied mid-round is no longer reverted.
- Lifting a pause now undoes the forward shift of `time_of_last_notification` too, so `/start` and switching notifications back on really resume them.

## Test plan
- [x] `./gradlew formatKotlin check` green - 919 tests, lint and detekt clean
- [x] Local e2e suite green against the branch
- [x] Every published route walked for a banned and for a deleted caller, with a guard comparing the walked list against what the application publishes
- [x] The architecture rule confirmed to fail on a deliberate second door
- [x] The pause fix confirmed red without it - the shift reset reverted, three assertions went red
