### PR TITLE
DPTB-111: grant and revoke admin privileges through the user state endpoint

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -152,7 +152,7 @@ The rules above are not left to review attention - most of them fail the build.
 | `package` matches the directory | detekt `InvalidPackageDeclaration` |
 | Naming, formatting, import order | ktlint |
 
-`deleted` and `is_banned` are written through `TelegramUserAccessServiceImpl` and nowhere else: every write there
+`deleted`, `is_banned` and `is_admin` are written through `TelegramUserAccessServiceImpl` and nowhere else: every write there
 records an audit event in `user_state_events` and drops the cached access flags. A second writer would produce a state
 change that the history never saw, so the rule matches both spellings of an assignment and any update statement over
 the users table.

--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/UserAdminController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/UserAdminController.kt
@@ -59,7 +59,7 @@ class UserAdminController(
     ): UserDetailsResponse = AdminUserResponseMapper.toDetails(userAdminService.getUser(id))
 
     @PatchMapping("/{id}")
-    @Operation(summary = "Update user state: soft delete, restore, ban or unban")
+    @Operation(summary = "Update the state of a user account, one field per toggle of the admin card")
     fun updateUserState(
         @Parameter(description = "Internal user id", example = "1042")
         @PathVariable(name = "id") id: Long,
@@ -67,7 +67,7 @@ class UserAdminController(
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) actor: TelegramAuthUserDto,
         @Valid @RequestBody request: UserStateRequest,
     ): UserDetailsResponse {
-        val state = UserStateDto(isActive = request.isActive, isBanned = request.isBanned)
+        val state = UserStateDto(isActive = request.isActive, isBanned = request.isBanned, isAdmin = request.isAdmin)
         val actorId = requireNotNull(actor.id) { "An admin without a stored account cannot reach this endpoint" }
 
         return AdminUserResponseMapper.toDetails(userAdminService.updateState(id, actorId, state))

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessService.kt
@@ -11,7 +11,6 @@ import ru.illine.drinking.ponies.model.dto.internal.UserStateChangeDto
 interface TelegramUserAccessService {
     fun resolveAccessFlags(externalUserId: Long): UserAccessDto
 
-    /** Returns null when the caller carries no profile, true when the stored one was refreshed. */
     fun syncProfile(
         externalUserId: Long,
         profile: TelegramUserProfileDto,
@@ -26,6 +25,8 @@ interface TelegramUserAccessService {
     fun findByIdForAdmin(id: Long): AdminUserDto?
 
     fun countForAdmin(search: String?): UserCountsDto
+
+    fun findActiveAdminIdsForUpdate(): List<Long>
 
     fun updateState(
         id: Long,

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/TelegramUserAccessServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/access/impl/TelegramUserAccessServiceImpl.kt
@@ -5,6 +5,7 @@ import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import ru.illine.drinking.ponies.config.cache.CacheConfig
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
@@ -99,6 +100,11 @@ class TelegramUserAccessServiceImpl(
         return AdminUserMapper.toCounts(telegramUserRepository.countForAdmin(search))
     }
 
+    // Mandatory rather than required: a transaction of its own would release the lock on the way out, and the
+    // caller would hold a guarantee that no longer exists.
+    @Transactional(propagation = Propagation.MANDATORY)
+    override fun findActiveAdminIdsForUpdate(): List<Long> = telegramUserRepository.findActiveAdminIdsForUpdate()
+
     @Transactional
     @CacheEvict(CacheConfig.USER_ACCESS_FLAGS, key = "#result.externalUserId")
     override fun updateState(
@@ -119,6 +125,10 @@ class TelegramUserAccessServiceImpl(
                 change.banned?.takeIf { it != user.isBanned }?.let {
                     user.isBanned = it
                     add(if (it) UserStateEventType.BANNED else UserStateEventType.UNBANNED)
+                }
+                change.admin?.takeIf { it != user.isAdmin }?.let {
+                    user.isAdmin = it
+                    add(if (it) UserStateEventType.PROMOTED else UserStateEventType.DEMOTED)
                 }
             }
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/TelegramUserRepository.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/dao/repository/TelegramUserRepository.kt
@@ -27,6 +27,24 @@ interface TelegramUserRepository : JpaRepository<TelegramUserEntity, Long> {
         @Param("id") id: Long,
     ): TelegramUserEntity?
 
+    // Locks the admin rows for the rest of the transaction, so two admins demoting each other at the same time
+    // are serialized instead of both reading a state where the other is still an admin. The weaker "no key update"
+    // is enough: it conflicts with the other writers of these rows, but not with the foreign key checks of the
+    // child tables, which take a key share lock on every water intake.
+    @Query(
+        value = """
+            select u.id
+            from telegram_users u
+            where u.is_admin = true
+              and u.deleted = false
+              and u.is_banned = false
+            order by u.id
+            for no key update
+        """,
+        nativeQuery = true,
+    )
+    fun findActiveAdminIdsForUpdate(): List<Long>
+
     @Query(
         value = """
             $ADMIN_USER_SELECT

--- a/src/main/kotlin/ru/illine/drinking/ponies/exception/InactiveUserPromotionException.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/exception/InactiveUserPromotionException.kt
@@ -1,0 +1,5 @@
+package ru.illine.drinking.ponies.exception
+
+class InactiveUserPromotionException(
+    message: String,
+) : ConflictException("you cannot grant admin privileges to a banned or deleted user", message)

--- a/src/main/kotlin/ru/illine/drinking/ponies/exception/LastAdminException.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/exception/LastAdminException.kt
@@ -1,0 +1,5 @@
+package ru.illine.drinking.ponies.exception
+
+class LastAdminException(
+    message: String,
+) : ConflictException("you cannot revoke the privileges of the last admin", message)

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/base/UserStateEventType.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/base/UserStateEventType.kt
@@ -5,4 +5,6 @@ enum class UserStateEventType {
     UNBANNED,
     DEACTIVATED,
     RESTORED,
+    PROMOTED,
+    DEMOTED,
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserStateChangeDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserStateChangeDto.kt
@@ -3,4 +3,5 @@ package ru.illine.drinking.ponies.model.dto.internal
 data class UserStateChangeDto(
     val deleted: Boolean? = null,
     val banned: Boolean? = null,
+    val admin: Boolean? = null,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserStateDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/UserStateDto.kt
@@ -3,4 +3,5 @@ package ru.illine.drinking.ponies.model.dto.internal
 data class UserStateDto(
     val isActive: Boolean? = null,
     val isBanned: Boolean? = null,
+    val isAdmin: Boolean? = null,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/UserStateRequest.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/UserStateRequest.kt
@@ -20,4 +20,11 @@ data class UserStateRequest(
         requiredMode = Schema.RequiredMode.NOT_REQUIRED,
     )
     val isBanned: Boolean?,
+    @Schema(
+        description = "True grants admin privileges, false revokes them",
+        example = "false",
+        nullable = true,
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val isAdmin: Boolean?,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/user/impl/UserAdminServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/user/impl/UserAdminServiceImpl.kt
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.query.EscapeCharacter
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
+import ru.illine.drinking.ponies.exception.InactiveUserPromotionException
+import ru.illine.drinking.ponies.exception.LastAdminException
 import ru.illine.drinking.ponies.exception.SelfStateChangeException
 import ru.illine.drinking.ponies.exception.TelegramUserNotFoundException
 import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
@@ -50,24 +52,51 @@ class UserAdminServiceImpl(
         actorId: Long,
         state: UserStateDto,
     ): AdminUserDto {
-        require(state.isActive != null || state.isBanned != null) {
+        require(state.isActive != null || state.isBanned != null || state.isAdmin != null) {
             "At least one state field is required, got an empty payload"
         }
         if (id == actorId) {
             throw SelfStateChangeException("Admin [$actorId] tried to change their own state")
         }
-
         val user = requireUser(id)
+        when {
+            state.isAdmin == true -> requireSignInPossible(id, state, user)
+            state.isAdmin == false && user.isAdmin -> requireAnotherAdminLeft(id)
+        }
 
-        logger.info("Setting isActive={}, isBanned={} for user [{}]", state.isActive, state.isBanned, id)
+        logger.info("Setting {} for user [{}]", state, id)
         val applied =
             telegramUserAccessService.updateState(
                 id = id,
                 actorId = actorId,
-                change = UserStateChangeDto(deleted = state.isActive?.not(), banned = state.isBanned),
+                change =
+                    UserStateChangeDto(
+                        deleted = state.isActive?.not(),
+                        banned = state.isBanned,
+                        admin = state.isAdmin,
+                    ),
             )
 
-        return user.copy(deleted = applied.isDeleted, isBanned = applied.isBanned)
+        return user.copy(deleted = applied.isDeleted, isBanned = applied.isBanned, isAdmin = applied.isAdmin)
+    }
+
+    private fun requireSignInPossible(
+        id: Long,
+        state: UserStateDto,
+        user: AdminUserDto,
+    ) {
+        val banned = state.isBanned ?: user.isBanned
+        val deleted = state.isActive?.not() ?: user.deleted
+
+        if (banned || deleted) {
+            throw InactiveUserPromotionException("User [$id] would stay locked out, so there is nothing to promote")
+        }
+    }
+
+    private fun requireAnotherAdminLeft(id: Long) {
+        if (telegramUserAccessService.findActiveAdminIdsForUpdate().singleOrNull() == id) {
+            throw LastAdminException("Demoting user [$id] would leave the system without an admin")
+        }
     }
 
     private fun String.toSearchPattern(): String = "%${EscapeCharacter.DEFAULT.escape(this)}%"

--- a/src/main/resources/liquibase/8.8.0/changes.yaml
+++ b/src/main/resources/liquibase/8.8.0/changes.yaml
@@ -23,3 +23,6 @@ databaseChangeLog:
   - include:
       file: ddl/05_grants.sql
       relativeToChangelogFile: true
+  - include:
+      file: ddl/06_state_comments_without_value_lists.sql
+      relativeToChangelogFile: true

--- a/src/main/resources/liquibase/8.8.0/ddl/06_state_comments_without_value_lists.sql
+++ b/src/main/resources/liquibase/8.8.0/ddl/06_state_comments_without_value_lists.sql
@@ -1,0 +1,15 @@
+--liquibase formatted sql
+
+--changeset illine:8.8.0/ddl/state_comments_without_value_lists
+
+/* liquibase rollback
+ comment on column user_state_events.event_type is 'Type of the event: BANNED, UNBANNED, DEACTIVATED, RESTORED';
+ comment on column telegram_users.is_admin is 'Whether the user has admin privileges; bootstrapped manually via SQL after deploy';
+ comment on column telegram_users.is_banned is 'Whether the user has been banned; bootstrapped manually via SQL after deploy';
+*/
+
+comment on column user_state_events.event_type is 'Type of the state change, one of the UserStateEventType values';
+
+comment on column telegram_users.is_admin is 'Whether the user has admin privileges; the first one is bootstrapped manually via SQL, the rest through the admin API';
+
+comment on column telegram_users.is_banned is 'Whether the user has been banned; set through the admin API';

--- a/src/test/kotlin/ru/illine/drinking/ponies/architecture/CodeLayoutTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/architecture/CodeLayoutTest.kt
@@ -30,7 +30,7 @@ private val STRING_LITERAL = Regex(""""([^"]*)"""")
 
 private const val STATE_DOOR = "TelegramUserAccessServiceImpl"
 
-private val STATE_FLAGS = listOf("deleted", "isBanned")
+private val STATE_FLAGS = listOf("deleted", "isBanned", "isAdmin")
 
 // Both spellings of a write: qualified (user.deleted = ...) and bare inside an apply/with block. The
 // lookbehind drops a named argument, which reads exactly like a bare write once the call wraps over lines.
@@ -205,18 +205,20 @@ class CodeLayoutTest {
     @DisplayName("the account state flags are written through a single door")
     fun `account state has a single door`() {
         val (door, rest) = Konsist.scopeFromProduction().files.partition { it.name == STATE_DOOR }
+        val doorCode = door.single().code()
+        val restCode = rest.map { it.name to it.code() }
 
         STATE_FLAGS.forEach { flag ->
             val write = stateFlagWrite(flag)
 
             assertEquals(
                 emptyList<String>(),
-                rest.filter { write.containsMatchIn(it.code()) }.map { it.name },
+                restCode.filter { (_, code) -> write.containsMatchIn(code) }.map { (name, _) -> name },
                 "'$flag' is written in $STATE_DOOR only, so no write escapes its audit record and cache eviction",
             )
             // Per flag, because the rule would otherwise stay green on a rename as long as one flag still matches.
             assertTrue(
-                write.containsMatchIn(door.single().code()),
+                write.containsMatchIn(doorCode),
                 "$STATE_DOOR must still hold the '$flag' write this rule guards",
             )
         }

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/web/DefaultExceptionHandlerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/web/DefaultExceptionHandlerTest.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import ru.illine.drinking.ponies.exception.LastAdminException
 import ru.illine.drinking.ponies.test.tag.UnitTest
 
 @UnitTest
@@ -99,6 +100,18 @@ class DefaultExceptionHandlerTest {
 
         assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
         assertEquals("resource not found", response.body?.message)
+    }
+
+    @Test
+    @DisplayName("handleConflict(): returns 409 with the client message of the exception")
+    fun `handleConflict returns 409`() {
+        val exception = LastAdminException("the last admin would be left without privileges")
+
+        val response = handler.handleConflict(exception)
+
+        assertEquals(HttpStatus.CONFLICT, response.statusCode)
+        assertEquals(MediaType.APPLICATION_JSON, response.headers.contentType)
+        assertEquals("you cannot revoke the privileges of the last admin", response.body?.message)
     }
 
     @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/UserAdminControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/UserAdminControllerTest.kt
@@ -24,6 +24,7 @@ import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
 import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.jdbc.Sql
@@ -459,6 +460,53 @@ class UserAdminControllerTest
             }
 
             @Test
+            @DisplayName("isAdmin=true - returns 200 with the promoted card and the privileges stick")
+            fun `promotes the user`() {
+                val response = patchState(ACTIVE_USER_ID, """{"isAdmin": true}""")
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertTrue(objectMapper.readTree(response.body).path("isAdmin").asBoolean())
+                assertTrue(getUser(ACTIVE_USER_ID).isAdmin)
+            }
+
+            @Test
+            @DisplayName("isAdmin=false - revokes the privileges as long as another admin stays behind")
+            fun `demotes the user`() {
+                patchState(ACTIVE_USER_ID, """{"isAdmin": true}""")
+
+                val response = patchState(ACTIVE_USER_ID, """{"isAdmin": false}""")
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                assertFalse(objectMapper.readTree(response.body).path("isAdmin").asBoolean())
+                assertFalse(getUser(ACTIVE_USER_ID).isAdmin)
+            }
+
+            @ParameterizedTest(name = "[{index}] id={0}")
+            @ValueSource(longs = [BANNED_USER_ID, DELETED_USER_ID, BANNED_DELETED_USER_ID])
+            @DisplayName("isAdmin=true over a locked out user - returns 409 and grants nothing")
+            fun `refuses to promote a locked out user`(id: Long) {
+                val response = patchState(id, """{"isAdmin": true}""")
+
+                assertEquals(HttpStatus.CONFLICT, response.statusCode)
+                assertEquals(
+                    "you cannot grant admin privileges to a banned or deleted user",
+                    objectMapper.readTree(response.body).path("message").asText(),
+                )
+                assertFalse(getUser(id).isAdmin)
+            }
+
+            @Test
+            @DisplayName("lifting the ban and granting the privileges in one call is allowed")
+            fun `promotes a user the same call unbans`() {
+                val response = patchState(BANNED_USER_ID, """{"isBanned": false, "isAdmin": true}""")
+
+                assertEquals(HttpStatus.OK, response.statusCode)
+                val card = getUser(BANNED_USER_ID)
+                assertTrue(card.isAdmin)
+                assertFalse(card.isBanned)
+            }
+
+            @Test
             @DisplayName("own account - returns 409 with a readable message and leaves the account alone")
             fun `refuses to change own state`() {
                 val response = patchState(ADMIN_USER_ID, """{"isBanned": true}""")
@@ -533,11 +581,45 @@ class UserAdminControllerTest
                 whenever(telegramValidatorService.map(any())).thenReturn(adminUser)
                 assertTrue(getUser(ACTIVE_USER_ID).isActive)
             }
+
+            @Test
+            @DisplayName("promoted caller - passes the guard right away, the stale flags never served on")
+            fun `a promotion opens the admin endpoints`() {
+                whenever(telegramValidatorService.map(any())).thenReturn(nonAdminUser)
+                assertEquals(HttpStatus.FORBIDDEN, listUsersStatus())
+
+                whenever(telegramValidatorService.map(any())).thenReturn(adminUser)
+                patchState(PLAIN_USER_ID, """{"isAdmin": true}""")
+
+                whenever(telegramValidatorService.map(any())).thenReturn(nonAdminUser)
+                assertEquals(HttpStatus.OK, listUsersStatus())
+            }
+
+            @Test
+            @DisplayName("demoted caller - is turned away again on the very next request")
+            fun `a demotion closes the admin endpoints`() {
+                patchState(PLAIN_USER_ID, """{"isAdmin": true}""")
+                whenever(telegramValidatorService.map(any())).thenReturn(nonAdminUser)
+                assertEquals(HttpStatus.OK, listUsersStatus())
+
+                whenever(telegramValidatorService.map(any())).thenReturn(adminUser)
+                patchState(PLAIN_USER_ID, """{"isAdmin": false}""")
+
+                whenever(telegramValidatorService.map(any())).thenReturn(nonAdminUser)
+                assertEquals(HttpStatus.FORBIDDEN, listUsersStatus())
+            }
+
+            private fun listUsersStatus(): HttpStatusCode =
+                restTemplate
+                    .exchange("/users", HttpMethod.GET, HttpEntity<Void>(buildHeaders()), String::class.java)
+                    .statusCode
         }
 
         companion object {
             private const val ADMIN_USER_ID = 1L
+            private const val PLAIN_USER_ID = 2L
             private const val DELETED_USER_ID = 3L
+            private const val BANNED_USER_ID = 4L
             private const val ACTIVE_USER_ID = 5L
             private const val BANNED_DELETED_USER_ID = 6L
             private const val MISSING_USER_ID = 999L

--- a/src/test/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/dao/access/TelegramUserAccessServiceTest.kt
@@ -19,6 +19,8 @@ import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.domain.PageRequest
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlConfig
+import org.springframework.transaction.IllegalTransactionStateException
+import org.springframework.transaction.support.TransactionTemplate
 import ru.illine.drinking.ponies.config.cache.CacheConfig
 import ru.illine.drinking.ponies.dao.repository.TelegramUserRepository
 import ru.illine.drinking.ponies.dao.repository.UserStateEventRepository
@@ -53,6 +55,7 @@ class TelegramUserAccessServiceTest
         private val userStateEventRepository: UserStateEventRepository,
         private val cacheManager: CacheManager,
         private val clock: Clock,
+        private val transactionTemplate: TransactionTemplate,
     ) {
         @BeforeEach
         fun clearCache() {
@@ -592,6 +595,74 @@ class TelegramUserAccessServiceTest
                 assertEquals(LocalDateTime.now(clock), event.eventTime)
             }
 
+            @ParameterizedTest(name = "[{index}] id={0} - admin={1} - {2}")
+            @CsvSource(
+                "5, true,  PROMOTED",
+                "1, false, DEMOTED",
+            )
+            @DisplayName("writes the admin flag and records who granted or revoked it")
+            fun `records the admin event`(
+                id: Long,
+                admin: Boolean,
+                expected: UserStateEventType,
+            ) {
+                accessService.updateState(id, ADMIN_USER_ID, UserStateChangeDto(admin = admin))
+
+                assertEquals(admin, accessService.findByIdForAdmin(id)!!.isAdmin)
+                val event = userStateEventRepository.findAll().single()
+                assertEquals(id, event.userId)
+                assertEquals(ADMIN_USER_ID, event.actorUserId)
+                assertEquals(expected, event.eventType)
+            }
+
+            @ParameterizedTest(name = "[{index}] id={0} - admin={1}")
+            @CsvSource(
+                "1, true",
+                "5, false",
+            )
+            @DisplayName("an admin flag set to the value it already carries records nothing")
+            fun `an unchanged admin flag records nothing`(
+                id: Long,
+                admin: Boolean,
+            ) {
+                accessService.updateState(id, ADMIN_USER_ID, UserStateChangeDto(admin = admin))
+
+                assertEquals(admin, accessService.findByIdForAdmin(id)!!.isAdmin)
+                assertTrue(userStateEventRepository.findAll().isEmpty(), "Nothing changed, nothing to record")
+            }
+
+            @Test
+            @DisplayName("all three fields at once are applied and recorded as three events of one moment")
+            fun `applies all three fields at once`() {
+                val applied =
+                    accessService.updateState(
+                        ACTIVE_USER_ID,
+                        ADMIN_USER_ID,
+                        UserStateChangeDto(deleted = true, banned = true, admin = true),
+                    )
+
+                assertEquals(
+                    UserAccessDto(
+                        ACTIVE_USER_ID,
+                        ACTIVE_EXTERNAL_ID,
+                        isAdmin = true,
+                        isBanned = true,
+                        isDeleted = true,
+                    ),
+                    applied,
+                )
+                val events = userStateEventRepository.findAll().sortedBy { it.id }
+                assertEquals(
+                    listOf(
+                        UserStateEventType.DEACTIVATED,
+                        UserStateEventType.BANNED,
+                        UserStateEventType.PROMOTED,
+                    ),
+                    events.map { it.eventType },
+                )
+                assertEquals(listOf(LocalDateTime.now(clock)), events.map { it.eventTime }.distinct())
+            }
+
             @Test
             @DisplayName("repeating the same update leaves the flag as it is and records a single event")
             fun `repeating the same update is idempotent`() {
@@ -652,6 +723,39 @@ class TelegramUserAccessServiceTest
                 accessService.updateState(ACTIVE_USER_ID, ADMIN_USER_ID, UserStateChangeDto(deleted = null))
 
                 assertNull(cache.get(ACTIVE_EXTERNAL_ID))
+            }
+        }
+
+        @Nested
+        @DisplayName("findActiveAdminIdsForUpdate()")
+        inner class FindAdminIdsForUpdate {
+            @Test
+            @DisplayName("returns the ids of the admins alone, a promotion showing up right away")
+            fun `returns the admin ids`() {
+                transactionTemplate.execute {
+                    assertEquals(listOf(ADMIN_USER_ID), accessService.findActiveAdminIdsForUpdate())
+
+                    accessService.updateState(ACTIVE_USER_ID, ADMIN_USER_ID, UserStateChangeDto(admin = true))
+
+                    assertEquals(listOf(ADMIN_USER_ID, ACTIVE_USER_ID), accessService.findActiveAdminIdsForUpdate())
+                }
+            }
+
+            @Test
+            @DisplayName("leaves out the admins who are turned away at the door anyway")
+            fun `skips banned and deleted admins`() {
+                transactionTemplate.execute {
+                    accessService.updateState(BANNED_USER_ID, ADMIN_USER_ID, UserStateChangeDto(admin = true))
+                    accessService.updateState(DELETED_USER_ID, ADMIN_USER_ID, UserStateChangeDto(admin = true))
+
+                    assertEquals(listOf(ADMIN_USER_ID), accessService.findActiveAdminIdsForUpdate())
+                }
+            }
+
+            @Test
+            @DisplayName("refuses to lock outside a transaction, where the lock would not outlive the call")
+            fun `refuses to run without a transaction`() {
+                assertThrows<IllegalTransactionStateException> { accessService.findActiveAdminIdsForUpdate() }
             }
         }
 

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/user/UserAdminServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/user/UserAdminServiceTest.kt
@@ -1,13 +1,16 @@
 package ru.illine.drinking.ponies.service.user
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.NullSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.kotlin.any
@@ -20,6 +23,8 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageRequest
 import ru.illine.drinking.ponies.dao.access.TelegramUserAccessService
+import ru.illine.drinking.ponies.exception.InactiveUserPromotionException
+import ru.illine.drinking.ponies.exception.LastAdminException
 import ru.illine.drinking.ponies.exception.SelfStateChangeException
 import ru.illine.drinking.ponies.exception.TelegramUserNotFoundException
 import ru.illine.drinking.ponies.model.base.AdminUserStatusFilter
@@ -29,8 +34,10 @@ import ru.illine.drinking.ponies.model.dto.internal.UserCountsDto
 import ru.illine.drinking.ponies.model.dto.internal.UserStateChangeDto
 import ru.illine.drinking.ponies.model.dto.internal.UserStateDto
 import ru.illine.drinking.ponies.service.user.impl.UserAdminServiceImpl
+import ru.illine.drinking.ponies.test.generator.DtoGenerator
 import ru.illine.drinking.ponies.test.tag.UnitTest
 import java.time.LocalDateTime
+import java.util.stream.Stream
 
 @UnitTest
 @DisplayName("UserAdminService Unit Test")
@@ -180,12 +187,170 @@ class UserAdminServiceTest {
         assertEquals(adminUser(deleted = false), result)
     }
 
+    @ParameterizedTest(name = "[{index}] isAdmin={0}")
+    @CsvSource("true", "false")
+    @DisplayName("updateState(): writes the admin flag and answers with it")
+    fun `updateState answers with the freshly written admin flag`(isAdmin: Boolean) {
+        whenever(telegramUserAccessService.findByIdForAdmin(USER_ID))
+            .thenReturn(adminUser(deleted = false, isAdmin = !isAdmin))
+        whenever(telegramUserAccessService.findActiveAdminIdsForUpdate()).thenReturn(listOf(ACTOR_ID, USER_ID))
+        stubApplied(deleted = false, admin = isAdmin)
+
+        val result = userAdminService.updateState(USER_ID, ACTOR_ID, UserStateDto(isAdmin = isAdmin))
+
+        assertEquals(isAdmin, result.isAdmin)
+        verify(telegramUserAccessService).updateState(
+            USER_ID,
+            ACTOR_ID,
+            UserStateChangeDto(admin = isAdmin),
+        )
+    }
+
+    @ParameterizedTest(name = "[{index}] banned={0}, deleted={1}")
+    @CsvSource(
+        "true,  false",
+        "false, true",
+        "true,  true",
+    )
+    @DisplayName("updateState(): refuses to promote a user who would stay locked out, and writes nothing")
+    fun `updateState refuses to promote a locked out user`(
+        banned: Boolean,
+        deleted: Boolean,
+    ) {
+        whenever(telegramUserAccessService.findByIdForAdmin(USER_ID))
+            .thenReturn(adminUser(deleted = deleted, banned = banned))
+
+        assertThrows<InactiveUserPromotionException> {
+            userAdminService.updateState(USER_ID, ACTOR_ID, UserStateDto(isAdmin = true))
+        }
+
+        verify(telegramUserAccessService, never()).updateState(any(), any(), any())
+    }
+
+    @ParameterizedTest(name = "[{index}] stored banned={0}, deleted={1} - {2}")
+    @MethodSource("providePromotionsThatUnlock")
+    @DisplayName("updateState(): a promotion that lifts the lockout in the same call goes through")
+    fun `updateState promotes a user the same call unlocks`(
+        banned: Boolean,
+        deleted: Boolean,
+        state: UserStateDto,
+    ) {
+        whenever(telegramUserAccessService.findByIdForAdmin(USER_ID))
+            .thenReturn(adminUser(deleted = deleted, banned = banned))
+        stubApplied(deleted = false, admin = true)
+
+        val result = userAdminService.updateState(USER_ID, ACTOR_ID, state)
+
+        assertTrue(result.isAdmin)
+        verify(telegramUserAccessService).updateState(any(), any(), any())
+    }
+
+    @Test
+    @DisplayName("updateState(): refuses to revoke the privileges of the only admin left and writes nothing")
+    fun `updateState refuses to demote the last admin`() {
+        whenever(telegramUserAccessService.findByIdForAdmin(USER_ID))
+            .thenReturn(adminUser(deleted = false, isAdmin = true))
+        whenever(telegramUserAccessService.findActiveAdminIdsForUpdate()).thenReturn(listOf(USER_ID))
+
+        assertThrows<LastAdminException> {
+            userAdminService.updateState(USER_ID, ACTOR_ID, UserStateDto(isAdmin = false))
+        }
+
+        verify(telegramUserAccessService, never()).updateState(any(), any(), any())
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("providePayloadsKeepingThePrivileges")
+    @DisplayName("updateState(): a payload that does not revoke the privileges locks no admin rows")
+    fun `updateState locks nothing outside a demotion`(state: UserStateDto) {
+        whenever(telegramUserAccessService.findByIdForAdmin(USER_ID)).thenReturn(adminUser(deleted = false))
+        stubApplied(deleted = false)
+
+        userAdminService.updateState(USER_ID, ACTOR_ID, state)
+
+        verify(telegramUserAccessService, never()).findActiveAdminIdsForUpdate()
+    }
+
+    @Test
+    @DisplayName("updateState(): an admin revoking their own privileges is a self change, nothing is even read")
+    fun `updateState rejects a self demotion`() {
+        assertThrows<SelfStateChangeException> {
+            userAdminService.updateState(USER_ID, USER_ID, UserStateDto(isAdmin = false))
+        }
+
+        verifyNoInteractions(telegramUserAccessService)
+    }
+
+    @Test
+    @DisplayName("updateState(): the only admin left being somebody else does not stand in the way of a demotion")
+    fun `updateState demotes a user who is not the last admin`() {
+        whenever(telegramUserAccessService.findByIdForAdmin(USER_ID))
+            .thenReturn(adminUser(deleted = false, isAdmin = true))
+        whenever(telegramUserAccessService.findActiveAdminIdsForUpdate()).thenReturn(listOf(ACTOR_ID))
+        stubApplied(deleted = false)
+
+        val result = userAdminService.updateState(USER_ID, ACTOR_ID, UserStateDto(isAdmin = false))
+
+        assertFalse(result.isAdmin)
+        verify(telegramUserAccessService).updateState(
+            USER_ID,
+            ACTOR_ID,
+            UserStateChangeDto(admin = false),
+        )
+    }
+
+    @Test
+    @DisplayName("updateState(): an unknown user is reported as not found on a demotion as well")
+    fun `updateState reports an unknown user on a demotion`() {
+        whenever(telegramUserAccessService.findByIdForAdmin(USER_ID)).thenReturn(null)
+
+        assertThrows<TelegramUserNotFoundException> {
+            userAdminService.updateState(USER_ID, ACTOR_ID, UserStateDto(isAdmin = false))
+        }
+
+        verify(telegramUserAccessService, never()).findActiveAdminIdsForUpdate()
+        verify(telegramUserAccessService, never()).updateState(any(), any(), any())
+    }
+
+    @Test
+    @DisplayName("updateState(): all three toggles reach the DAO as one change, the activity arriving inverted")
+    fun `updateState forwards all three fields at once`() {
+        whenever(telegramUserAccessService.findByIdForAdmin(USER_ID))
+            .thenReturn(adminUser(deleted = true, banned = true))
+        stubApplied(deleted = false, admin = true)
+
+        val result =
+            userAdminService.updateState(
+                USER_ID,
+                ACTOR_ID,
+                UserStateDto(isActive = true, isBanned = false, isAdmin = true),
+            )
+
+        assertFalse(result.deleted)
+        assertFalse(result.isBanned)
+        assertTrue(result.isAdmin)
+        verify(telegramUserAccessService).updateState(
+            USER_ID,
+            ACTOR_ID,
+            UserStateChangeDto(deleted = false, banned = false, admin = true),
+        )
+    }
+
     private fun stubApplied(
         deleted: Boolean,
         banned: Boolean = false,
+        admin: Boolean = false,
     ) {
         whenever(telegramUserAccessService.updateState(any(), any(), any()))
-            .thenReturn(UserAccessDto(USER_ID, EXTERNAL_USER_ID, isBanned = banned, isDeleted = deleted))
+            .thenReturn(
+                DtoGenerator.generateUserAccessDto(
+                    id = USER_ID,
+                    externalUserId = EXTERNAL_USER_ID,
+                    isAdmin = admin,
+                    isBanned = banned,
+                    isDeleted = deleted,
+                ),
+            )
     }
 
     @Test
@@ -205,15 +370,19 @@ class UserAdminServiceTest {
         whenever(telegramUserAccessService.countForAdmin(anyOrNull())).thenReturn(EMPTY_COUNTS)
     }
 
-    private fun adminUser(deleted: Boolean): AdminUserDto =
+    private fun adminUser(
+        deleted: Boolean,
+        isAdmin: Boolean = false,
+        banned: Boolean = false,
+    ): AdminUserDto =
         AdminUserDto(
             id = USER_ID,
             externalUserId = EXTERNAL_USER_ID,
             firstName = "Alisa",
             lastName = "Petrova",
             username = "alisaadmin",
-            isAdmin = false,
-            isBanned = false,
+            isAdmin = isAdmin,
+            isBanned = banned,
             deleted = deleted,
             timeZone = "Europe/Moscow",
             created = LocalDateTime.of(2026, 1, 1, 10, 0),
@@ -221,6 +390,21 @@ class UserAdminServiceTest {
         )
 
     companion object {
+        @JvmStatic
+        fun providePayloadsKeepingThePrivileges(): Stream<UserStateDto> =
+            Stream.of(
+                UserStateDto(isAdmin = true),
+                UserStateDto(isActive = false, isBanned = true),
+            )
+
+        @JvmStatic
+        fun providePromotionsThatUnlock(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of(true, false, UserStateDto(isBanned = false, isAdmin = true)),
+                Arguments.of(false, true, UserStateDto(isActive = true, isAdmin = true)),
+                Arguments.of(true, true, UserStateDto(isActive = true, isBanned = false, isAdmin = true)),
+            )
+
         private const val USER_ID = 1042L
         private const val EXTERNAL_USER_ID = 482719301L
         private const val ACTOR_ID = 1L


### PR DESCRIPTION
## Summary
- `PATCH /users/{id}` takes a third state field, `isAdmin`, next to activity and ban. The flag is written through the same single door as the others and recorded in `user_state_events` as `PROMOTED` / `DEMOTED`.
- Revoking the privileges of the last admin who can still sign in is refused with 409. The guard locks the admin rows with `for no key update` inside the caller's transaction, so two admins demoting each other are serialized instead of both acting on a stale state.
- Promoting a banned or soft-deleted user is refused with 409 as well. The check reads the state the request leaves behind, so lifting a ban and granting the privileges in a single call still works.
- A migration drops the enum value list from the state column comments, so the next event type will not need one.
- The architecture rule "account state flags are written through a single door" now covers `is_admin` too.

## Test plan
- [x] `./gradlew check` green locally: lint, detekt and the whole suite (unit, Spring integration, architecture).
- [x] The extended single-door rule verified by hand - a write of the flag outside the door turns the architecture test red.
- [x] The locking query verified to need a writable transaction: with `readOnly = true` Postgres rejects it with `cannot execute SELECT FOR UPDATE in a read-only transaction`.
