### PR TITLE
DPTB-233: apply the logback configuration under every profile

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,8 +1,7 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
-    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
 
-    <springProfile name="default">
+    <springProfile name="!deploy">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
                 <pattern>
@@ -34,10 +33,6 @@
         <appender-ref ref="CONSOLE"/>
     </root>
 
-    <logger name="org.telegram.telegrambots.abilitybots.api.bot" level="WARN">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
-    <logger name="org.hibernate.engine.internal.StatisticalLoggingSessionEventListener" level="WARN">
-        <appender-ref ref="CONSOLE"/>
-    </logger>
+    <logger name="org.telegram.telegrambots.abilitybots.api.bot" level="WARN"/>
+    <logger name="org.hibernate.engine.internal.StatisticalLoggingSessionEventListener" level="WARN"/>
 </configuration>

--- a/src/test/kotlin/ru/illine/drinking/ponies/config/LoggingConfigurationTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/config/LoggingConfigurationTest.kt
@@ -1,0 +1,56 @@
+package ru.illine.drinking.ponies.config
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.logging.LogLevel
+import org.springframework.boot.logging.LoggingSystem
+import org.springframework.core.io.ClassPathResource
+import org.w3c.dom.Element
+import ru.illine.drinking.ponies.test.tag.SpringIntegrationTest
+import javax.xml.parsers.DocumentBuilderFactory
+
+@SpringIntegrationTest
+@DisplayName("Logging Configuration Spring Integration Test")
+class LoggingConfigurationTest
+    @Autowired
+    constructor(
+        private val loggingSystem: LoggingSystem,
+    ) {
+        @Test
+        @DisplayName("the root level from the configuration file is the one in effect, not logback's own default")
+        fun `root level is applied`() {
+            val declared = LogLevel.valueOf(readElements("root").single().getAttribute("level"))
+
+            val applied = loggingSystem.getLoggerConfiguration(LoggingSystem.ROOT_LOGGER_NAME)?.configuredLevel
+
+            assertEquals(declared, applied)
+        }
+
+        @Test
+        @DisplayName("every logger the configuration file declares carries the declared level")
+        fun `declared logger levels are applied`() {
+            val declared =
+                readElements("logger")
+                    .associate { it.getAttribute("name") to LogLevel.valueOf(it.getAttribute("level")) }
+            assertTrue(declared.isNotEmpty(), "the configuration file declares no logger, so this test guards nothing")
+
+            val applied = declared.keys.associateWith { loggingSystem.getLoggerConfiguration(it)?.configuredLevel }
+
+            assertEquals(declared, applied)
+        }
+
+        private fun readElements(tag: String): List<Element> =
+            DocumentBuilderFactory
+                .newInstance()
+                .newDocumentBuilder()
+                .parse(ClassPathResource(CONFIGURATION_FILE).inputStream)
+                .getElementsByTagName(tag)
+                .let { nodes -> (0 until nodes.length).map { nodes.item(it) as Element } }
+
+        private companion object {
+            const val CONFIGURATION_FILE = "logback-spring.xml"
+        }
+    }


### PR DESCRIPTION
## Summary
- rename `logback.xml` to `logback-spring.xml`, the name Spring Boot expects for profile-aware configuration
- widen the console appender from the `default` profile to `!deploy`, so the integration-test profile gets an appender as well
- an element referencing a missing appender is dropped whole, level included, which is why the root logger sat at logback's built-in DEBUG in tests
- drop the `NopStatusListener` that silenced logback's own diagnostics
- drop the redundant `appender-ref` from two loggers, additivity already routes them through root
- add `LoggingConfigurationTest`, reading levels from the configuration file and asserting they are in effect

## Test plan
- [x] `./gradlew check` green (lint, detekt, tests)
- [x] guard test verified both ways: green on the fix, red once the profile is reverted
- [x] logback status output clean, no `springProfile` warnings
- [x] `deploy` profile booted locally, logs still JSON with the fields file.d parses
- [x] test stand after deploy: INFO/WARN only, zero DEBUG, zero unparsed records, log volume unchanged
