### PR TITLE
DPTB-234: mark application loggers in the logger admin api

### DIFF
--- a/src/main/kotlin/ru/illine/drinking/ponies/controller/LoggerAdminController.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/controller/LoggerAdminController.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import ru.illine.drinking.ponies.config.web.security.AdminOnly
+import ru.illine.drinking.ponies.mapper.LoggerLevelResponseMapper
 import ru.illine.drinking.ponies.model.dto.internal.TelegramAuthUserDto
 import ru.illine.drinking.ponies.model.dto.internal.requireStoredId
 import ru.illine.drinking.ponies.model.dto.request.LoggerLevelRequest
@@ -35,11 +36,7 @@ class LoggerAdminController(
     @GetMapping
     @Operation(summary = "List our own loggers plus every logger that carries an explicit level")
     fun getLoggers(): LoggersResponse =
-        LoggersResponse(
-            loggerAdminService.getKnownLevels().map {
-                LoggerLevelResponse(it.name, it.configuredLevel, it.effectiveLevel)
-            },
-        )
+        LoggersResponse(loggerAdminService.getKnownLevels().map(LoggerLevelResponseMapper::toResponse))
 
     @GetMapping("/{name}")
     @Operation(summary = "Get the level of any logger, including one of a third-party library")
@@ -47,10 +44,7 @@ class LoggerAdminController(
         @Parameter(description = "Logger name", example = "org.hibernate.SQL")
         @PathVariable(name = "name")
         @Pattern(regexp = LoggingConstants.LOGGER_NAME_PATTERN) name: String,
-    ): LoggerLevelResponse =
-        loggerAdminService.getLevel(name).let {
-            LoggerLevelResponse(it.name, it.configuredLevel, it.effectiveLevel)
-        }
+    ): LoggerLevelResponse = LoggerLevelResponseMapper.toResponse(loggerAdminService.getLevel(name))
 
     @PutMapping("/{name}")
     @Operation(summary = "Set the level of a logger until the application restarts")
@@ -62,9 +56,9 @@ class LoggerAdminController(
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) actor: TelegramAuthUserDto,
         @Valid @RequestBody request: LoggerLevelRequest,
     ): LoggerLevelResponse =
-        loggerAdminService.setLevel(name, request.level, actor.requireStoredId()).let {
-            LoggerLevelResponse(it.name, it.configuredLevel, it.effectiveLevel)
-        }
+        LoggerLevelResponseMapper.toResponse(
+            loggerAdminService.setLevel(name, request.level, actor.requireStoredId()),
+        )
 
     @PostMapping("/reset")
     @Operation(summary = "Return every logger to the level it had at startup")
@@ -73,8 +67,6 @@ class LoggerAdminController(
         @RequestAttribute(TelegramGeneralConstants.TELEGRAM_USER_ATTRIBUTE) actor: TelegramAuthUserDto,
     ): LoggersResponse =
         LoggersResponse(
-            loggerAdminService.resetLevels(actor.requireStoredId()).map {
-                LoggerLevelResponse(it.name, it.configuredLevel, it.effectiveLevel)
-            },
+            loggerAdminService.resetLevels(actor.requireStoredId()).map(LoggerLevelResponseMapper::toResponse),
         )
 }

