### PR TITLE
DPTB-238: drop FATAL from the logger level contract

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -135,6 +135,7 @@ The rules above are not left to review attention - most of them fail the build.
 | Entities stay inside `dao` and `mapper` | detekt `ForbiddenImport/entityOutsideDao` |
 | HTTP types (`request` and `response`) stay in the web layer | detekt `ForbiddenImport/httpTypesOutsideWeb` |
 | A foreign wire schema stays at its parser | detekt `ForbiddenImport/foreignSchemaOutsideParser` |
+| Spring's `LogLevel` stays at the `LoggingSystem` boundary | detekt `ForbiddenImport/springLogLevelOutsideLoggingService` |
 | Tests mock through mockito-kotlin, not the raw Mockito API | detekt `ForbiddenImport/rawMockitoInTests` |
 | No `@Suppress` switches off a boundary or a whole ruleset | `architecture/CodeLayoutTest` |
 | Three packages under `model/dto`, empty root | `architecture/CodeLayoutTest` |
@@ -167,6 +168,11 @@ enum, which also covers `getLogger(Foo::class.java)` that no list of literals wo
 The admin API does not reuse Actuator's `loggers` endpoint even though the starter is a dependency: Actuator listens
 on its own management port with no Telegram admin check, and `application-deploy.yaml` excludes that endpoint on
 purpose. The controller talks to the `LoggingSystem` bean directly, which keeps the exclusion intact.
+
+The levels that API speaks are `LogLevelType`, not Spring's own `LogLevel`, which stays at the `LoggingSystem`
+boundary. The two differ by one value: `FATAL` has no counterpart underneath, the logging system applies it as
+`ERROR`, and the endpoint would answer with a level nobody asked for. Leaving it out of the enum makes the parser
+reject it as a 400 before any code runs, so the contract offers exactly the levels it can honour.
 
 Silencing a boundary is caught by the architecture test rather than by detekt's
 own `ForbiddenSuppress`: detekt matches suppression ids as literals while

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -652,6 +652,14 @@ style:
     forbiddenImports:
       - reason: 'A schema owned by Telegram stops at the parser and is converted into an internal DTO right away'
         value: 'ru.illine.drinking.ponies.util.telegram.TelegramInitDataUser'
+  # The enum owns the translation, the logging service is the one caller that talks to LoggingSystem.
+  # Tests are excluded: the ones covering this very boundary have to see both types.
+  ForbiddenImport/springLogLevelOutsideLoggingService:
+    active: true
+    excludes: ['**/model/base/**', '**/service/logging/**', '**/src/test/**']
+    forbiddenImports:
+      - reason: 'The API speaks LogLevelType, the Spring level stops at the LoggingSystem boundary'
+        value: 'org.springframework.boot.logging.LogLevel'
   # Test style, see TESTING.md. util/sql is the one legal consumer: mockito-kotlin ships no mockStatic wrapper.
   ForbiddenImport/rawMockitoInTests:
     active: true

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/base/LogLevelType.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/base/LogLevelType.kt
@@ -1,0 +1,19 @@
+package ru.illine.drinking.ponies.model.base
+
+import org.springframework.boot.logging.LogLevel
+
+enum class LogLevelType(
+    val level: LogLevel,
+) {
+    TRACE(LogLevel.TRACE),
+    DEBUG(LogLevel.DEBUG),
+    INFO(LogLevel.INFO),
+    WARN(LogLevel.WARN),
+    ERROR(LogLevel.ERROR),
+    OFF(LogLevel.OFF),
+    ;
+
+    companion object {
+        fun of(level: LogLevel?): LogLevelType? = entries.find { it.level == level }
+    }
+}

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/LoggerLevelDto.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/internal/LoggerLevelDto.kt
@@ -1,10 +1,10 @@
 package ru.illine.drinking.ponies.model.dto.internal
 
-import org.springframework.boot.logging.LogLevel
+import ru.illine.drinking.ponies.model.base.LogLevelType
 
 data class LoggerLevelDto(
     val name: String,
-    val configuredLevel: LogLevel?,
-    val effectiveLevel: LogLevel?,
+    val configuredLevel: LogLevelType?,
+    val effectiveLevel: LogLevelType?,
     val application: Boolean,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/LoggerLevelRequest.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/request/LoggerLevelRequest.kt
@@ -2,14 +2,14 @@ package ru.illine.drinking.ponies.model.dto.request
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import io.swagger.v3.oas.annotations.media.Schema
-import org.springframework.boot.logging.LogLevel
+import ru.illine.drinking.ponies.model.base.LogLevelType
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(description = "Log level to apply to a logger")
 data class LoggerLevelRequest(
     @Schema(
-        description = "Level the logger is set to; OFF silences it completely, FATAL is applied as ERROR",
+        description = "Level the logger is set to; OFF silences it completely, a level outside the list is rejected",
         example = "DEBUG",
     )
-    val level: LogLevel,
+    val level: LogLevelType,
 )

--- a/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/LoggerLevelResponse.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/model/dto/response/LoggerLevelResponse.kt
@@ -1,7 +1,7 @@
 package ru.illine.drinking.ponies.model.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import org.springframework.boot.logging.LogLevel
+import ru.illine.drinking.ponies.model.base.LogLevelType
 
 @Schema(description = "Log level of a single logger")
 data class LoggerLevelResponse(
@@ -12,13 +12,13 @@ data class LoggerLevelResponse(
         example = "DEBUG",
         nullable = true,
     )
-    val configuredLevel: LogLevel?,
+    val configuredLevel: LogLevelType?,
     @Schema(
         description = "Level in effect, inherited from the closest configured parent; null for an unknown logger",
         example = "INFO",
         nullable = true,
     )
-    val effectiveLevel: LogLevel?,
+    val effectiveLevel: LogLevelType?,
     @Schema(
         description = "True for a logger the application declares itself, false for one coming from a library",
         example = "true",

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/logging/LoggerAdminService.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/logging/LoggerAdminService.kt
@@ -1,6 +1,6 @@
 package ru.illine.drinking.ponies.service.logging
 
-import org.springframework.boot.logging.LogLevel
+import ru.illine.drinking.ponies.model.base.LogLevelType
 import ru.illine.drinking.ponies.model.dto.internal.LoggerLevelDto
 
 interface LoggerAdminService {
@@ -10,7 +10,7 @@ interface LoggerAdminService {
 
     fun setLevel(
         name: String,
-        level: LogLevel,
+        level: LogLevelType,
         actorId: Long,
     ): LoggerLevelDto
 

--- a/src/main/kotlin/ru/illine/drinking/ponies/service/logging/impl/LoggerAdminServiceImpl.kt
+++ b/src/main/kotlin/ru/illine/drinking/ponies/service/logging/impl/LoggerAdminServiceImpl.kt
@@ -4,6 +4,7 @@ import org.springframework.boot.logging.LogLevel
 import org.springframework.boot.logging.LoggingSystem
 import org.springframework.stereotype.Service
 import ru.illine.drinking.ponies.model.base.AppLogger
+import ru.illine.drinking.ponies.model.base.LogLevelType
 import ru.illine.drinking.ponies.model.dto.internal.LoggerLevelDto
 import ru.illine.drinking.ponies.service.logging.LoggerAdminService
 
@@ -30,7 +31,7 @@ class LoggerAdminServiceImpl(
 
     override fun setLevel(
         name: String,
-        level: LogLevel,
+        level: LogLevelType,
         actorId: Long,
     ): LoggerLevelDto {
         require(name != logger.name) { "The audit logger cannot be reconfigured through the API" }
@@ -42,7 +43,7 @@ class LoggerAdminServiceImpl(
             level,
             loggingSystem.getLoggerConfiguration(name)?.effectiveLevel,
         )
-        loggingSystem.setLogLevel(name, level)
+        loggingSystem.setLogLevel(name, level.level)
 
         return readLevel(name)
     }
@@ -67,8 +68,8 @@ class LoggerAdminServiceImpl(
         loggingSystem.getLoggerConfiguration(name).let {
             LoggerLevelDto(
                 name = name,
-                configuredLevel = it?.configuredLevel,
-                effectiveLevel = it?.effectiveLevel,
+                configuredLevel = LogLevelType.of(it?.configuredLevel),
+                effectiveLevel = LogLevelType.of(it?.effectiveLevel),
                 application = AppLogger.entries.any { appLogger -> name == appLogger.value },
             )
         }

--- a/src/test/kotlin/ru/illine/drinking/ponies/controller/LoggerAdminControllerTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/controller/LoggerAdminControllerTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
@@ -31,6 +32,7 @@ import org.springframework.test.context.jdbc.SqlConfig
 import ru.illine.drinking.ponies.config.cache.CacheConfig
 import ru.illine.drinking.ponies.config.web.security.AuthErrorType
 import ru.illine.drinking.ponies.model.base.AppLogger
+import ru.illine.drinking.ponies.model.base.LogLevelType
 import ru.illine.drinking.ponies.model.dto.response.LoggerLevelResponse
 import ru.illine.drinking.ponies.model.dto.response.LoggersResponse
 import ru.illine.drinking.ponies.service.telegram.TelegramValidatorService
@@ -238,7 +240,20 @@ class LoggerAdminControllerTest
 
                 assertEquals(HttpStatus.OK, response.statusCode)
                 assertFalse(LoggerFactory.getLogger(SANDBOX_LOGGER).isErrorEnabled)
-                assertEquals(LogLevel.OFF, getLogger(SANDBOX_LOGGER).configuredLevel)
+            }
+
+            @ParameterizedTest(name = "[{index}] {0}")
+            @EnumSource(LogLevelType::class)
+            @DisplayName("a level of the contract is applied as asked and answered back as the very same level")
+            fun `answers with the level that was asked for`(level: LogLevelType) {
+                val body = putLevelForResponse(SANDBOX_LOGGER, """{"level": "${level.name}"}""")
+
+                assertEquals(level, body.configuredLevel)
+                assertEquals(level, body.effectiveLevel)
+                assertEquals(
+                    LogLevel.valueOf(level.name),
+                    loggingSystem.getLoggerConfiguration(SANDBOX_LOGGER)?.configuredLevel,
+                )
             }
 
             @Test
@@ -256,10 +271,17 @@ class LoggerAdminControllerTest
             }
 
             @ParameterizedTest(name = "[{index}] {0}")
-            @ValueSource(strings = ["""{"level": "LOUD"}""", """{"level": null}""", "{}"])
-            @DisplayName("a level outside the enum is rejected with 400")
+            @ValueSource(
+                strings = ["""{"level": "FATAL"}""", """{"level": "LOUD"}""", """{"level": null}""", "{}"],
+            )
+            @DisplayName("a level outside the contract is rejected with 400, the logger keeping the level it had")
             fun `rejects an unknown level`(body: String) {
-                assertEquals(HttpStatus.BAD_REQUEST, putLevel(SANDBOX_LOGGER, body).statusCode)
+                loggingSystem.setLogLevel(SANDBOX_LOGGER, LogLevel.DEBUG)
+
+                val response = putLevel(SANDBOX_LOGGER, body)
+
+                assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+                assertEquals(LogLevel.DEBUG, loggingSystem.getLoggerConfiguration(SANDBOX_LOGGER)?.configuredLevel)
             }
 
             @Test

--- a/src/test/kotlin/ru/illine/drinking/ponies/model/base/LogLevelTypeTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/model/base/LogLevelTypeTest.kt
@@ -1,0 +1,42 @@
+package ru.illine.drinking.ponies.model.base
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.boot.logging.LogLevel
+import ru.illine.drinking.ponies.test.tag.UnitTest
+
+@UnitTest
+@DisplayName("LogLevelType Unit Test")
+class LogLevelTypeTest {
+    @ParameterizedTest(name = "[{index}] {0}")
+    @EnumSource(LogLevelType::class)
+    @DisplayName("level: an entry carries the logging level of the same name, so the wire value is not renamed")
+    fun `entries carry the level of the same name`(type: LogLevelType) {
+        assertEquals(LogLevel.valueOf(type.name), type.level)
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @EnumSource(LogLevelType::class)
+    @DisplayName("of(): a level read back from a logger is translated into the entry that set it")
+    fun `of translates a level back into its entry`(type: LogLevelType) {
+        assertEquals(type, LogLevelType.of(type.level))
+    }
+
+    @Test
+    @DisplayName("of(): FATAL is the only level with no entry, the logging system applying it as ERROR instead")
+    fun `fatal is the only level left out`() {
+        val withoutEntry = LogLevel.entries.filter { LogLevelType.of(it) == null }
+
+        assertEquals(listOf(LogLevel.FATAL), withoutEntry)
+    }
+
+    @Test
+    @DisplayName("of(): a logger with no level at all yields no entry instead of a default one")
+    fun `no level yields no entry`() {
+        assertNull(LogLevelType.of(null))
+    }
+}

--- a/src/test/kotlin/ru/illine/drinking/ponies/service/logging/LoggerAdminServiceTest.kt
+++ b/src/test/kotlin/ru/illine/drinking/ponies/service/logging/LoggerAdminServiceTest.kt
@@ -24,6 +24,7 @@ import org.springframework.boot.logging.LogLevel
 import org.springframework.boot.logging.LoggerConfiguration
 import org.springframework.boot.logging.LoggingSystem
 import ru.illine.drinking.ponies.model.base.AppLogger
+import ru.illine.drinking.ponies.model.base.LogLevelType
 import ru.illine.drinking.ponies.service.logging.impl.LoggerAdminServiceImpl
 import ru.illine.drinking.ponies.test.tag.UnitTest
 
@@ -103,7 +104,7 @@ class LoggerAdminServiceTest {
     @DisplayName("setLevel(): refuses to touch the audit logger, which would silence the record of doing so")
     fun `audit logger cannot be reconfigured`() {
         assertThrows<IllegalArgumentException> {
-            service.setLevel(AppLogger.AUDIT.value, LogLevel.OFF, ACTOR_ID)
+            service.setLevel(AppLogger.AUDIT.value, LogLevelType.OFF, ACTOR_ID)
         }
 
         verify(loggingSystem, never()).setLogLevel(any(), eq(LogLevel.OFF))
@@ -155,11 +156,11 @@ class LoggerAdminServiceTest {
             .thenReturn(LoggerConfiguration(AppLogger.SQL.value, null, LogLevel.WARN))
             .thenReturn(LoggerConfiguration(AppLogger.SQL.value, LogLevel.DEBUG, LogLevel.DEBUG))
 
-        val applied = service.setLevel(AppLogger.SQL.value, LogLevel.DEBUG, ACTOR_ID)
+        val applied = service.setLevel(AppLogger.SQL.value, LogLevelType.DEBUG, ACTOR_ID)
 
         verify(loggingSystem).setLogLevel(eq(AppLogger.SQL.value), eq(LogLevel.DEBUG))
-        assertEquals(LogLevel.DEBUG, applied.configuredLevel)
-        assertEquals(LogLevel.DEBUG, applied.effectiveLevel)
+        assertEquals(LogLevelType.DEBUG, applied.configuredLevel)
+        assertEquals(LogLevelType.DEBUG, applied.effectiveLevel)
         assertTrue(applied.application)
     }
 
@@ -176,7 +177,7 @@ class LoggerAdminServiceTest {
             .setLogLevel(any(), any())
 
         try {
-            service.setLevel(AppLogger.SQL.value, LogLevel.OFF, ACTOR_ID)
+            service.setLevel(AppLogger.SQL.value, LogLevelType.OFF, ACTOR_ID)
         } finally {
             auditLogger.detachAppender(auditRecords)
         }
@@ -184,7 +185,7 @@ class LoggerAdminServiceTest {
         val record = auditRecords.list.single().formattedMessage
         assertTrue(record.contains(ACTOR_ID.toString()), "the audit record names the actor: $record")
         assertTrue(record.contains(AppLogger.SQL.value), "the audit record names the logger: $record")
-        assertTrue(record.contains(LogLevel.OFF.name), "the audit record names the new level: $record")
+        assertTrue(record.contains(LogLevelType.OFF.name), "the audit record names the new level: $record")
     }
 
     companion object {


### PR DESCRIPTION
## Summary
- The logger admin API speaks its own `LogLevelType` instead of Spring's `LogLevel`, which carries a `FATAL` the logging system silently applies as `ERROR` - the endpoint answered with a level nobody asked for
- A level outside the contract is now rejected as 400 by the parser, before any code runs; no extra validation branch and no new exception handler
- Spring's `LogLevel` stays at the `LoggingSystem` boundary, held there by a new detekt rule instead of review attention
- `DEVELOPMENT.md` records why the contract offers one level fewer than Spring does
- The screen still offering `FATAL` is handled separately in DPTB-239

## Test plan
- [x] `./gradlew check` green locally: ktlint, detekt, 1028 tests
- [x] `LogLevelTypeTest` covers the translation both ways and pins `FATAL` as the only level left out, so a new Spring level fails the build
- [x] controller test: `PUT` with `FATAL` answers 400 and leaves the logger at the level it had
- [x] the new detekt rule confirmed red on a deliberate violation, then reverted