--- a/src/main/kotlin/ru/illine/drinking/ponies/mapper/LoggerLevelResponseMapper.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/mapper/LoggerLevelResponseMapper.kt
@@ -1,0 +1,12 @@
+package ru.illine.drinking.ponies.mapper
+
+import io.mcarle.konvert.api.Konverter
+import ru.illine.drinking.ponies.model.dto.internal.LoggerLevelDto
+import ru.illine.drinking.ponies.model.dto.response.LoggerLevelResponse
+
+@Konverter
+interface LoggerLevelResponseMapper {
+    fun toResponse(dto: LoggerLevelDto): LoggerLevelResponse
+
+    companion object : LoggerLevelResponseMapper by Konverter.get<LoggerLevelResponseMapper>()
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/LoggerLevelDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/LoggerLevelDto.kt
@@ -6,4 +6,5 @@ data class LoggerLevelDto(
     val name: String,
     val configuredLevel: LogLevel?,
     val effectiveLevel: LogLevel?,
+    val application: Boolean,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/LoggerLevelResponse.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/LoggerLevelResponse.kt
@@ -19,4 +19,9 @@ data class LoggerLevelResponse(
         nullable = true,
     )
     val effectiveLevel: LogLevel?,
+    @Schema(
+        description = "True for a logger the application declares itself, false for one coming from a library",
+        example = "true",
+    )
+    val application: Boolean,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/logging/impl/LoggerAdminServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/logging/impl/LoggerAdminServiceImpl.kt
@@ -26,12 +26,6 @@ class LoggerAdminServiceImpl(
             .filterNot { it == logger.name }
             .map { readLevel(it) }
 
-    private fun configuredLoggerNames(): List<String> =
-        loggingSystem
-            .loggerConfigurations
-            .filter { it.configuredLevel != null }
-            .map { it.name }
-
     override fun getLevel(name: String): LoggerLevelDto = readLevel(name)
 
     override fun setLevel(
@@ -63,8 +57,19 @@ class LoggerAdminServiceImpl(
         return getKnownLevels()
     }
 
+    private fun configuredLoggerNames(): List<String> =
+        loggingSystem
+            .loggerConfigurations
+            .filter { it.configuredLevel != null }
+            .map { it.name }
+
     private fun readLevel(name: String): LoggerLevelDto =
         loggingSystem.getLoggerConfiguration(name).let {
-            LoggerLevelDto(name = name, configuredLevel = it?.configuredLevel, effectiveLevel = it?.effectiveLevel)
+            LoggerLevelDto(
+                name = name,
+                configuredLevel = it?.configuredLevel,
+                effectiveLevel = it?.effectiveLevel,
+                application = AppLogger.entries.any { appLogger -> name == appLogger.value },
+            )
         }
 }

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/LoggerAdminControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/LoggerAdminControllerTest.kt
@@ -117,6 +117,22 @@ class LoggerAdminControllerTest
             String::class.java,
         )
 
+        private fun putLevelForResponse(
+            name: String,
+            body: String,
+        ): LoggerLevelResponse {
+            val response =
+                restTemplate.exchange(
+                    "/systems/loggers/$name",
+                    HttpMethod.PUT,
+                    HttpEntity(body, buildHeaders()),
+                    LoggerLevelResponse::class.java,
+                )
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            return response.body!!
+        }
+
         private fun resetLevels(): LoggersResponse {
             val response =
                 restTemplate.exchange(
@@ -158,6 +174,17 @@ class LoggerAdminControllerTest
             }
 
             @Test
+            @DisplayName("tells our loggers from the libraries', so the client does not guess by the dot in a name")
+            fun `marks which loggers are ours`() {
+                putLevel(SANDBOX_LOGGER, """{"level": "DEBUG"}""")
+
+                val loggers = getLoggers().loggers
+
+                assertEquals(PUBLISHED_LOGGERS.map { it.value }, loggers.filter { it.application }.map { it.name })
+                assertFalse(loggers.single { it.name == SANDBOX_LOGGER }.application)
+            }
+
+            @Test
             @DisplayName("a logger with no level of its own reports the one inherited from the root")
             fun `reports the inherited level`() {
                 val loggers = getLoggers().loggers
@@ -179,6 +206,13 @@ class LoggerAdminControllerTest
 
                 assertEquals(THIRD_PARTY_LOGGER, body.name)
                 assertNotNull(body.effectiveLevel)
+                assertFalse(body.application)
+            }
+
+            @Test
+            @DisplayName("one of our own loggers is answered as ours, read by name and not only in the list")
+            fun `marks a single logger of ours`() {
+                assertTrue(getLogger(AppLogger.SERVICE.value).application)
             }
 
             @Test
@@ -188,6 +222,7 @@ class LoggerAdminControllerTest
 
                 assertNull(body.configuredLevel)
                 assertNull(body.effectiveLevel)
+                assertFalse(body.application)
             }
         }
 
@@ -204,6 +239,20 @@ class LoggerAdminControllerTest
                 assertEquals(HttpStatus.OK, response.statusCode)
                 assertFalse(LoggerFactory.getLogger(SANDBOX_LOGGER).isErrorEnabled)
                 assertEquals(LogLevel.OFF, getLogger(SANDBOX_LOGGER).configuredLevel)
+            }
+
+            @Test
+            @DisplayName("the answer says whether the logger is ours, so the changed row keeps its section")
+            fun `reports ownership of the changed logger`() {
+                val sqlWas = loggingSystem.getLoggerConfiguration(AppLogger.SQL.value).configuredLevel
+
+                try {
+                    assertTrue(putLevelForResponse(AppLogger.SQL.value, """{"level": "DEBUG"}""").application)
+                } finally {
+                    loggingSystem.setLogLevel(AppLogger.SQL.value, sqlWas)
+                }
+
+                assertFalse(putLevelForResponse(SANDBOX_LOGGER, """{"level": "DEBUG"}""").application)
             }
 
             @ParameterizedTest(name = "[{index}] {0}")
@@ -268,6 +317,14 @@ class LoggerAdminControllerTest
                 resetLevels()
 
                 assertEquals(configured, getLoggers().loggers.filter { it.configuredLevel != null })
+            }
+
+            @Test
+            @DisplayName("the answer keeps the ownership flag, both sections being redrawn from it")
+            fun `reset reports ownership`() {
+                val loggers = resetLevels().loggers
+
+                assertEquals(PUBLISHED_LOGGERS.map { it.value }, loggers.filter { it.application }.map { it.name })
             }
 
             @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/logging/LoggerAdminServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/logging/LoggerAdminServiceTest.kt
@@ -4,11 +4,15 @@ import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.read.ListAppender
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
@@ -42,6 +46,26 @@ class LoggerAdminServiceTest {
         PUBLISHED_LOGGERS.forEach { verify(loggingSystem).getLoggerConfiguration(it.value) }
     }
 
+    @ParameterizedTest(name = "[{index}] {0}")
+    @EnumSource(AppLogger::class)
+    @DisplayName("getLevel(): a logger the application declares is reported as its own")
+    fun `declared loggers are reported as ours`(appLogger: AppLogger) {
+        whenever(loggingSystem.getLoggerConfiguration(appLogger.value))
+            .thenReturn(LoggerConfiguration(appLogger.value, null, LogLevel.INFO))
+
+        assertTrue(service.getLevel(appLogger.value).application)
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @ValueSource(strings = [THIRD_PARTY_LOGGER, UNKNOWN_LOGGER])
+    @DisplayName("getLevel(): a logger outside the enum is not reported as ours, the dots in its name aside")
+    fun `foreign loggers are not reported as ours`(name: String) {
+        whenever(loggingSystem.getLoggerConfiguration(name))
+            .thenReturn(LoggerConfiguration(name, null, LogLevel.INFO))
+
+        assertFalse(service.getLevel(name).application)
+    }
+
     @Test
     @DisplayName("getKnownLevels(): a third-party logger with an explicit level joins the list, once")
     fun `known levels pick up configured outsiders`() {
@@ -60,6 +84,19 @@ class LoggerAdminServiceTest {
         val names = service.getKnownLevels().map { it.name }
 
         assertEquals(PUBLISHED_LOGGERS.map { it.value } + THIRD_PARTY_LOGGER, names)
+    }
+
+    @Test
+    @DisplayName("getKnownLevels(): tells our loggers from the libraries', the flat list carrying both")
+    fun `known levels tell ours from the libraries`() {
+        whenever(loggingSystem.loggerConfigurations)
+            .thenReturn(listOf(LoggerConfiguration(THIRD_PARTY_LOGGER, LogLevel.DEBUG, LogLevel.DEBUG)))
+        whenever(loggingSystem.getLoggerConfiguration(any()))
+            .thenAnswer { LoggerConfiguration(it.arguments[0] as String, null, LogLevel.INFO) }
+
+        val ours = service.getKnownLevels().filter { it.application }.map { it.name }
+
+        assertEquals(PUBLISHED_LOGGERS.map { it.value }, ours)
     }
 
     @Test
@@ -123,6 +160,7 @@ class LoggerAdminServiceTest {
         verify(loggingSystem).setLogLevel(eq(AppLogger.SQL.value), eq(LogLevel.DEBUG))
         assertEquals(LogLevel.DEBUG, applied.configuredLevel)
         assertEquals(LogLevel.DEBUG, applied.effectiveLevel)
+        assertTrue(applied.application)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `LoggerLevelResponse` carries `application: Boolean` - true for a logger declared in `AppLogger`, false for a library one, so the client no longer guesses ownership from a dot in the name
- the flag is filled in by all four endpoints (`GET /systems/loggers`, `GET /systems/loggers/{name}`, `PUT /systems/loggers/{name}`, `POST /systems/loggers/reset`), `AppLogger.entries` staying the single source of truth
- the response is assembled by a new Konvert mapper instead of four hand-written constructor calls in the controller
- `@Schema` documents the new field in the OpenAPI contract

## Test plan
- [x] `./gradlew check` green locally - detekt, lintKotlin (main + test), full test suite
- [x] service test: every `AppLogger` entry is reported as ours, `org.hibernate.SQL` and an unknown logger are not
- [x] controller test: the flag is asserted over HTTP for each of the four endpoints
- [x] mutation check - hardcoding the flag to `false` fails 18 tests, to `true` fails 8
